### PR TITLE
Remember dropped filename for imported concepts / filter values

### DIFF
--- a/frontend/src/js/external-forms/form-components/DropzoneList.tsx
+++ b/frontend/src/js/external-forms/form-components/DropzoneList.tsx
@@ -67,7 +67,7 @@ interface PropsT<DroppableObject> {
     monitor: DropTargetMonitor,
   ) => void;
   onDropFile: (file: File) => void;
-  onImportLines: (lines: string[]) => void;
+  onImportLines: (lines: string[], filename?: string) => void;
   dropBetween: (
     i: number,
   ) => (item: PossibleDroppableObject, monitor: DropTargetMonitor) => void;

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
@@ -261,8 +261,8 @@ const FormConceptGroup = (props: Props) => {
         onDropFile={(file) =>
           onDropFile(file, { valueIdx: props.value.length })
         }
-        onImportLines={(lines) =>
-          onImportLines(lines, { valueIdx: props.value.length })
+        onImportLines={(lines, filename) =>
+          onImportLines({ lines, filename }, { valueIdx: props.value.length })
         }
         onDrop={(item: DragItemFile | DragItemConceptTreeNode) => {
           setScrollToDropzone(true);
@@ -376,8 +376,11 @@ const FormConceptGroup = (props: Props) => {
                 ) : (
                   <DropzoneWithFileInput /* TODO: ADD GENERIC TYPE <DragItemConceptTreeNode> */
                     acceptedDropTypes={DROP_TYPES}
-                    onImportLines={(lines) =>
-                      onImportLines(lines, { valueIdx: i, conceptIdx: j })
+                    onImportLines={(lines, filename) =>
+                      onImportLines(
+                        { lines, filename },
+                        { valueIdx: i, conceptIdx: j },
+                      )
                     }
                     onDrop={(item: DragItemConceptTreeNode | DragItemFile) => {
                       if (item.type === "__NATIVE_FILE__") {

--- a/frontend/src/js/external-forms/form-concept-group/useUploadConceptListModal.ts
+++ b/frontend/src/js/external-forms/form-concept-group/useUploadConceptListModal.ts
@@ -75,14 +75,14 @@ export const useUploadConceptListModal = ({
   };
 
   const onImportLines = (
-    lines: string[],
+    { lines, filename }: { lines: string[]; filename?: string },
     { valueIdx, conceptIdx }: UploadConceptListModalContext,
   ) => {
     setModalContext({ valueIdx, conceptIdx });
     dispatch(
       initUploadConceptListModal({
         rows: lines,
-        filename: t("importModal.pasted"),
+        filename: filename || t("importModal.pasted"),
       }),
     );
 

--- a/frontend/src/js/standard-query-editor/Query.tsx
+++ b/frontend/src/js/standard-query-editor/Query.tsx
@@ -61,11 +61,11 @@ const useImport = () => {
   }, []);
 
   const onImportLines = useCallback(
-    (lines: string[], andIdx?: number) => {
+    (lines: string[], filename?: string, andIdx?: number) => {
       dispatch(
         initUploadConceptListModal({
           rows: lines,
-          filename: t("importModal.pasted"),
+          filename: filename || t("importModal.pasted"),
         }),
       );
 

--- a/frontend/src/js/standard-query-editor/QueryEditorDropzone.tsx
+++ b/frontend/src/js/standard-query-editor/QueryEditorDropzone.tsx
@@ -50,7 +50,7 @@ interface Props {
   onDropNode: (node: StandardQueryNodeT) => void;
   onDropFile: (file: File) => void;
   onLoadPreviousQuery: (id: QueryIdT) => void;
-  onImportLines?: (lines: string[]) => void;
+  onImportLines?: (lines: string[], filename?: string) => void;
 }
 
 const QueryEditorDropzone = forwardRef<HTMLDivElement, Props>(

--- a/frontend/src/js/standard-query-editor/QueryGroup.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroup.tsx
@@ -53,7 +53,7 @@ interface PropsT {
   andIdx: number;
   onDropOrNode: (node: StandardQueryNodeT, andIdx: number) => void;
   onDropFile: (file: File, andIdx: number) => void;
-  onImportLines: (lines: string[], andIdx?: number) => void;
+  onImportLines: (lines: string[], filename?: string, andIdx?: number) => void;
   onDeleteNode: (andIdx: number, orIdx: number) => void;
   onEditClick: (andIdx: number, orIdx: number) => void;
   onExpandClick: (q: QueryT) => void;
@@ -106,7 +106,8 @@ const QueryGroup = ({
     [andIdx, onDropFile],
   );
   const importLines = useCallback(
-    (lines: string[]) => onImportLines(lines, andIdx),
+    (lines: string[], filename?: string) =>
+      onImportLines(lines, filename, andIdx),
     [andIdx, onImportLines],
   );
 

--- a/frontend/src/js/ui-components/DropzoneWithFileInput.tsx
+++ b/frontend/src/js/ui-components/DropzoneWithFileInput.tsx
@@ -70,7 +70,7 @@ interface PropsT<DroppableObject> {
 
   showImportButton?: boolean;
   importButtonOutside?: boolean;
-  onImportLines?: (lines: string[]) => void;
+  onImportLines?: (lines: string[], filename?: string) => void;
   importPlaceholder?: string;
   importDescription?: string;
 }
@@ -111,8 +111,8 @@ const DropzoneWithFileInput = <
 
   const [importModalOpen, setImportModalOpen] = useState(false);
 
-  function onSubmitImport(lines: string[]) {
-    onImportLines?.(lines);
+  function onSubmitImport(lines: string[], filename?: string) {
+    onImportLines?.(lines, filename);
   }
 
   function onOpenFileDialog() {

--- a/frontend/src/js/ui-components/ImportModal.tsx
+++ b/frontend/src/js/ui-components/ImportModal.tsx
@@ -69,10 +69,11 @@ export const ImportModal = ({
   description?: string;
   placeholder?: string;
   onClose: () => void;
-  onSubmit: (lines: string[]) => void;
+  onSubmit: (lines: string[], filename?: string) => void;
 }) => {
   const { t } = useTranslation();
   const [textInput, setTextInput] = useState("");
+  const [droppedFilename, setDroppedFilename] = useState<string>();
   const canReadClipboard = useCanReadClipboard();
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -84,7 +85,7 @@ export const ImportModal = ({
 
     const lines = textInput.split("\n").map((line) => line.trim());
 
-    onSubmit(lines);
+    onSubmit(lines, droppedFilename);
     onClose();
   };
 
@@ -114,6 +115,7 @@ export const ImportModal = ({
   const onSelectFile = async (file: File) => {
     const rows = await getUniqueFileRows(file);
 
+    setDroppedFilename(file.name);
     autoFormatAndSet(rows.join("\n"));
   };
 


### PR DESCRIPTION
For editor and form dropzones, remember dropped filename for imported concept / filter values