### PR TITLE
wraps realm in abstract binder

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/config/auth/ApiTokenRealmFactory.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/auth/ApiTokenRealmFactory.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import org.apache.http.util.CharArrayBuffer;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 @CPSType(base = AuthenticationRealmFactory.class, id = "API_TOKEN")
 @Data
@@ -45,8 +46,13 @@ public class ApiTokenRealmFactory implements AuthenticationRealmFactory {
 		managerNode.getAuthController().getAuthenticationFilter().registerTokenExtractor(new ApiTokenExtractor());
 
 		JerseyEnvironment environment = managerNode.getEnvironment().jersey();
-		environment.register(apiTokenRealm);
 
+		environment.register(new AbstractBinder() {
+			@Override
+			protected void configure() {
+				bind(apiTokenRealm).to(ApiTokenRealm.class);
+			}
+		});
 		environment.register(ApiTokenResource.class);
 
 		return apiTokenRealm;


### PR DESCRIPTION
Removes the following warning, wehen the ApiTokenRealm was configured:
```log
WARN  [2023-11-15 14:52:08]     o.g.j.i.i.Providers             A provider com.bakdata.conquery.models.auth.apitoken.ApiTokenRealm registered in SERVER runtime does not implement any provider interfaces applicable in the SERVER runtime. Due to constraint configuration problems the provider com.bakdata.conquery.models.auth.apitoken.ApiTokenRealm will be ignored.
```

However, the ApiTokenRealm was still usable