### PR TITLE
Change HoverNavitgable Timeout from 0.6s to 1s

### DIFF
--- a/frontend/src/js/small-tab-navigation/HoverNavigatable.tsx
+++ b/frontend/src/js/small-tab-navigation/HoverNavigatable.tsx
@@ -33,7 +33,7 @@ const Root = styled("div")<{
 `;
 
 // estimated to feel responsive, but not too quick
-const TIME_UNTIL_NAVIGATE = 600;
+const TIME_UNTIL_NAVIGATE = 1000;
 
 export const HoverNavigatable = ({
   triggerNavigate,


### PR DESCRIPTION
A small remaining change from a ticket from last week. Since the time until Navigate was too fast for some users. 

I originally set the value to what was good for me. But some users might be a bit slower. That might accidentally trigger the navigation on accident