### PR TITLE
Fix Bug where highlighting Breaks with search term ending with a space

### DIFF
--- a/frontend/src/js/tooltip/Tooltip.tsx
+++ b/frontend/src/js/tooltip/Tooltip.tsx
@@ -189,7 +189,6 @@ const Tooltip = () => {
   );
 
   const highlightRegex = useMemo(() => {
-    console.log("words", words);
     return words.length > 0
       ? new RegExp(words.filter((word) => word.length > 0).join("|"), "gi")
       : null;

--- a/frontend/src/js/tooltip/Tooltip.tsx
+++ b/frontend/src/js/tooltip/Tooltip.tsx
@@ -188,10 +188,12 @@ const Tooltip = () => {
     (state) => state.tooltip.toggleAdditionalInfos,
   );
 
-  const highlightRegex = useMemo(
-    () => (words.length > 0 ? new RegExp(words.join("|"), "gi") : null),
-    [words],
-  );
+  const highlightRegex = useMemo(() => {
+    console.log("words", words);
+    return words.length > 0
+      ? new RegExp(words.filter((word) => word.length > 0).join("|"), "gi")
+      : null;
+  }, [words]);
 
   const dispatch = useDispatch();
   const onToggleAdditionalInfos = () => dispatch(toggleInfos());


### PR DESCRIPTION
Unfortunatley the | joining of strings would fail for the regex creation if it terminated into a space, since the array would look like this `["search", ""]` => resulting in a regex `search|`=> creating malformed markdown as a result