### PR TITLE
removes FilterValue Subclasses and determines filter value type from filter

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/Filter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/Filter.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.models.datasets.concepts.filters;
 
 import com.bakdata.conquery.apiv1.frontend.FEFilter;
+import com.bakdata.conquery.apiv1.query.concept.filter.FilterValue;
 import com.bakdata.conquery.io.cps.CPSBase;
 import com.bakdata.conquery.models.datasets.Column;
 import com.bakdata.conquery.models.datasets.Dataset;
@@ -14,11 +15,13 @@ import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.dropwizard.validation.ValidationMethod;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.formula.functions.T;
 
 /**
  * This class is the abstract superclass for all filters.
@@ -50,6 +53,18 @@ public abstract class Filter<FILTER_VALUE> extends Labeled<FilterId> implements 
 
 	@JsonIgnore
 	public abstract Column[] getRequiredColumns();
+
+	/**
+	 * The method body will look the same for all implementing classes:
+	 * <code>
+	 *     {
+	 *      	return new TypeReference<>() {};
+	 *     }
+	 * </code>
+	 * However thus is necessary, to pick up the parameter value during compilation.
+	 */
+	@JsonIgnore
+	public abstract TypeReference<? extends FILTER_VALUE> getValueTypeReference();
 
 	public abstract FilterNode<?> createFilterNode(FILTER_VALUE filterValue);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/BigMultiSelectFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/BigMultiSelectFilter.java
@@ -5,6 +5,7 @@ import com.bakdata.conquery.apiv1.frontend.FEFilterType;
 import com.bakdata.conquery.models.datasets.concepts.filters.Filter;
 import com.bakdata.conquery.models.query.filter.event.MultiSelectFilterNode;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,6 +19,11 @@ public class BigMultiSelectFilter extends AbstractSelectFilter<String[]> {
 
 	public BigMultiSelectFilter() {
 		super(-1, FEFilterType.BIG_MULTI_SELECT);
+	}
+
+	@Override
+	public TypeReference<String[]> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/CountFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/CountFilter.java
@@ -16,6 +16,7 @@ import com.bakdata.conquery.models.query.queryplan.aggregators.DistinctValuesWra
 import com.bakdata.conquery.models.query.queryplan.aggregators.MultiDistinctValuesWrapperAggregator;
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.CountAggregator;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.ArrayUtils;
@@ -46,7 +47,10 @@ public class CountFilter extends Filter<Range.LongRange> {
 		f.setType(FEFilterType.INTEGER_RANGE);
 		f.setMin(1);
 	}
-	
+
+	public TypeReference<Range.LongRange> getValueTypeReference(){
+		return new TypeReference<>() {};
+	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/CountQuartersFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/CountQuartersFilter.java
@@ -13,6 +13,7 @@ import com.bakdata.conquery.models.query.filter.RangeFilterNode;
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.CountQuartersOfDateRangeAggregator;
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.CountQuartersOfDatesAggregator;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -29,6 +30,11 @@ public class CountQuartersFilter extends SingleColumnFilter<Range.LongRange> {
 	public void configureFrontend(FEFilter f) {
 		f.setType(FEFilterType.INTEGER_RANGE);
 		f.setMin(1);
+	}
+
+	@Override
+	public TypeReference<Range.LongRange> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/DateDistanceFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/DateDistanceFilter.java
@@ -15,6 +15,7 @@ import com.bakdata.conquery.models.events.MajorTypeId;
 import com.bakdata.conquery.models.exceptions.ConceptConfigurationException;
 import com.bakdata.conquery.models.query.filter.event.DateDistanceFilterNode;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +46,12 @@ public class DateDistanceFilter extends SingleColumnFilter<Range.LongRange> {
 				throw new ConceptConfigurationException(getConnector(), "DATE_DISTANCE filter is incompatible with columns of type " + getColumn().getType());
 		}
 	}
-	
+
+	@Override
+	public TypeReference<Range.LongRange> getValueTypeReference() {
+		return new TypeReference<>() {};
+	}
+
 	@Override
 	public FilterNode createFilterNode(Range.LongRange value) {
 		return new DateDistanceFilterNode(getColumn(), timeUnit, value);

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/DurationSumFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/DurationSumFilter.java
@@ -13,6 +13,7 @@ import com.bakdata.conquery.models.exceptions.ConceptConfigurationException;
 import com.bakdata.conquery.models.query.filter.RangeFilterNode;
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.DurationSumAggregator;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,11 @@ public class DurationSumFilter extends SingleColumnFilter<Range.LongRange> {
 			default:
 				throw new ConceptConfigurationException(getConnector(), "DURATION_SUM filter is incompatible with columns of type " + getColumn().getType());
 		}
+	}
+
+	@Override
+	public TypeReference<Range.LongRange> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/MultiSelectFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/MultiSelectFilter.java
@@ -5,6 +5,7 @@ import com.bakdata.conquery.apiv1.frontend.FEFilterType;
 import com.bakdata.conquery.models.datasets.concepts.filters.Filter;
 import com.bakdata.conquery.models.query.filter.event.MultiSelectFilterNode;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,6 +19,11 @@ public class MultiSelectFilter extends AbstractSelectFilter<String[]> {
 
 	public MultiSelectFilter() {
 		super(128, FEFilterType.MULTI_SELECT);
+	}
+
+	@Override
+	public TypeReference<String[]> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/NumberFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/NumberFilter.java
@@ -16,6 +16,7 @@ import com.bakdata.conquery.models.query.filter.event.number.IntegerFilterNode;
 import com.bakdata.conquery.models.query.filter.event.number.MoneyFilterNode;
 import com.bakdata.conquery.models.query.filter.event.number.RealFilterNode;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +52,22 @@ public class NumberFilter<RANGE extends IRange<? extends Number, ?>> extends Sin
 	@Override
 	public Column[] getRequiredColumns() {
 		return new Column[]{getColumn()};
+	}
+
+	@Override
+	public TypeReference<? extends RANGE> getValueTypeReference() {
+		// TODO this is not cool. It is probably better to create separate classes for this.
+		switch (getColumn().getType()) {
+			case MONEY:
+			case INTEGER:
+				return (TypeReference<? extends RANGE>) new TypeReference<Range.LongRange>(){};
+			case DECIMAL:
+				return (TypeReference<? extends RANGE>) new TypeReference<Range<BigDecimal>>(){};
+			case REAL:
+				return (TypeReference<? extends RANGE>) new TypeReference<Range.DoubleRange>(){};
+			default:
+				throw new IllegalStateException(String.format("Column type %s may not be used (Assignment should not have been possible)", getColumn()));
+		}
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/PrefixTextFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/PrefixTextFilter.java
@@ -10,6 +10,7 @@ import com.bakdata.conquery.models.datasets.concepts.filters.SingleColumnFilter;
 import com.bakdata.conquery.models.events.MajorTypeId;
 import com.bakdata.conquery.models.query.filter.event.PrefixTextFilterNode;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,7 +24,12 @@ public class PrefixTextFilter extends SingleColumnFilter<String> {
 	public void configureFrontend(FEFilter f) {
 		f.setType(FEFilterType.STRING);
 	}
-	
+
+	@Override
+	public TypeReference<String> getValueTypeReference() {
+		return new TypeReference<>() {};
+	}
+
 	@Override
 	public EnumSet<MajorTypeId> getAcceptedColumnTypes() {
 		return EnumSet.of(MajorTypeId.STRING);

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/QuartersInYearFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/QuartersInYearFilter.java
@@ -12,6 +12,7 @@ import com.bakdata.conquery.models.events.MajorTypeId;
 import com.bakdata.conquery.models.query.filter.RangeFilterNode;
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.QuartersInYearAggregator;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -28,6 +29,11 @@ public class QuartersInYearFilter extends SingleColumnFilter<Range.LongRange> {
 		f.setType(FEFilterType.INTEGER_RANGE);
 		f.setMin(1);
 		f.setMax(4);
+	}
+
+	@Override
+	public TypeReference<Range.LongRange> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/SelectFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/SelectFilter.java
@@ -5,6 +5,7 @@ import com.bakdata.conquery.apiv1.frontend.FEFilterType;
 import com.bakdata.conquery.models.datasets.concepts.filters.Filter;
 import com.bakdata.conquery.models.query.filter.event.SelectFilterNode;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,6 +21,11 @@ public class SelectFilter extends AbstractSelectFilter<String> {
 	
 	public SelectFilter() {
 		super(128, FEFilterType.SELECT);
+	}
+
+	@Override
+	public TypeReference<String> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/SumFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/filters/specific/SumFilter.java
@@ -25,6 +25,7 @@ import com.bakdata.conquery.models.query.queryplan.aggregators.specific.sum.Inte
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.sum.MoneySumAggregator;
 import com.bakdata.conquery.models.query.queryplan.aggregators.specific.sum.RealSumAggregator;
 import com.bakdata.conquery.models.query.queryplan.filter.FilterNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -81,6 +82,11 @@ public class SumFilter<RANGE extends IRange<? extends Number, ?>> extends Filter
 	@Override
 	public Column[] getRequiredColumns() {
 		return new Column[]{getColumn(), getSubtractColumn(), getDistinctByColumn()};
+	}
+
+	@Override
+	public TypeReference<RANGE> getValueTypeReference() {
+		return new TypeReference<>() {};
 	}
 
 	@Override

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/ReusedQueryTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/ReusedQueryTest.java
@@ -150,7 +150,7 @@ public class ReusedQueryTest implements ProgrammaticIntegrationTest {
 			final CentralRegistry centralRegistry = conquery.getNamespaceStorage().getCentralRegistry();
 			final Connector connector = centralRegistry.resolve(new ConnectorId(conceptId, "connector1"));
 			cqTable.setConnector(connector);
-			cqTable.setFilters(List.of(new FilterValue.CQRealRangeFilter((Filter<Range<BigDecimal>>) centralRegistry.resolve(new FilterId(connector.getId(), "filter")), new Range<>(BigDecimal.valueOf(1.01d), BigDecimal.valueOf(1.01d)))));
+			cqTable.setFilters(List.of(new FilterValue<>((Filter<Range<BigDecimal>>) centralRegistry.resolve(new FilterId(connector.getId(), "filter")), new Range<>(BigDecimal.valueOf(1.01d), BigDecimal.valueOf(1.01d)))));
 
 			cqConcept.setTables(List.of(cqTable));
 			cqConcept.setExcludeFromSecondaryIdQuery(false);

--- a/backend/src/test/resources/tests/aggregator/EXISTS_AGGREGATOR/NUMBER.test.json
+++ b/backend/src/test/resources/tests/aggregator/EXISTS_AGGREGATOR/NUMBER.test.json
@@ -15,7 +15,6 @@
           "filters": [
             {
               "filter": "concept.connector.filter",
-              "type": "REAL_RANGE",
               "value": {
                 "min": 1,
                 "max": 1

--- a/backend/src/test/resources/tests/aggregator/EXISTS_AGGREGATOR_OR/NUMBER.test.json
+++ b/backend/src/test/resources/tests/aggregator/EXISTS_AGGREGATOR_OR/NUMBER.test.json
@@ -18,7 +18,6 @@
               "filters": [
                 {
                   "filter": "concept.connector.value",
-                  "type": "REAL_RANGE",
                   "value": {
                     "min": 1,
                     "max": 1
@@ -40,7 +39,6 @@
               "filters": [
                 {
                   "filter": "concept.connector.value",
-                  "type": "REAL_RANGE",
                   "value": {
                     "min": 2,
                     "max": 2

--- a/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT/BIG_MULTI_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT/BIG_MULTI_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "MULTI_SELECT",
     "value": "1"
   }
 }

--- a/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_2VALUES/BIG_MULTI_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_2VALUES/BIG_MULTI_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "MULTI_SELECT",
     "value": ["1","2"]
   }
 }

--- a/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_EMPTY_VALUES/BIG_MULTI_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_EMPTY_VALUES/BIG_MULTI_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "MULTI_SELECT",
     "value": "1"
   }
 }

--- a/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_SPEZIAL_CHARACTER/BIG_MULTI_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_SPEZIAL_CHARACTER/BIG_MULTI_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "MULTI_SELECT",
     "value": " "
   }
 }

--- a/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_SPEZIAL_CHARACTER2/BIG_MULTI_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/BIG_MULTI_SELECT_SPEZIAL_CHARACTER2/BIG_MULTI_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "MULTI_SELECT",
     "value": "!"
   }
 }

--- a/backend/src/test/resources/tests/filter/COUNT/COUNT.test.json
+++ b/backend/src/test/resources/tests/filter/COUNT/COUNT.test.json
@@ -15,7 +15,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 5,
       "max": 6

--- a/backend/src/test/resources/tests/filter/COUNT_DISTINCT/COUNT.test.json
+++ b/backend/src/test/resources/tests/filter/COUNT_DISTINCT/COUNT.test.json
@@ -33,7 +33,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 5,
       "max": 6

--- a/backend/src/test/resources/tests/filter/COUNT_DISTINCT_MULTI/COUNT.test.json
+++ b/backend/src/test/resources/tests/filter/COUNT_DISTINCT_MULTI/COUNT.test.json
@@ -45,7 +45,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 5,
       "max": 6

--- a/backend/src/test/resources/tests/filter/COUNT_QUARTERS/COUNT_QUARTERS.test.json
+++ b/backend/src/test/resources/tests/filter/COUNT_QUARTERS/COUNT_QUARTERS.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 2,
       "max": 3

--- a/backend/src/test/resources/tests/filter/COUNT_QUARTERS_RANGE/COUNT_QUARTERS.test.json
+++ b/backend/src/test/resources/tests/filter/COUNT_QUARTERS_RANGE/COUNT_QUARTERS.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 2,
       "max": 3

--- a/backend/src/test/resources/tests/filter/COUNTfalse/COUNT.test.json
+++ b/backend/src/test/resources/tests/filter/COUNTfalse/COUNT.test.json
@@ -33,7 +33,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 5,
       "max": 6

--- a/backend/src/test/resources/tests/filter/DATE_DISTANCE/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/DATE_DISTANCE/NUMBER.test.json
@@ -36,7 +36,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 10,
       "max": 10

--- a/backend/src/test/resources/tests/filter/DIFFSUM_INTEGER/SUM.test.json
+++ b/backend/src/test/resources/tests/filter/DIFFSUM_INTEGER/SUM.test.json
@@ -37,7 +37,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/filter/DIFFSUM_REAL/SUM_REAL.test.json
+++ b/backend/src/test/resources/tests/filter/DIFFSUM_REAL/SUM_REAL.test.json
@@ -37,7 +37,6 @@
     }
   },
   "filterValue": {
-    "type": "REAL_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/filter/DURATION_SUM/DURATION_SUM.test.json
+++ b/backend/src/test/resources/tests/filter/DURATION_SUM/DURATION_SUM.test.json
@@ -30,7 +30,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 5
     }

--- a/backend/src/test/resources/tests/filter/DURATION_SUM_2/DURATION_SUM_2.test.json
+++ b/backend/src/test/resources/tests/filter/DURATION_SUM_2/DURATION_SUM_2.test.json
@@ -30,7 +30,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 0
     }

--- a/backend/src/test/resources/tests/filter/MULTI_SELECT/SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/MULTI_SELECT/SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "MULTI_SELECT",
     "value": [
       "1",
       "2"

--- a/backend/src/test/resources/tests/filter/NUMBER_DECIMAL/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/NUMBER_DECIMAL/NUMBER.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "REAL_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/filter/NUMBER_INTEGER/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/NUMBER_INTEGER/NUMBER.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/filter/NUMBER_INTEGER2/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/NUMBER_INTEGER2/NUMBER.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 50,
       "max": 50

--- a/backend/src/test/resources/tests/filter/NUMBER_MONEY/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/NUMBER_MONEY/NUMBER.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 10000,
       "max": 20000

--- a/backend/src/test/resources/tests/filter/NUMBER_REAL/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/NUMBER_REAL/NUMBER.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "REAL_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/filter/NUMBER_REAL_MISSING/NUMBER.test.json
+++ b/backend/src/test/resources/tests/filter/NUMBER_REAL_MISSING/NUMBER.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "REAL_RANGE",
     "value": {
       "min": 0,
       "max": 200

--- a/backend/src/test/resources/tests/filter/QUARTERS_IN_YEAR/QUARTERS_IN_YEAR.test.json
+++ b/backend/src/test/resources/tests/filter/QUARTERS_IN_YEAR/QUARTERS_IN_YEAR.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 2,
       "max": 3

--- a/backend/src/test/resources/tests/filter/SELECT/SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/SELECT/SELECT.test.json
@@ -35,7 +35,6 @@
     }
   },
   "filterValue": {
-    "type": "SELECT",
     "value": "1"
   }
 }

--- a/backend/src/test/resources/tests/filter/SINGLE_SELECT_EMPTY_VALUES/SINGLE_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/SINGLE_SELECT_EMPTY_VALUES/SINGLE_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "SELECT",
     "value": "1"
   }
 }

--- a/backend/src/test/resources/tests/filter/SINGLE_SELECT_SPEZIAL_CHARACTER/SINGLE_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/SINGLE_SELECT_SPEZIAL_CHARACTER/SINGLE_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "SELECT",
     "value": " "
   }
 }

--- a/backend/src/test/resources/tests/filter/SINGLE_SELECT_SPEZIAL_CHARACTER2/SINGLE_SELECT.test.json
+++ b/backend/src/test/resources/tests/filter/SINGLE_SELECT_SPEZIAL_CHARACTER2/SINGLE_SELECT.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "SELECT",
     "value": "!"
   }
 }

--- a/backend/src/test/resources/tests/filter/SINGLE_SELECT_SPEZIAL_CHARACTER2/SINGLE_SELECT2.test.json
+++ b/backend/src/test/resources/tests/filter/SINGLE_SELECT_SPEZIAL_CHARACTER2/SINGLE_SELECT2.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "SELECT",
     "value": "?"
   }
 }

--- a/backend/src/test/resources/tests/filter/SUM_DECIMAL/SUM.test.json
+++ b/backend/src/test/resources/tests/filter/SUM_DECIMAL/SUM.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "REAL_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/filter/SUM_INTEGER/SUM.test.json
+++ b/backend/src/test/resources/tests/filter/SUM_INTEGER/SUM.test.json
@@ -32,7 +32,6 @@
     }
   },
   "filterValue": {
-    "type": "INTEGER_RANGE",
     "value": {
       "min": 100,
       "max": 200

--- a/backend/src/test/resources/tests/query/ARRAY_CONCEPT_QUERY/ARRAY_Query.test.json
+++ b/backend/src/test/resources/tests/query/ARRAY_CONCEPT_QUERY/ARRAY_Query.test.json
@@ -37,7 +37,6 @@
 							"id": "select.connector",
 							"filters":[
 								{
-								"type": "INTEGER_RANGE",
 								"filter":"select.connector.geschlecht",
 								"value": {
 									"min": 2,

--- a/backend/src/test/resources/tests/query/BIG_MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY/BIG_MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/BIG_MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY/BIG_MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -25,7 +25,6 @@
                         "filters":[  
                            {  
                               "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                              "type":"BIG_MULTI_SELECT",
                               "value":[  
                                  "f"
                               ]

--- a/backend/src/test/resources/tests/query/BIG_MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY/BIG_MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/BIG_MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY/BIG_MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -29,7 +29,6 @@
                               "filters":[  
                                  {  
                                     "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                                    "type":"BIG_MULTI_SELECT",
                                     "value":[  
                                        "f"
                                     ]

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE/DATE_DISTANCE.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE/DATE_DISTANCE.test.json
@@ -29,7 +29,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"11"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE/DATE_DISTANCE_ERSTER.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE/DATE_DISTANCE_ERSTER.test.json
@@ -29,7 +29,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"11"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE/DATE_DISTANCE_LETZTER.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE/DATE_DISTANCE_LETZTER.test.json
@@ -29,7 +29,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"11"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE_AGE_SPAN/DATE_DISTANCE.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE_AGE_SPAN/DATE_DISTANCE.test.json
@@ -29,7 +29,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"12"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE_AGE_SPAN/DATE_DISTANCE_ERSTER.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE_AGE_SPAN/DATE_DISTANCE_ERSTER.test.json
@@ -29,7 +29,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"12"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE_AGE_SPAN/DATE_DISTANCE_LETZTER.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE_AGE_SPAN/DATE_DISTANCE_LETZTER.test.json
@@ -29,7 +29,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"12"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE_NEGATION/DATE_DISTANCE.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE_NEGATION/DATE_DISTANCE.test.json
@@ -31,7 +31,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"11"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE_NEGATION/DATE_DISTANCE_ERSTER.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE_NEGATION/DATE_DISTANCE_ERSTER.test.json
@@ -31,7 +31,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"11"

--- a/backend/src/test/resources/tests/query/DATE_DISTANCE_NEGATION/DATE_DISTANCE_LETZTER.test.json
+++ b/backend/src/test/resources/tests/query/DATE_DISTANCE_NEGATION/DATE_DISTANCE_LETZTER.test.json
@@ -31,7 +31,6 @@
                            "filters":[
                               {  
                                  "filter":"alter.alterxy.alterseinschrankung",
-                                 "type":"INTEGER_RANGE",
                                  "value":{  
                                     "min":"11",
                                     "max":"11"

--- a/backend/src/test/resources/tests/query/DURATION_SUM_EMPTY_DATE_CONCEPT_QUERY/DURATION_SUM_EMPTY_DATE_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/DURATION_SUM_EMPTY_DATE_CONCEPT_QUERY/DURATION_SUM_EMPTY_DATE_CONCEPT_QUERY.test.json
@@ -22,7 +22,6 @@
                   "filters":[  
                      {  
                         "filter":"kg_tage_duration_sum.kg_tage_connector.datum",
-                        "type":"INTEGER_RANGE",
                         "value":{  
                            "min":0
                         }

--- a/backend/src/test/resources/tests/query/MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY/MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY/MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -25,7 +25,6 @@
                         "filters":[  
                            {  
                               "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                              "type":"MULTI_SELECT",
                               "value":[  
                                  "f"
                               ]

--- a/backend/src/test/resources/tests/query/MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY/MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY/MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -27,7 +27,6 @@
                            "filters":[  
                               {  
                                  "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                                 "type":"MULTI_SELECT",
                                  "value":[  
                                     "f"
                                  ]
@@ -48,7 +47,6 @@
                            "filters":[  
                               {  
                                  "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                                 "type":"MULTI_SELECT",
                                  "value":[  
                                     "m"
                                  ]

--- a/backend/src/test/resources/tests/query/MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY2/MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/MULTI_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY2/MULTI_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -28,9 +28,7 @@
                               "id":"geschlecht_select.geschlecht_connector",
                               "filters":[  
                                  {  
-                                    "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                                    "type":"MULTI_SELECT",
-                                    "value":[  
+                                    "filter":"geschlecht_select.geschlecht_connector.geschlecht",                                    "value":[  
                                        "f"
                                     ]
                                  }

--- a/backend/src/test/resources/tests/query/NUMBER/NUMBER.test.json
+++ b/backend/src/test/resources/tests/query/NUMBER/NUMBER.test.json
@@ -25,7 +25,6 @@
 								"filters": [
 									{
 										"filter": "number.number_connector.value",
-										"type": "REAL_RANGE",
 										"value": {
 											"min": 1,
 											"max": 1

--- a/backend/src/test/resources/tests/query/NUMBER_MISSING/NUMBER.test.json
+++ b/backend/src/test/resources/tests/query/NUMBER_MISSING/NUMBER.test.json
@@ -26,7 +26,6 @@
                            "filters":[  
                               {  
                                  "filter":"number.number_connector.value",
-                                 "type":"REAL_RANGE",
                                  "value":{  
                                     "min": 0,
 									"max": 0

--- a/backend/src/test/resources/tests/query/NUMBER_NEGATION/NUMBER.test.json
+++ b/backend/src/test/resources/tests/query/NUMBER_NEGATION/NUMBER.test.json
@@ -28,7 +28,6 @@
                            "filters":[  
                               {  
                                  "filter":"number.number_connector.value",
-                                 "type":"REAL_RANGE",
                                  "value":{  
                                     "min": 1,
 									"max": 1

--- a/backend/src/test/resources/tests/query/QUERY_AND_NOT_TEMPORAL_SAME_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/QUERY_AND_NOT_TEMPORAL_SAME_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
@@ -22,7 +22,6 @@
                 "filters": [
                   {
                     "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                    "type": "SELECT",
                     "value": "f"
                   }
                 ]
@@ -44,7 +43,6 @@
                 "filters": [
                   {
                     "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                    "type": "SELECT",
                     "value": "m"
                   }
                 ]

--- a/backend/src/test/resources/tests/query/SECONDARY_ID/SECONDARY_IDS.test.json
+++ b/backend/src/test/resources/tests/query/SECONDARY_ID/SECONDARY_IDS.test.json
@@ -20,7 +20,6 @@
               "filters": [
                 {
                   "filter": "number.number_connector.value",
-                  "type": "REAL_RANGE",
                   "value": {
                     "min": 1,
                     "max": 1
@@ -33,7 +32,6 @@
               "filters": [
                 {
                   "filter": "number.number_connector2.value",
-                  "type": "REAL_RANGE",
                   "value": {
                     "min": 1,
                     "max": 1

--- a/backend/src/test/resources/tests/query/SECONDARY_ID_DATEMODE_LOGICAL/SECONDARY_IDS.test.json
+++ b/backend/src/test/resources/tests/query/SECONDARY_ID_DATEMODE_LOGICAL/SECONDARY_IDS.test.json
@@ -22,7 +22,6 @@
               "filters": [
                 {
                   "filter": "number.number_connector.value",
-                  "type": "REAL_RANGE",
                   "value": {
                     "min": 1,
                     "max": 1
@@ -45,7 +44,6 @@
               "filters": [
                 {
                   "filter": "number.number_connector2.value",
-                  "type": "REAL_RANGE",
                   "value": {
                     "min": 1,
                     "max": 1

--- a/backend/src/test/resources/tests/query/SECONDARY_ID_EXCLUDED/SECONDARY_IDS_EXCLUDED.test.json
+++ b/backend/src/test/resources/tests/query/SECONDARY_ID_EXCLUDED/SECONDARY_IDS_EXCLUDED.test.json
@@ -33,7 +33,6 @@
               "filters": [
                 {
                   "filter": "concept.connector1.value",
-                  "type": "INTEGER_RANGE",
                   "value": {
                     "min": 2
                   }

--- a/backend/src/test/resources/tests/query/SECONDARY_ID_MIXED/SECONDARY_IDS_MIXED.test.json
+++ b/backend/src/test/resources/tests/query/SECONDARY_ID_MIXED/SECONDARY_IDS_MIXED.test.json
@@ -17,7 +17,6 @@
           "filters": [
             {
               "filter": "concept.connector1.filter",
-              "type": "REAL_RANGE",
               "value": {
                 "min": 1,
                 "max": 1
@@ -30,7 +29,6 @@
           "filters": [
             {
               "filter": "concept.connector2.filter",
-              "type": "REAL_RANGE",
               "value": {
                 "min": 1,
                 "max": 1

--- a/backend/src/test/resources/tests/query/SIMPLE_VIRTUAL_CONCEPT_QUERY/SIMPLE_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/SIMPLE_VIRTUAL_CONCEPT_QUERY/SIMPLE_VIRTUAL_CONCEPT_Query.test.json
@@ -16,7 +16,6 @@
                     "filters": [
                         {
                             "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                            "type": "MULTI_SELECT",
                             "value": [
                                 "f"
                             ]

--- a/backend/src/test/resources/tests/query/SINGLE_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY/SINGLE_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/SINGLE_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY/SINGLE_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -25,7 +25,6 @@
                         "filters":[  
                            {  
                               "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                              "type":"SELECT",
                               "value": "f"
                            }
                         ]

--- a/backend/src/test/resources/tests/query/SINGLE_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY/SINGLE_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/SINGLE_SELECT_NEGATION_DATE_RESTRICTION_OR_CONCEPT_QUERY/SINGLE_SELECT_DATE_RESTRICTION_OR_CONCEPT_QUERY.test.json
@@ -29,7 +29,6 @@
                               "filters":[  
                                  {  
                                     "filter":"geschlecht_select.geschlecht_connector.geschlecht",
-                                    "type":"SELECT",
                                     "value":"f"
                                  }
                               ]

--- a/backend/src/test/resources/tests/query/SUM_EMPTY_DATE_CONCEPT_QUERY/SUM_EMPTY_DATE_CONCEPT_QUERY.test.json
+++ b/backend/src/test/resources/tests/query/SUM_EMPTY_DATE_CONCEPT_QUERY/SUM_EMPTY_DATE_CONCEPT_QUERY.test.json
@@ -26,7 +26,6 @@
                            "filters":[  
                               {  
                                  "filter":"sum.sum_connector.value",
-                                 "type":"REAL_RANGE",
                                  "value":{  
                                     "min": 2,
 									"max": 2

--- a/backend/src/test/resources/tests/query/TABLE_EXPORT/TABLE_EXPORT.test.json
+++ b/backend/src/test/resources/tests/query/TABLE_EXPORT/TABLE_EXPORT.test.json
@@ -35,7 +35,6 @@
             "filters": [
               {
                 "filter": "concept.connector.value",
-                "type": "REAL_RANGE",
                 "value": {
                   "min": 1,
                   "max": 1
@@ -48,7 +47,6 @@
             "filters": [
               {
                 "filter": "concept.connector2.value",
-                "type": "REAL_RANGE",
                 "value": {
                   "min": 1,
                   "max": 1

--- a/backend/src/test/resources/tests/query/TEMPORAL_BEFORE_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/TEMPORAL_BEFORE_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
@@ -19,7 +19,6 @@
               "filters": [
                 {
                   "filter": "concept.connector.filter",
-                  "type": "SELECT",
                   "value": "f"
                 }
               ]
@@ -40,7 +39,6 @@
               "filters": [
                 {
                   "filter": "concept.connector.filter",
-                  "type": "SELECT",
                   "value": "m"
                 }
               ]

--- a/backend/src/test/resources/tests/query/TEMPORAL_BEFORE_OR_SAME_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/TEMPORAL_BEFORE_OR_SAME_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
@@ -20,7 +20,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "f"
                 }
               ]
@@ -42,7 +41,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "m"
                 }
               ]

--- a/backend/src/test/resources/tests/query/TEMPORAL_DAYS_BEFORE_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/TEMPORAL_DAYS_BEFORE_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
@@ -24,7 +24,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "f"
                 }
               ]
@@ -46,7 +45,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "m"
                 }
               ]

--- a/backend/src/test/resources/tests/query/TEMPORAL_DAYS_BEFORE_OR_NEVER_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/TEMPORAL_DAYS_BEFORE_OR_NEVER_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
@@ -21,7 +21,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "1"
                 }
               ]
@@ -43,7 +42,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "2"
                 }
               ]

--- a/backend/src/test/resources/tests/query/TEMPORAL_SAME_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
+++ b/backend/src/test/resources/tests/query/TEMPORAL_SAME_CONCEPT_QUERY/TEMPORAL_VIRTUAL_CONCEPT_Query.test.json
@@ -20,7 +20,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "f"
                 }
               ]
@@ -42,7 +41,6 @@
               "filters": [
                 {
                   "filter": "geschlecht_select.geschlecht_connector.geschlecht",
-                  "type": "SELECT",
                   "value": "m"
                 }
               ]

--- a/backend/src/test/resources/tests/query/VIRTUAL_CONCEPT_REUSED_QUERY/VIRTUAL_CONCEPT_REUSED_Query.test.json
+++ b/backend/src/test/resources/tests/query/VIRTUAL_CONCEPT_REUSED_QUERY/VIRTUAL_CONCEPT_REUSED_Query.test.json
@@ -24,7 +24,6 @@
               "filters": [
                 {
                   "filter": "test_concept.test_connector.test_filter",
-                  "type": "MULTI_SELECT",
                   "value": [
                     "2"
                   ]


### PR DESCRIPTION
@Njimefo @awildturtok Noch nicht ganz funktionierender Vorschlag um nicht einen extra Compound-Filter-Value-Type einführen zu müssen.

Die Filter legen einfach eine beliebe Klasse fest, die sie erwarten zu bekommen. Das klappt leider noch nicht ganz mit parametriesierten FilterValues, aber da findet sich bestimmt eine Lösung.