### PR TITLE
adds tooltip for validitydate selector

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/frontend/FrontendValidityDate.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/frontend/FrontendValidityDate.java
@@ -2,12 +2,21 @@ package com.bakdata.conquery.apiv1.frontend;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
 public class FrontendValidityDate {
+
+	/**
+	 * Further information about the available validity dates.
+	 */
+	@Nullable
+	private String tooltip;
+
 	private String defaultValue;
 	private List<FrontendValue> options;
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/Connector.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -20,6 +21,7 @@ import com.bakdata.conquery.models.identifiable.Labeled;
 import com.bakdata.conquery.models.identifiable.ids.NamespacedIdentifiable;
 import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.models.identifiable.ids.specific.FilterId;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -46,6 +48,10 @@ public abstract class Connector extends Labeled<ConnectorId> implements SelectHo
 
 	public static final int[] NOT_CONTAINED = new int[]{-1};
 	private static final long serialVersionUID = 1L;
+
+	@Nullable
+	@JsonAlias("validityDatesTooltip")
+	private String validityDatesDescription;
 
 	@NotNull
 	@JsonManagedReference

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/FrontEndConceptBuilder.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/FrontEndConceptBuilder.java
@@ -224,6 +224,7 @@ public class FrontEndConceptBuilder {
 		if(con.getValidityDates().size() > 1) {
 			result.setDateColumn(
 					new FrontendValidityDate(
+							con.getValidityDatesDescription(),
 							null,
 							con
 									.getValidityDates()

--- a/cypress/support/test_data/all_types.concept.json
+++ b/cypress/support/test_data/all_types.concept.json
@@ -2,18 +2,19 @@
     "label": "Concept1",
     "type": "TREE",
     "connectors": {
-        "name": "column",
-        "column": "table.STRING",
-        "validityDates": [
-            {
-                "label": "DATE",
-                "column": "table.DATE"
-            },
-            {
-                "label": "DATE_RANGE",
-                "column": "table.DATE_RANGE"
-            }
-        ],
+      "name": "column",
+      "column": "table.STRING",
+      "validityDatesDescription": "Tooltip for the available validity dates",
+      "validityDates": [
+        {
+          "label": "DATE",
+          "column": "table.DATE"
+        },
+        {
+          "label": "DATE_RANGE",
+          "column": "table.DATE_RANGE"
+        }
+      ],
         "filters": [
             {
                 "type": "SUM",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -934,6 +934,9 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/Filter"
+            validityDatesDescription:
+              description: "Further information about the available validity dates."
+              type: string
             validityDates:
               description: "Definitions of relevant date columns for this connector.
               e.g.: The publishing date of a movie, and its production period."


### PR DESCRIPTION
@Kadrian this adds an optional tooltip for the validity date selection.
It is available under `GET /datasets/<dataset>/concepts >` ` <conceptId> > tables[*] > dateColumn > tooltip` and can be null.