### PR TITLE
uses ExecutionId in ExecutionManager cache, because the underlying im…

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -184,7 +184,7 @@ public class QueryProcessor {
 		if (!user.isOwner(execution)) {
 			final ManagedExecution
 					newExecution =
-					executionManager.createExecution(namespace, execution.getSubmitted(), user, execution.getDataset(), false);
+					executionManager.createExecution(execution.getSubmitted(), user, execution.getDataset(), false);
 			newExecution.setLabel(execution.getLabel());
 			newExecution.setTags(execution.getTags().clone());
 			storage.updateExecution(newExecution);
@@ -318,22 +318,6 @@ public class QueryProcessor {
 
 		patch.applyTo(execution, storage, subject);
 		storage.updateExecution(execution);
-
-		// TODO remove this, since we don't translate anymore
-		// Patch this query in other datasets
-		final List<Dataset> remainingDatasets = datasetRegistry.getAllDatasets();
-		remainingDatasets.remove(execution.getDataset());
-
-		for (Dataset dataset : remainingDatasets) {
-			final ManagedExecutionId id = new ManagedExecutionId(dataset.getId(), execution.getQueryId());
-			final ManagedExecution otherExecution = storage.getExecution(id);
-			if (otherExecution == null) {
-				continue;
-			}
-			log.trace("Patching {} ({}) with patch: {}", execution.getClass().getSimpleName(), id, patch);
-			patch.applyTo(otherExecution, storage, subject);
-			storage.updateExecution(execution);
-		}
 	}
 
 	public void reexecute(Subject subject, ManagedExecution query) {
@@ -399,7 +383,7 @@ public class QueryProcessor {
 				execution =
 				((ManagedQuery) namespace
 						.getExecutionManager()
-						.createExecution(namespace, query, subject.getUser(), dataset, false));
+						.createExecution(query, subject.getUser(), dataset, false));
 
 		execution.setLastResultCount((long) statistic.getResolved().size());
 

--- a/backend/src/main/java/com/bakdata/conquery/io/result/csv/ResultCsvProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/result/csv/ResultCsvProcessor.java
@@ -75,12 +75,7 @@ public class ResultCsvProcessor {
 			}
 		};
 
-		return makeResponseWithFileName(
-				Response.ok(out),
-				String.join(".", exec.getLabelWithoutAutoLabelSuffix(), ResourceConstants.FILE_EXTENTION_CSV),
-				new MediaType("text", "csv", charset.toString()),
-				ResultUtil.ContentDispositionOption.ATTACHMENT
-		);
+		return makeResponseWithFileName(Response.ok(out), String.join(".", exec.getLabelWithoutAutoLabelSuffix(), ResourceConstants.FILE_EXTENTION_CSV), new MediaType("text", "csv", charset.toString()), ResultUtil.ContentDispositionOption.ATTACHMENT);
 
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/io/storage/MetaStorage.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/storage/MetaStorage.java
@@ -30,19 +30,16 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MetaStorage extends ConqueryStorage implements Injectable {
 
-	private final StoreFactory storageFactory;
-
-	private IdentifiableStore<ManagedExecution> executions;
-
-	private IdentifiableStore<FormConfig> formConfigs;
-	private IdentifiableStore<User> authUser;
-	private IdentifiableStore<Role> authRole;
-	private IdentifiableStore<Group> authGroup;
-
 	@Getter
 	protected final CentralRegistry centralRegistry = new CentralRegistry();
 	@Getter
 	protected final DatasetRegistry datasetRegistry;
+	private final StoreFactory storageFactory;
+	private IdentifiableStore<ManagedExecution> executions;
+	private IdentifiableStore<FormConfig> formConfigs;
+	private IdentifiableStore<User> authUser;
+	private IdentifiableStore<Role> authRole;
+	private IdentifiableStore<Group> authGroup;
 
 	public void openStores(ObjectMapper mapper) {
 		authUser = storageFactory.createUserStore(centralRegistry, "meta", this, mapper);
@@ -66,7 +63,6 @@ public class MetaStorage extends ConqueryStorage implements Injectable {
 				authUser,
 				authRole,
 				authGroup,
-
 				executions,
 				formConfigs
 		);

--- a/backend/src/main/java/com/bakdata/conquery/io/storage/MetaStorage.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/storage/MetaStorage.java
@@ -32,9 +32,10 @@ public class MetaStorage extends ConqueryStorage implements Injectable {
 
 	@Getter
 	protected final CentralRegistry centralRegistry = new CentralRegistry();
+	private final StoreFactory storageFactory;
+
 	@Getter
 	protected final DatasetRegistry datasetRegistry;
-	private final StoreFactory storageFactory;
 	private IdentifiableStore<ManagedExecution> executions;
 	private IdentifiableStore<FormConfig> formConfigs;
 	private IdentifiableStore<User> authUser;

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
@@ -74,7 +74,7 @@ public class LoadingUtil {
 			ConceptQuery query = new ConceptQuery(new CQExternal(Arrays.asList("ID", "DATE_SET"), data, false));
 
 			ManagedExecution managed = support.getNamespace().getExecutionManager()
-											  .createQuery(support.getNamespace(), query, queryId, user, support.getNamespace().getDataset(), false);
+											  .createQuery(query, queryId, user, support.getNamespace().getDataset(), false);
 
 			user.addPermission(managed.createPermission(AbilitySets.QUERY_CREATOR));
 
@@ -91,7 +91,7 @@ public class LoadingUtil {
 			ManagedExecution managed =
 					support.getNamespace()
 						   .getExecutionManager()
-						   .createQuery(support.getNamespace(), query, queryId, user, support.getNamespace().getDataset(), false);
+						   .createQuery(query, queryId, user, support.getNamespace().getDataset(), false);
 
 			user.addPermission(ExecutionPermission.onInstance(AbilitySets.QUERY_CREATOR, managed.getId()));
 


### PR DESCRIPTION
…plementation relies on hashing which breaks results on patch