### PR TITLE
Feature/synchronous add deletion dataset

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/AcknowledgeWorkerRemoved.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/namespaces/specific/AcknowledgeWorkerRemoved.java
@@ -1,0 +1,23 @@
+package com.bakdata.conquery.models.messages.namespaces.specific;
+
+import com.bakdata.conquery.io.cps.CPSType;
+import com.bakdata.conquery.models.identifiable.ids.specific.WorkerId;
+import com.bakdata.conquery.models.messages.network.MessageToManagerNode;
+import com.bakdata.conquery.models.messages.network.NetworkMessage;
+import com.bakdata.conquery.models.messages.network.NetworkMessageContext;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(onConstructor_ = @JsonCreator)
+@CPSType(id = "WORKER_REMOVED", base = NetworkMessage.class)
+@Getter
+public class AcknowledgeWorkerRemoved extends MessageToManagerNode.Slow {
+
+	private final WorkerId workerId;
+
+	@Override
+	public void react(NetworkMessageContext.ManagerNodeNetworkContext context) throws Exception {
+		context.getDatasetRegistry().acknowledgeWorkerDeletion(workerId);
+	}
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/NetworkMessageContext.java
@@ -52,12 +52,12 @@ public abstract class NetworkMessageContext<MESSAGE extends NetworkMessage<?>> e
 	@Getter
 	public static class ManagerNodeNetworkContext extends NetworkMessageContext<MessageToShardNode> {
 
-		private final DatasetRegistry namespaces;
+		private final DatasetRegistry datasetRegistry;
 
 
-		public ManagerNodeNetworkContext(NetworkSession session, DatasetRegistry namespaces, int backpressure) {
+		public ManagerNodeNetworkContext(NetworkSession session, DatasetRegistry datasetRegistry, int backpressure) {
 			super(session, backpressure);
-			this.namespaces = namespaces;
+			this.datasetRegistry = datasetRegistry;
 		}
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddShardNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddShardNode.java
@@ -26,7 +26,7 @@ public class AddShardNode extends MessageToManagerNode {
 				context.getBackpressure()
 		);
 
-		context.getNamespaces().getShardNodes().put(context.getRemoteAddress(), nodeInformation);
+		context.getDatasetRegistry().getShardNodes().put(context.getRemoteAddress(), nodeInformation);
 
 		log.info("ShardNode `{}` registered.", context.getRemoteAddress());
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/AddWorker.java
@@ -24,7 +24,7 @@ public class AddWorker extends MessageToShardNode.Slow {
 
 	@Override
 	public void react(ShardNodeNetworkContext context) throws Exception {
-		log.info("creating a new worker for {}", dataset);
+		log.info("Creating a new worker for {}", dataset);
 		ConqueryConfig config = context.getConfig();
 
 		Worker worker = context.getWorkers().createWorker(dataset, config.getStorage(), createWorkerName(), context.getValidator(), config.isFailOnError());

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToNamespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/ForwardToNamespace.java
@@ -25,7 +25,7 @@ public class ForwardToNamespace extends MessageToManagerNode implements SlowMess
 
 	@Override
 	public void react(ManagerNodeNetworkContext context) throws Exception {
-		Namespace ns = Objects.requireNonNull(context.getNamespaces().get(datasetId), () -> String.format("Missing dataset `%s`", datasetId));
+		Namespace ns = Objects.requireNonNull(context.getDatasetRegistry().get(datasetId), () -> String.format("Missing dataset `%s`", datasetId));
 		ConqueryMDC.setLocation(ns.getStorage().getDataset().toString());
 		message.react(ns);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
@@ -32,7 +32,7 @@ public class RegisterWorker extends MessageToManagerNode {
 			.until(()->getShardNode(context) != null);
 		
 		if(node == null) {
-			throw new IllegalStateException("Could not find the slave "+context.getRemoteAddress()+" to register worker "+info.getId());
+			throw new IllegalStateException("Could not find the shard " + context.getRemoteAddress() + " to register worker " + info.getId());
 		}
 
 		info.setConnectedShardNode(node);

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RegisterWorker.java
@@ -36,10 +36,10 @@ public class RegisterWorker extends MessageToManagerNode {
 		}
 
 		info.setConnectedShardNode(node);
-		context.getNamespaces().register(node, info);
+		context.getDatasetRegistry().register(node, info);
 
 		// Request consistency report
-		context.getNamespaces().getWorkers().get(info.getId()).send(new RequestConsistency());
+		context.getDatasetRegistry().getWorkers().get(info.getId()).send(new RequestConsistency());
 	}
 
 	/**
@@ -48,8 +48,8 @@ public class RegisterWorker extends MessageToManagerNode {
 	 * @return the found slave or null if none was found
 	 */
 	private ShardNodeInformation getShardNode(ManagerNodeNetworkContext context) {
-		return context.getNamespaces()
-			.getShardNodes()
-			.get(context.getRemoteAddress());
+		return context.getDatasetRegistry()
+					  .getShardNodes()
+					  .get(context.getRemoteAddress());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveShardNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveShardNode.java
@@ -24,6 +24,6 @@ public class RemoveShardNode extends MessageToManagerNode {
 	@Override
 	public void react(NetworkMessageContext.ManagerNodeNetworkContext context) throws Exception {
 		log.info("ShardNode {} unregistered.", context.getRemoteAddress());
-		context.getNamespaces().getShardNodes().remove(context.getRemoteAddress());
+		context.getDatasetRegistry().getShardNodes().remove(context.getRemoteAddress());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveWorker.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/RemoveWorker.java
@@ -3,6 +3,8 @@ package com.bakdata.conquery.models.messages.network.specific;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.serializer.NsIdRef;
 import com.bakdata.conquery.models.datasets.Dataset;
+import com.bakdata.conquery.models.identifiable.ids.specific.WorkerId;
+import com.bakdata.conquery.models.messages.namespaces.specific.AcknowledgeWorkerRemoved;
 import com.bakdata.conquery.models.messages.network.MessageToShardNode;
 import com.bakdata.conquery.models.messages.network.NetworkMessage;
 import com.bakdata.conquery.models.messages.network.NetworkMessageContext.ShardNodeNetworkContext;
@@ -22,7 +24,8 @@ public class RemoveWorker extends MessageToShardNode.Slow {
 	public void react(ShardNodeNetworkContext context) throws Exception {
 		log.info("Removing worker {}", dataset);
 
-		context.getWorkers().removeWorkerFor(dataset.getId());
+		final WorkerId workerId = context.getWorkers().removeWorkerFor(dataset.getId());
 
+		context.send(new AcknowledgeWorkerRemoved(workerId));
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/messages/network/specific/UpdateJobManagerStatus.java
@@ -24,12 +24,12 @@ public class UpdateJobManagerStatus extends MessageToManagerNode {
 
 	@Override
 	public void react(ManagerNodeNetworkContext context) throws Exception {
-		ShardNodeInformation node = context.getNamespaces()
-										 .getShardNodes()
-										 .get(context.getRemoteAddress());
+		ShardNodeInformation node = context.getDatasetRegistry()
+										   .getShardNodes()
+										   .get(context.getRemoteAddress());
 
 		if (node == null) {
-			log.error("Could not find ShardNode {}, I only know of {}", context.getRemoteAddress(), context.getNamespaces().getShardNodes().keySet());
+			log.error("Could not find ShardNode {}, I only know of {}", context.getRemoteAddress(), context.getDatasetRegistry().getShardNodes().keySet());
 		}
 		else {
 			node.setJobManagerStatus(status);

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Namespace.java
@@ -80,6 +80,7 @@ public class Namespace extends IdResolveContext implements Closeable {
 	// Jackson's injectables that are available when deserializing requests (see PathParamInjector) or items from the storage
 	private final List<Injectable> injectables;
 
+
 	public static Namespace create(ExecutionManager executionManager, NamespaceStorage storage, ConqueryConfig config, Function<Class<? extends View>, ObjectMapper> mapperCreator) {
 
 		// Prepare namespace dependent Jackson injectables
@@ -182,7 +183,7 @@ public class Namespace extends IdResolveContext implements Closeable {
 		}
 	}
 
-	public void remove() {
+	public synchronized void remove() {
 		try {
 			jobManager.close();
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Workers.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Workers.java
@@ -27,12 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * {@link com.bakdata.conquery.commands.ShardNode} container of {@link Worker}.
- *
+ * <p>
  * Each Shard contains one {@link Worker} per {@link Dataset}.
  */
 @Slf4j
 public class Workers extends IdResolveContext {
-	@Getter @Setter
+	@Getter
+	@Setter
 	private AtomicInteger nextWorker = new AtomicInteger(0);
 	@Getter
 	private ConcurrentHashMap<WorkerId, Worker> workers = new ConcurrentHashMap<>();
@@ -50,7 +51,7 @@ public class Workers extends IdResolveContext {
 
 	private final int entityBucketSize;
 
-	
+
 	public Workers(ThreadPoolDefinition queryThreadPoolDefinition, Supplier<ObjectMapper> persistenceMapperSupplier, Supplier<ObjectMapper> communicationMapperSupplier, int entityBucketSize) {
 		this.queryThreadPoolDefinition = queryThreadPoolDefinition;
 
@@ -135,19 +136,20 @@ public class Workers extends IdResolveContext {
 			return null;
 		}
 
-		workers.remove(removed.getInfo().getId());
+		final WorkerId id = removed.getInfo().getId();
+		workers.remove(id);
 		try {
 			removed.remove();
 		}
-		catch(Exception e) {
-			log.error("Failed to remove storage "+removed, e);
+		catch (Exception e) {
+			log.error("Failed to remove storage " + removed, e);
 		}
-		return removed.getInfo().getId();
+		return id;
 	}
-	
+
 	public boolean isBusy() {
-		for( Worker worker : workers.values()) {
-			if(worker.isBusy()) {
+		for (Worker worker : workers.values()) {
+			if (worker.isBusy()) {
 				return true;
 			}
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/Workers.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/Workers.java
@@ -121,7 +121,7 @@ public class Workers extends IdResolveContext {
 		return null; // Workers simply have no MetaRegistry.
 	}
 
-	public void removeWorkerFor(DatasetId dataset) {
+	public WorkerId removeWorkerFor(DatasetId dataset) {
 		final Worker worker = dataset2Worker.get(dataset);
 
 		/*
@@ -132,7 +132,7 @@ public class Workers extends IdResolveContext {
 
 		Worker removed = dataset2Worker.remove(dataset);
 		if (removed == null) {
-			return;
+			return null;
 		}
 
 		workers.remove(removed.getInfo().getId());
@@ -142,6 +142,7 @@ public class Workers extends IdResolveContext {
 		catch(Exception e) {
 			log.error("Failed to remove storage "+removed, e);
 		}
+		return removed.getInfo().getId();
 	}
 	
 	public boolean isBusy() {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetProcessor.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.validation.Validator;
 import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -109,7 +110,12 @@ public class AdminDatasetProcessor {
 			);
 		}
 
-		datasetRegistry.removeNamespace(dataset.getId());
+		try {
+			datasetRegistry.removeNamespace(dataset.getId());
+		}
+		catch (InterruptedException e) {
+			throw new InternalServerErrorException(e);
+		}
 
 	}
 


### PR DESCRIPTION
The manager node waits until it has add/delete confirmation from all shards/workers.

Came up with new e2e tests for the admin-ui