### PR TITLE
Refactor additional info hover

### DIFF
--- a/frontend/src/js/concept-trees/ConceptTree.tsx
+++ b/frontend/src/js/concept-trees/ConceptTree.tsx
@@ -1,5 +1,9 @@
 import styled from "@emotion/styled";
-import { faRedo, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import {
+  faEllipsisH,
+  faRedo,
+  faSpinner,
+} from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
 
 import type { ConceptT, ConceptIdT } from "../api/types";
@@ -41,7 +45,7 @@ const ConceptTree = ({
   search,
   onLoadTree,
 }: {
-  tree: ConceptT | null;
+  tree?: ConceptT;
   conceptId: ConceptIdT;
   label: string;
   depth: number;
@@ -78,7 +82,15 @@ const ConceptTree = ({
         search={search}
       />
     );
-  else return <ConceptTreeNodeText disabled label={label} depth={depth} />;
+  else
+    return (
+      <ConceptTreeNodeText
+        disabled
+        icon={faEllipsisH}
+        label={label}
+        depth={depth}
+      />
+    );
 };
 
 export default ConceptTree;

--- a/frontend/src/js/concept-trees/ConceptTreeFolder.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeFolder.tsx
@@ -82,6 +82,7 @@ const ConceptTreeFolder: FC<PropsT> = ({
           children: tree.children,
         }}
         conceptId={conceptId}
+        root={tree}
         isStructFolder
         open={open || false}
         depth={depth}

--- a/frontend/src/js/concept-trees/ConceptTreeNode.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNode.tsx
@@ -79,6 +79,11 @@ const ConceptTreeNode: FC<PropsT> = ({
 
   const isOpen = open || search.allOpen;
 
+  const root = getConceptById(
+    rootConceptId,
+    rootConceptId, // To optimize lookup
+  ) as ConceptElementT;
+
   return (
     <Root>
       <ConceptTreeNodeTextContainer
@@ -93,14 +98,9 @@ const ConceptTreeNode: FC<PropsT> = ({
 
           children: data.children,
         }}
-        parentId={rootConceptId}
+        root={root}
         conceptId={conceptId}
         createQueryElement={(): ConceptQueryNodeType => {
-          const concept = getConceptById(
-            rootConceptId,
-            rootConceptId, // To optimize lookup
-          ) as ConceptElementT | null;
-
           const description = data.description
             ? { description: data.description }
             : {};
@@ -109,11 +109,11 @@ const ConceptTreeNode: FC<PropsT> = ({
             ids: [conceptId],
             ...description,
             label: data.label,
-            tables: concept?.tables
-              ? resetTables(concept.tables, { useDefaults: true })
+            tables: root?.tables
+              ? resetTables(root.tables, { useDefaults: true })
               : [],
-            selects: concept?.selects
-              ? resetSelects(concept.selects, { useDefaults: true })
+            selects: root?.selects
+              ? resetSelects(root.selects, { useDefaults: true })
               : [],
 
             additionalInfos: data.additionalInfos,

--- a/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
@@ -1,16 +1,9 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import {
-  faFolderOpen as faFolderOpenRegular,
-  faFolder as faFolderRegular,
-} from "@fortawesome/free-regular-svg-icons";
-import {
   faCaretDown,
   faCaretRight,
-  faFolderOpen,
-  faFolder,
-  faEllipsisH,
-  faMinus,
+  IconDefinition,
 } from "@fortawesome/free-solid-svg-icons";
 import { forwardRef } from "react";
 import Highlighter from "react-highlight-words";
@@ -100,33 +93,35 @@ const ResultsNumber = styled("span")`
   font-weight: 700;
 `;
 
-interface PropsT {
-  label: string;
-  depth: number;
-  className?: string;
-  description?: string;
-  resultCount?: number | null;
-  searchWords?: string[] | null;
-  isOpen?: boolean;
-  isStructFolder?: boolean;
-  hasChildren?: boolean;
-  red?: boolean;
-  disabled?: boolean;
-  onClick?: () => void;
-}
+const ConceptTreeNodeText = forwardRef<
+  HTMLDivElement,
+  {
+    label: string;
+    depth: number;
+    icon: IconDefinition;
 
-const ConceptTreeNodeText = forwardRef<HTMLDivElement, PropsT>(
+    className?: string;
+    description?: string;
+    resultCount?: number | null;
+    searchWords?: string[] | null;
+    isOpen?: boolean;
+    hasChildren?: boolean;
+    red?: boolean;
+    disabled?: boolean;
+    onClick?: () => void;
+  }
+>(
   (
     {
       label,
       description,
+      icon,
       resultCount,
       searchWords,
       className,
       depth,
 
       isOpen,
-      isStructFolder,
       red,
       disabled,
       hasChildren,
@@ -134,73 +129,58 @@ const ConceptTreeNodeText = forwardRef<HTMLDivElement, PropsT>(
       onClick,
     },
     ref,
-  ) => (
-    <Root ref={ref} className={className} depth={depth}>
-      <Text onClick={onClick} isOpen={isOpen} red={red} disabled={disabled}>
-        {hasChildren && (
-          <>
-            <CaretIconContainer>
-              <FaIcon
-                disabled={disabled}
-                active
-                icon={!!isOpen ? faCaretDown : faCaretRight}
-              />
-            </CaretIconContainer>
-            <FolderIconContainer>
-              <FaIcon
-                active
-                disabled={disabled}
-                icon={
-                  !!isOpen
-                    ? isStructFolder
-                      ? faFolderOpenRegular
-                      : faFolderOpen
-                    : isStructFolder
-                    ? faFolderRegular
-                    : faFolder
-                }
-              />
-            </FolderIconContainer>
-          </>
-        )}
-        {!hasChildren && (
-          <DashIconContainer>
-            <FaIcon
-              disabled={disabled}
-              large
-              active
-              icon={disabled ? faEllipsisH : faMinus}
-            />
-          </DashIconContainer>
-        )}
-        {resultCount && <ResultsNumber>{resultCount}</ResultsNumber>}
-        <span>
-          {!!searchWords ? (
-            <Highlighter
-              searchWords={searchWords}
-              autoEscape={true}
-              textToHighlight={label}
-            />
-          ) : (
-            label
+  ) => {
+    return (
+      <Root ref={ref} className={className} depth={depth}>
+        <Text onClick={onClick} isOpen={isOpen} red={red} disabled={disabled}>
+          {hasChildren && (
+            <>
+              <CaretIconContainer>
+                <FaIcon
+                  disabled={disabled}
+                  active
+                  icon={!!isOpen ? faCaretDown : faCaretRight}
+                />
+              </CaretIconContainer>
+              <FolderIconContainer>
+                <FaIcon active disabled={disabled} icon={icon} />
+              </FolderIconContainer>
+            </>
           )}
-        </span>
-        {!!description && (
-          <Description>
+          {!hasChildren && (
+            <DashIconContainer>
+              <FaIcon disabled={disabled} large active icon={icon} />
+            </DashIconContainer>
+          )}
+          {resultCount && <ResultsNumber>{resultCount}</ResultsNumber>}
+          <span>
             {!!searchWords ? (
               <Highlighter
                 searchWords={searchWords}
                 autoEscape={true}
-                textToHighlight={description}
+                textToHighlight={label}
               />
             ) : (
-              `- ${description}`
+              label
             )}
-          </Description>
-        )}
-      </Text>
-    </Root>
-  ),
+          </span>
+          {!!description && (
+            <Description>
+              {!!searchWords ? (
+                <Highlighter
+                  searchWords={searchWords}
+                  autoEscape={true}
+                  textToHighlight={description}
+                />
+              ) : (
+                `- ${description}`
+              )}
+            </Description>
+          )}
+        </Text>
+      </Root>
+    );
+  },
 );
 
 export default ConceptTreeNodeText;

--- a/frontend/src/js/concept-trees/ConceptTreeNodeTextContainer.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNodeTextContainer.tsx
@@ -5,6 +5,7 @@ import type { ConceptIdT, ConceptT } from "../api/types";
 import { getWidthAndHeight } from "../app/DndProvider";
 import { DNDType } from "../common/constants/dndTypes";
 import { exists } from "../common/helpers/exists";
+import { getNodeIcon } from "../model/node";
 import type {
   ConceptQueryNodeType,
   DragItemConceptTreeNode,
@@ -12,13 +13,12 @@ import type {
 import AdditionalInfoHoverable from "../tooltip/AdditionalInfoHoverable";
 
 import ConceptTreeNodeText from "./ConceptTreeNodeText";
-import { getConceptById } from "./globalTreeStoreHelper";
 import type { SearchT } from "./reducer";
 
 interface PropsT {
-  node: ConceptT;
-  parentId?: string;
   conceptId: ConceptIdT;
+  node: ConceptT;
+  root: ConceptT;
   open: boolean;
   depth: number;
   active?: boolean;
@@ -45,8 +45,9 @@ function getResultCount(
 }
 
 const ConceptTreeNodeTextContainer: FC<PropsT> = ({
-  node,
   conceptId,
+  node,
+  root,
   depth,
   search,
   active,
@@ -54,7 +55,6 @@ const ConceptTreeNodeTextContainer: FC<PropsT> = ({
   onTextClick,
   isStructFolder,
   createQueryElement,
-  parentId,
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -91,13 +91,13 @@ const ConceptTreeNodeTextContainer: FC<PropsT> = ({
     }),
   });
 
+  const icon = getNodeIcon(node, {
+    isStructNode: isStructFolder || active === false,
+    open,
+  });
+
   return (
-    <AdditionalInfoHoverable
-      node={node}
-      parent={
-        parentId ? getConceptById(parentId, parentId) ?? undefined : undefined
-      }
-    >
+    <AdditionalInfoHoverable node={node} root={root}>
       <ConceptTreeNodeText
         ref={(instance) => {
           ref.current = instance;
@@ -114,7 +114,7 @@ const ConceptTreeNodeTextContainer: FC<PropsT> = ({
         searchWords={search.words}
         hasChildren={hasChildren}
         isOpen={open}
-        isStructFolder={isStructFolder || active === false}
+        icon={icon}
         red={red}
         onClick={onTextClick}
       />

--- a/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
+++ b/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
@@ -49,9 +49,9 @@ export function setTree(
 export function getConceptById(
   conceptId: ConceptIdT,
   rootId?: ConceptIdT,
-): ConceptT | null {
+): ConceptT | undefined {
   if (rootId) {
-    return window.conceptTrees[rootId][conceptId] || null;
+    return window.conceptTrees[rootId]?.[conceptId];
   }
 
   const conceptTreeRootIds: ConceptIdT[] = Object.keys(window.conceptTrees);
@@ -62,7 +62,7 @@ export function getConceptById(
     if (concept) return concept;
   }
 
-  return null;
+  return undefined;
 }
 
 //

--- a/frontend/src/js/entity-history/SearchEntities.tsx
+++ b/frontend/src/js/entity-history/SearchEntities.tsx
@@ -32,11 +32,11 @@ export const SearchEntites = ({
 }: {
   onLoad: (payload: LoadingPayload) => void;
 }) => {
-  const searchConcept = useSelector<StateT, ConceptT | null>((state) =>
-    state.entityHistory.defaultParams.searchConcept
-      ? getConceptById(state.entityHistory.defaultParams.searchConcept)
-      : null,
-  );
+  const searchConcept = useSelector<StateT, ConceptT | undefined>((state) => {
+    const searchConceptId = state.entityHistory.defaultParams.searchConcept;
+
+    return searchConceptId ? getConceptById(searchConceptId) : undefined;
+  });
 
   if (
     !searchConcept ||

--- a/frontend/src/js/model/node.ts
+++ b/frontend/src/js/model/node.ts
@@ -1,3 +1,13 @@
+import {
+  faFolder as faFolderRegular,
+  faFolderOpen as faFolderOpenRegular,
+} from "@fortawesome/free-regular-svg-icons";
+import {
+  faFolder,
+  faFolderOpen,
+  faMinus,
+} from "@fortawesome/free-solid-svg-icons";
+
 import { ConceptElementT, ConceptT } from "../api/types";
 import { DNDType } from "../common/constants/dndTypes";
 import type {
@@ -95,4 +105,24 @@ export function nodeIsAllowlisted(
 
 export function nodeIsElement(node: ConceptT): node is ConceptElementT {
   return "tables" in node;
+}
+
+export function getNodeIcon(
+  node: ConceptT,
+  config?: {
+    isStructNode?: boolean;
+    open?: boolean;
+  },
+) {
+  const hasChildren = node.children && node.children?.length > 0;
+
+  if (!hasChildren) {
+    return faMinus;
+  }
+
+  if (config?.open) {
+    return config?.isStructNode ? faFolderOpenRegular : faFolderOpen;
+  }
+
+  return config?.isStructNode ? faFolderRegular : faFolder;
 }

--- a/frontend/src/js/query-node-editor/AdditionalConceptNodeChildren.tsx
+++ b/frontend/src/js/query-node-editor/AdditionalConceptNodeChildren.tsx
@@ -3,7 +3,6 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ConceptBaseT, ConceptIdT } from "../api/types";
-import { getConceptById } from "../concept-trees/globalTreeStoreHelper";
 import { Heading4 } from "../headings/Headings";
 import { DragItemConceptTreeNode } from "../standard-query-editor/types";
 
@@ -56,8 +55,8 @@ const AdditionalConceptNodeChildren = ({
           {sortedNodeIds.map((conceptId) => (
             <ConceptEntry
               key={conceptId}
-              node={getConceptById(conceptId)}
               conceptId={conceptId}
+              root={rootConcept}
               canRemoveConcepts={node.ids.length > 1}
               onRemoveConcept={onRemoveConcept}
             />

--- a/frontend/src/js/query-node-editor/ConceptEntry.tsx
+++ b/frontend/src/js/query-node-editor/ConceptEntry.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import type { ConceptIdT, ConceptT } from "../api/types";
 import IconButton from "../button/IconButton";
+import { getConceptById } from "../concept-trees/globalTreeStoreHelper";
 import AdditionalInfoHoverable from "../tooltip/AdditionalInfoHoverable";
 
 const Concept = styled("div")`
@@ -41,19 +42,20 @@ const SxIconButton = styled(IconButton)`
 `;
 
 interface Props {
-  node: ConceptT | null;
   conceptId: ConceptIdT;
+  root: ConceptT;
   canRemoveConcepts?: boolean;
   onRemoveConcept: (conceptId: ConceptIdT) => void;
 }
 
 const ConceptEntry = ({
-  node,
   conceptId,
+  root,
   canRemoveConcepts,
   onRemoveConcept,
 }: Props) => {
   const { t } = useTranslation();
+  const node = getConceptById(conceptId);
 
   const ConceptEntryRoot = (
     <Concept>
@@ -81,8 +83,8 @@ const ConceptEntry = ({
     </Concept>
   );
 
-  return node ? (
-    <AdditionalInfoHoverable node={node}>
+  return node && root ? (
+    <AdditionalInfoHoverable node={node} root={root}>
       {ConceptEntryRoot}
     </AdditionalInfoHoverable>
   ) : (

--- a/frontend/src/js/standard-query-editor/QueryNode.tsx
+++ b/frontend/src/js/standard-query-editor/QueryNode.tsx
@@ -245,11 +245,12 @@ const QueryNode = ({
   );
 
   if (nodeIsConceptQueryNode(node)) {
-    const conceptById = getConceptById(node.ids[0]);
+    const conceptById = getConceptById(node.ids[0], node.tree);
+    const root = getConceptById(node.tree, node.tree);
 
-    if (conceptById) {
+    if (conceptById && root) {
       return (
-        <AdditionalInfoHoverable node={conceptById}>
+        <AdditionalInfoHoverable node={conceptById} root={root}>
           {QueryNodeRoot}
         </AdditionalInfoHoverable>
       );

--- a/frontend/src/js/tooltip/AdditionalInfoHoverable.tsx
+++ b/frontend/src/js/tooltip/AdditionalInfoHoverable.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 
 import type { ConceptT } from "../api/types";
 import { isEmpty } from "../common/helpers/commonHelper";
+import { getNodeIcon } from "../model/node";
 
 import { toggleAdditionalInfos, displayAdditionalInfos } from "./actions";
 import { AdditionalInfosType } from "./reducer";
@@ -15,28 +16,31 @@ const Root = styled("div")`
 // Allowlist the data we pass (especially: don't pass all children)
 const getAdditionalInfos = (
   node: ConceptT,
-  parent?: ConceptT,
+  root?: ConceptT,
 ): AdditionalInfosType => ({
   label: node.label,
   description: node.description,
-  isFolder: !!node.children && node.children.length > 0,
   matchingEntries: node.matchingEntries,
   matchingEntities: node.matchingEntities,
   dateRange: node.dateRange,
   infos: node.additionalInfos,
-  parent: parent,
+  icon: getNodeIcon(node, {
+    isStructNode: !root?.detailsAvailable,
+  }),
+  rootLabel: root?.label,
+  rootIcon: root ? getNodeIcon(root) : undefined,
 });
 
 const AdditionalInfoHoverable = ({
   node,
   className,
   children,
-  parent,
+  root,
 }: {
   children: ReactNode;
-  node: ConceptT;
   className?: string;
-  parent?: ConceptT;
+  node: ConceptT;
+  root: ConceptT;
 }) => {
   const dispatch = useDispatch();
 
@@ -44,7 +48,7 @@ const AdditionalInfoHoverable = ({
     if (!node.additionalInfos && isEmpty(node.matchingEntries)) return;
     dispatch(
       displayAdditionalInfos({
-        additionalInfos: getAdditionalInfos(node, parent),
+        additionalInfos: getAdditionalInfos(node, root),
       }),
     );
   };
@@ -55,7 +59,7 @@ const AdditionalInfoHoverable = ({
     dispatch(toggleAdditionalInfos());
     dispatch(
       displayAdditionalInfos({
-        additionalInfos: getAdditionalInfos(node, parent),
+        additionalInfos: getAdditionalInfos(node, root),
       }),
     );
   };

--- a/frontend/src/js/tooltip/Tooltip.tsx
+++ b/frontend/src/js/tooltip/Tooltip.tsx
@@ -1,10 +1,6 @@
 import styled from "@emotion/styled";
-import { faFolder as faFolderRegular } from "@fortawesome/free-regular-svg-icons";
-import {
-  faFolder,
-  faMinus,
-  faThumbtack,
-} from "@fortawesome/free-solid-svg-icons";
+import { faThumbtack, IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { ReactNode } from "react";
 import Highlighter from "react-highlight-words";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
@@ -13,7 +9,6 @@ import remarkGfm from "remark-gfm";
 
 import type { StateT } from "../app/reducers";
 import IconButton from "../button/IconButton";
-import type { SearchT } from "../concept-trees/reducer";
 import FaIcon from "../icon/FaIcon";
 
 import ActivateTooltip from "./ActivateTooltip";
@@ -83,7 +78,7 @@ const Infos = styled("div")`
 
 const IndentRoot = styled("div")`
   padding-left: 15px;
-  margin: 3px 0 8px;
+  margin: 5px 0 12px;
 `;
 
 const PieceOfInfo = styled("div")`
@@ -118,10 +113,66 @@ const InfoHeadline = styled("h4")`
   line-height: 1.3;
 `;
 
-const Tooltip = () => {
+const HighlightedText = ({
+  text,
+  words = [],
+}: {
+  words: string[];
+  text: string;
+}) => {
+  return (
+    <Highlighter
+      searchWords={words}
+      autoEscape={true}
+      textToHighlight={text || ""}
+    />
+  );
+};
+
+const ConceptLabel = ({
+  label,
+  conceptIcon,
+  tackIcon,
+}: {
+  label?: string;
+  conceptIcon?: IconDefinition;
+  tackIcon?: ReactNode;
+}) => {
+  const words = useSelector<StateT, string[]>(
+    (state) => state.conceptTrees.search.words || [],
+  );
   const { t } = useTranslation();
 
-  const additionalInfos = useSelector<StateT, AdditionalInfosType>(
+  return (
+    <PinnedLabel>
+      {conceptIcon && <TypeIcon icon={conceptIcon} />}
+      <Label>
+        {label ? (
+          <HighlightedText words={words} text={label} />
+        ) : (
+          t("tooltip.placeholder")
+        )}
+      </Label>
+      {tackIcon}
+    </PinnedLabel>
+  );
+};
+
+const Tooltip = () => {
+  const words = useSelector<StateT, string[]>(
+    (state) => state.conceptTrees.search.words || [],
+  );
+  const {
+    label,
+    description,
+    infos,
+    matchingEntries,
+    matchingEntities,
+    dateRange,
+    icon,
+    rootLabel,
+    rootIcon,
+  } = useSelector<StateT, AdditionalInfosType>(
     (state) => state.tooltip.additionalInfos,
   );
   const displayTooltip = useSelector<StateT, boolean>(
@@ -130,42 +181,17 @@ const Tooltip = () => {
   const toggleAdditionalInfos = useSelector<StateT, boolean>(
     (state) => state.tooltip.toggleAdditionalInfos,
   );
-  const search = useSelector<StateT, SearchT>(
-    (state) => state.conceptTrees.search,
-  );
 
   const dispatch = useDispatch();
   const onToggleAdditionalInfos = () => dispatch(toggleInfos());
 
-  const {
-    label,
-    description,
-    isFolder,
-    infos,
-    matchingEntries,
-    matchingEntities,
-    dateRange,
-    parent,
-  } = additionalInfos;
-
   if (!displayTooltip) return <ActivateTooltip />;
 
-  const searchHighlight = (text: string) => {
-    return (
-      <Highlighter
-        searchWords={search.words || []}
-        autoEscape={true}
-        textToHighlight={text || ""}
-      />
-    );
-  };
-  const chooseIcon = () => {
-    const parentProvided = parent?.label !== label;
-    if (!isFolder && !parentProvided) return faMinus;
+  const mainLabel = rootLabel || label;
+  const mainIcon = rootIcon || icon;
 
-    const isStructNode = !parent?.detailsAvailable;
-    return isStructNode ? faFolderRegular : faFolder;
-  };
+  const differentRootLabel = !!rootLabel && rootLabel !== label;
+
   return (
     <Root>
       <TooltipHeader />
@@ -176,43 +202,38 @@ const Tooltip = () => {
           dateRange={dateRange}
         />
         <Head>
-          <PinnedLabel>
-            <TypeIcon icon={chooseIcon()} />
-            <Label>
-              {parent?.label
-                ? searchHighlight(parent?.label)
-                : label
-                ? searchHighlight(label)
-                : t("tooltip.placeholder")}
-            </Label>
-            {toggleAdditionalInfos && (
-              <TackIconButton
-                bare
-                active
-                onClick={onToggleAdditionalInfos}
-                icon={faThumbtack}
-              />
-            )}
-          </PinnedLabel>
-          {parent?.label !== label && parent?.label && (
+          <ConceptLabel
+            label={mainLabel}
+            conceptIcon={mainIcon}
+            tackIcon={
+              toggleAdditionalInfos && (
+                <TackIconButton
+                  bare
+                  active
+                  onClick={onToggleAdditionalInfos}
+                  icon={faThumbtack}
+                />
+              )
+            }
+          />
+          {differentRootLabel && (
             <IndentRoot>
-              <PinnedLabel>
-                <TypeIcon icon={isFolder ? faFolder : faMinus} />
-                <Label>
-                  {label ? searchHighlight(label) : t("tooltip.placeholder")}
-                </Label>
-              </PinnedLabel>
+              <ConceptLabel label={label} conceptIcon={icon} />
             </IndentRoot>
           )}
           {description && (
-            <Description>{searchHighlight(description)}</Description>
+            <Description>
+              <HighlightedText words={words} text={description} />
+            </Description>
           )}
         </Head>
         <Infos>
           {infos &&
             infos.map((info, i) => (
               <PieceOfInfo key={info.key + i}>
-                <InfoHeadline>{searchHighlight(info.key)}</InfoHeadline>
+                <InfoHeadline>
+                  <HighlightedText words={words} text={info.key} />
+                </InfoHeadline>
                 <Markdown
                   remarkPlugins={[remarkGfm]}
                   components={

--- a/frontend/src/js/tooltip/reducer.ts
+++ b/frontend/src/js/tooltip/reducer.ts
@@ -1,6 +1,7 @@
+import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { ActionType, getType } from "typesafe-actions";
 
-import type { ConceptT, DateRangeT } from "../api/types";
+import type { DateRangeT } from "../api/types";
 import type { Action } from "../app/actions";
 
 import {
@@ -15,14 +16,16 @@ type InfoType = {
 };
 
 export type AdditionalInfosType = {
-  label: string | null;
+  label?: string;
   description?: string;
-  isFolder: boolean;
   matchingEntries: number | null;
   matchingEntities: number | null;
   dateRange?: DateRangeT;
   infos?: InfoType[];
-  parent?: ConceptT;
+  isStructNode?: boolean;
+  icon?: IconDefinition;
+  rootIcon?: IconDefinition;
+  rootLabel?: string;
 };
 
 export type TooltipStateT = {
@@ -32,13 +35,8 @@ export type TooltipStateT = {
 };
 
 const additionalInfosInitialState: AdditionalInfosType = {
-  label: null,
-  description: undefined,
-  isFolder: false,
   matchingEntries: null,
   matchingEntities: null,
-  dateRange: undefined,
-  infos: undefined,
 };
 
 const initialState: TooltipStateT = {


### PR DESCRIPTION
- Fix root display for hovering query nodes and concept entries
- Refactor global tree getter
- Extract some smaller components from Tooltip
- Extract a shared node icon helper to always get the same icon for a concept

@fabian-bizfactory FYI, I also added some comments to explain