### PR TITLE
Reduce ChunkWriter#bufferSize to 2MB from 32MB

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/io/mina/ChunkWriter.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/mina/ChunkWriter.java
@@ -26,7 +26,7 @@ public class ChunkWriter extends ProtocolEncoderAdapter {
 
 	@Getter
 	@Setter
-	private int bufferSize = Ints.checkedCast(Size.megabytes(32).toBytes());
+	private int bufferSize = Ints.checkedCast(Size.megabytes(2).toBytes());
 	private final SoftPool<IoBuffer> bufferPool = new SoftPool<>(() -> IoBuffer.allocate(bufferSize));
 	@SuppressWarnings("rawtypes")
 	private final CQCoder coder;


### PR DESCRIPTION
The avergae GZIPPED Bucket is just 1MB in size. Only Dictionaries are bigger, but they are transmitted far less often, therefore it should be fine to chunk them much finer.