### PR TITLE
Fix/e2e backend refresh to early

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To run the end-to-end test locally:
 2. From the repo root folder run  `conquery/scripts/run_e2e_all.sh`
 3. Wait until the output: `Node server listening on port: 8000` appears
 4. To install cypress and it's dependencies, run `npm install` from an other terminal in the `conquery/` folder
-5. Then run `npm run cypress open` to start cypress
+5. Then run `npx cypress open` to start cypress
 6. Then chose a test suite and start it.
 
 For further informations on this and other tests, please refer to the

--- a/cypress/integration/backend-admin-ui/test_1_datasets.js
+++ b/cypress/integration/backend-admin-ui/test_1_datasets.js
@@ -14,17 +14,15 @@ context("Admin UI Datasets", () => {
     });
 
     describe("Create a new dataset", () => {
-        before(() => { visitAdminUI('datasets'); });
 
         it("Can create a new dataset", () => {
+            visitAdminUI('datasets');
             cy.get('[data-test-id="entity-name"]').type(testDSLabel);
             cy.get('[data-test-id="entity-id"]').type(testDSID);
             cy.get('[data-test-id="create-dataset-btn"]').click().as('createDataset');
-        });
-
-        it("Can see the new dataset", () => {
             cy.contains(testDSID);
         });
+
     });
 
     describe("Delete a dataset", () => {


### PR DESCRIPTION
Collapses test iterations so the site refresh is not manually by the test (too early) but by the backend. Otherwise the created dataset might not be visible yet.