### PR TITLE
Fix crashing MapInternToExternMapper#external when not yet initialize…

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/index/MapInternToExternMapper.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/index/MapInternToExternMapper.java
@@ -74,6 +74,10 @@ public class MapInternToExternMapper extends NamedImpl<InternToExternMapperId> i
 
 	@Override
 	public String external(String internalValue) {
+		if(!initialized()){
+			return internalValue;
+		}
+
 		return int2ext.getOrDefault(internalValue, internalValue);
 	}
 


### PR DESCRIPTION
…d, instead return internalValue