### PR TITLE
Fix SQL tests

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -41,5 +41,4 @@ jobs:
       - name: JSON based Integration Tests
         run: mvn test -T 1C -pl backend -Dgroups="INTEGRATION_JSON"
       - name: SQL based Integration Tests
-        if: ${{ startsWith(github.head_ref, 'sql/') }}
         run: mvn test -T 1C -pl backend -Dgroups="INTEGRATION_SQL_BACKEND"

--- a/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/execution/ManagedExecution.java
@@ -120,7 +120,7 @@ public abstract class ManagedExecution extends IdentifiableImpl<ManagedExecution
 
 	@JsonIgnore
 	@EqualsAndHashCode.Exclude
-	private transient DistributedNamespace namespace;
+	private transient Namespace namespace;
 	@JsonIgnore
 	@EqualsAndHashCode.Exclude
 	private transient ConqueryConfig config;
@@ -161,7 +161,7 @@ public abstract class ManagedExecution extends IdentifiableImpl<ManagedExecution
 				label = makeAutoLabel(new PrintSettings(true, I18n.LOCALE.get(), namespace, config, null));
 			}
 
-			this.namespace = ((DistributedNamespace) namespace);
+			this.namespace = namespace;
 			this.config = config;
 
 			doInitExecutable();

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedInternalForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedInternalForm.java
@@ -28,6 +28,7 @@ import com.bakdata.conquery.models.query.SingleTableResult;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfo;
 import com.bakdata.conquery.models.query.results.EntityResult;
 import com.bakdata.conquery.models.query.results.FormShardResult;
+import com.bakdata.conquery.models.worker.DistributedNamespace;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.OptBoolean;
@@ -204,5 +205,9 @@ public class ManagedInternalForm<F extends Form & InternalForm> extends ManagedF
 		synchronized (this) {
 			return flatSubQueries.values().stream().allMatch(q -> q.getState().equals(ExecutionState.DONE));
 		}
+	}
+
+	public DistributedNamespace getNamespace() {
+		return (DistributedNamespace) super.getNamespace();
 	}
 }

--- a/backend/src/test/java/com/bakdata/conquery/integration/sql/PostgreSqlIntegrationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/sql/PostgreSqlIntegrationTests.java
@@ -1,5 +1,7 @@
 package com.bakdata.conquery.integration.sql;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.stream.Stream;
 
 import com.bakdata.conquery.TestTags;
@@ -8,6 +10,7 @@ import com.bakdata.conquery.integration.IntegrationTests;
 import com.bakdata.conquery.models.config.Dialect;
 import com.bakdata.conquery.models.config.SqlConnectorConfig;
 import com.bakdata.conquery.models.error.ConqueryError;
+import com.bakdata.conquery.models.i18n.I18n;
 import com.bakdata.conquery.sql.DslContextFactory;
 import com.bakdata.conquery.sql.SqlQuery;
 import com.bakdata.conquery.sql.conquery.SqlManagedQuery;
@@ -64,6 +67,8 @@ public class PostgreSqlIntegrationTests extends IntegrationTests {
 	@Test
 	@Tag(TestTags.INTEGRATION_SQL_BACKEND)
 	public void shouldThrowException() {
+		// This can be removed as soon as we switch to a full integration test including the REST API
+		I18n.init();
 		SqlExecutionService executionService = new SqlExecutionService(dslContext);
 		SqlManagedQuery validQuery = new SqlManagedQuery(new ConceptQuery(), null, null, null, new SqlQuery("SELECT 1"));
 		Assertions.assertThatNoException().isThrownBy(() -> executionService.execute(validQuery));
@@ -72,7 +77,7 @@ public class PostgreSqlIntegrationTests extends IntegrationTests {
 		SqlManagedQuery emptyQuery = new SqlManagedQuery(new ConceptQuery(), null, null, null, new SqlQuery(""));
 		Assertions.assertThatThrownBy(() -> executionService.execute(emptyQuery))
 				  .isInstanceOf(ConqueryError.SqlError.class)
-				  .hasMessageContaining("Something went wrong while querying the database: org.postgresql.util.PSQLException");
+				  .hasMessageContaining("Something went wrong while querying the database: $org.postgresql.util.PSQLException");
 	}
 
 


### PR DESCRIPTION
The SQL tests are broken after recent changes to develop. This removes the condition that SQL tests are only run on branches starting with `sql/` because it seems to me like it would be better to have them run for all changes now to avoid such situations.

Additionally, there are the following fixes:

1) Namespace CastClassException 

ManagedExecution is used by both connectors. We therefore cannot cast to `DistributedNamespace` here
because this will lead to a `CastClassException` when using the SQL connector. The cast was introduced in b4bc03774b1a9778c9023382f26f17eab82de184. For the resulting exception, see the following CI run: https://github.com/ingef/conquery/actions/runs/5655732144/job/15321399831.

This pushes the cast down to `ManagedInternalForm`. We could also think about introducing an additional parent class for all ManagedExecution classes except `SqlManagedQuery`, in which the cast is done.

2) I18n Initalization

Because the error messages use the C10n interface (changed in 52a3b9fce91ee9fb0340b90bad0a52fe76829c23), the error message in one of our tests was wrong. This changes the expected error messageand adds the initialization for I18n
