### PR TITLE
Use builder for Selects

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/types/ResultType.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/types/ResultType.java
@@ -1,6 +1,8 @@
 package com.bakdata.conquery.models.types;
 
 import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -15,6 +17,7 @@ import com.bakdata.conquery.models.common.daterange.CDateRange;
 import com.bakdata.conquery.models.config.LocaleConfig;
 import com.bakdata.conquery.models.events.MajorTypeId;
 import com.bakdata.conquery.models.query.PrintSettings;
+import com.bakdata.conquery.sql.execution.ResultSetProcessor;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Preconditions;
@@ -28,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type")
 @CPSBase
 @Slf4j
-public abstract class ResultType {
+public abstract class ResultType<T> {
 
 	public String printNullable(PrintSettings cfg, Object f) {
 		if (f == null) {
@@ -43,7 +46,13 @@ public abstract class ResultType {
 
 	public abstract String typeInfo();
 
-	public static ResultType resolveResultType(MajorTypeId majorTypeId) {
+	public abstract T getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException;
+
+	protected List<T> getFromResultSetAsList(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+		throw new UnsupportedOperationException("ResultType list of type %s not supported for now.".formatted(getClass().getSimpleName()));
+	}
+
+	public static ResultType<?> resolveResultType(MajorTypeId majorTypeId) {
 		return switch (majorTypeId) {
 			case STRING -> StringT.INSTANCE;
 			case BOOLEAN -> BooleanT.INSTANCE;
@@ -55,7 +64,7 @@ public abstract class ResultType {
 		};
 	}
 
-	abstract static class PrimitiveResultType extends ResultType {
+	abstract static class PrimitiveResultType<T> extends ResultType<T> {
 		@Override
 		public String typeInfo() {
 			return this.getClass().getAnnotation(CPSType.class).id();
@@ -69,7 +78,7 @@ public abstract class ResultType {
 
 	@CPSType(id = "BOOLEAN", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class BooleanT extends PrimitiveResultType {
+	public static class BooleanT extends PrimitiveResultType<Boolean> {
 		@Getter(onMethod_ = @JsonCreator)
 		public static final BooleanT INSTANCE = new BooleanT();
 
@@ -84,12 +93,17 @@ public abstract class ResultType {
 
 			return (Boolean) f ? "1" : "0";
 		}
+
+		@Override
+		public Boolean getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getBoolean(resultSet, columnIndex);
+		}
 	}
 
 
 	@CPSType(id = "INTEGER", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class IntegerT extends PrimitiveResultType {
+	public static class IntegerT extends PrimitiveResultType<Integer> {
 		@Getter(onMethod_ = @JsonCreator)
 		public static final IntegerT INSTANCE = new IntegerT();
 
@@ -100,11 +114,16 @@ public abstract class ResultType {
 			}
 			return f.toString();
 		}
+
+		@Override
+		public Integer getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getInteger(resultSet, columnIndex);
+		}
 	}
 
 	@CPSType(id = "NUMERIC", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class NumericT extends PrimitiveResultType {
+	public static class NumericT extends PrimitiveResultType<Double> {
 		@Getter(onMethod_ = @JsonCreator)
 		public static final NumericT INSTANCE = new NumericT();
 
@@ -115,13 +134,16 @@ public abstract class ResultType {
 			}
 			return f.toString();
 		}
+
+		@Override
+		public Double getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getDouble(resultSet, columnIndex);
+		}
 	}
-
-
 
 	@CPSType(id = "DATE", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class DateT extends PrimitiveResultType {
+	public static class DateT extends PrimitiveResultType<Number> {
 		@Getter(onMethod_ = @JsonCreator)
 		public static final DateT INSTANCE = new DateT();
 
@@ -134,11 +156,14 @@ public abstract class ResultType {
 			return print(number, cfg.getDateFormatter());
 		}
 
+		@Override
+		public Number getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getDate(resultSet, columnIndex);
+		}
+
 		public static String print(Number num, DateTimeFormatter formatter) {
 			return formatter.format(LocalDate.ofEpochDay(num.intValue()));
 		}
-
-
 	}
 
 	/**
@@ -147,7 +172,7 @@ public abstract class ResultType {
 	 */
 	@CPSType(id = "DATE_RANGE", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class DateRangeT extends PrimitiveResultType {
+	public static class DateRangeT extends PrimitiveResultType<List<Integer>> {
 		@Getter(onMethod_ = @JsonCreator)
 		public static final DateRangeT INSTANCE = new DateRangeT();
 
@@ -177,11 +202,21 @@ public abstract class ResultType {
 
 			return minString + cfg.getDateRangeSeparator() + maxString;
 		}
+
+		@Override
+		public List<Integer> getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getDateRange(resultSet, columnIndex);
+		}
+
+		@Override
+		public List<List<Integer>> getFromResultSetAsList(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getDateRangeList(resultSet, columnIndex);
+		}
 	}
 
 	@CPSType(id = "STRING", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class StringT extends PrimitiveResultType {
+	public static class StringT extends PrimitiveResultType<String> {
 		@Getter(onMethod_ = @JsonCreator)
 		public static final StringT INSTANCE = new StringT();
 
@@ -203,13 +238,16 @@ public abstract class ResultType {
 			}
 			return super.print(cfg, valueMapper.apply(f, cfg));
 		}
+
+		@Override
+		public String getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getString(resultSet, columnIndex);
+		}
 	}
-
-
 
 	@CPSType(id = "MONEY", base = ResultType.class)
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class MoneyT extends PrimitiveResultType {
+	public static class MoneyT extends PrimitiveResultType<BigDecimal> {
 
 		@Getter(onMethod_ = @JsonCreator)
 		public static final MoneyT INSTANCE = new MoneyT();
@@ -221,17 +259,23 @@ public abstract class ResultType {
 			}
 			return IntegerT.INSTANCE.print(cfg, f);
 		}
+
+		@Override
+		public BigDecimal getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			return resultSetProcessor.getMoney(resultSet, columnIndex);
+		}
+
 	}
 
 	@CPSType(id = "LIST", base = ResultType.class)
 	@Getter
 	@EqualsAndHashCode(callSuper = false)
-	public static class ListT extends ResultType {
+	public static class ListT<T> extends ResultType<List<T>> {
 		@NonNull
-		private final ResultType elementType;
+		private final ResultType<T> elementType;
 
 		@JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-		public ListT(@NonNull ResultType elementType) {
+		public ListT(@NonNull ResultType<T> elementType) {
 			this.elementType = elementType;
 		}
 
@@ -253,6 +297,15 @@ public abstract class ResultType {
 		@Override
 		public String typeInfo() {
 			return this.getClass().getAnnotation(CPSType.class).id() + "[" + elementType.typeInfo() + "]";
+		}
+
+		@Override
+		public List<T> getFromResultSet(ResultSet resultSet, int columnIndex, ResultSetProcessor resultSetProcessor) throws SQLException {
+			if (elementType instanceof DateRangeT) {
+				return elementType.getFromResultSetAsList(resultSet, columnIndex, resultSetProcessor);
+			}
+			// TODO handle all other list types properly by
+			throw new UnsupportedOperationException("Other result type lists not supported for now.");
 		}
 
 		@Override

--- a/backend/src/main/java/com/bakdata/conquery/sql/SqlContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/SqlContext.java
@@ -1,12 +1,11 @@
 package com.bakdata.conquery.sql;
 
 import com.bakdata.conquery.models.config.SqlConnectorConfig;
-import com.bakdata.conquery.sql.conversion.Context;
 import com.bakdata.conquery.sql.conversion.dialect.SqlDialect;
 import lombok.Value;
 
 @Value
-public class SqlContext implements Context {
+public class SqlContext {
 	SqlConnectorConfig config;
 	SqlDialect sqlDialect;
 }

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/IntermediateTableCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/IntermediateTableCte.java
@@ -24,14 +24,14 @@ class IntermediateTableCte extends DateAggregationCte {
 	@Override
 	protected QueryStep.QueryStepBuilder convertStep(DateAggregationContext context) {
 
-		List<SqlSelect> selects = context.getSqlAggregationAction().getIntermediateTableSelects(
+		List<SqlSelect> intermediateTableSelects = context.getSqlAggregationAction().getIntermediateTableSelects(
 				context.getDateAggregationDates(),
 				context.getCarryThroughSelects()
 		);
-		Selects intermediateTableSelects = new Selects(
-				context.getPrimaryColumn(),
-				selects
-		);
+		Selects selects = Selects.builder()
+								 .primaryColumn(context.getPrimaryColumn())
+								 .sqlSelects(intermediateTableSelects)
+								 .build();
 
 		DateAggregationDates dateAggregationDates = context.getDateAggregationDates();
 		List<Field<Date>> allStarts = dateAggregationDates.allStarts();
@@ -48,7 +48,7 @@ class IntermediateTableCte extends DateAggregationCte {
 		Condition intermediateTableCondition = startIsNull.orNot(startBeforeEnd);
 
 		return QueryStep.builder()
-						.selects(intermediateTableSelects)
+						.selects(selects)
 						.conditions(List.of(intermediateTableCondition));
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/InvertCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/InvertCte.java
@@ -70,11 +70,11 @@ class InvertCte extends DateAggregationCte {
 				functionProvider.toDateField(functionProvider.getMaxDateExpression())
 		).as(DateAggregationCte.RANGE_END);
 
-		return new Selects(
-				coalescedPrimaryColumn,
-				Optional.of(ColumnDateRange.of(rangeStart, rangeEnd)),
-				context.getCarryThroughSelects()
-		);
+		return Selects.builder()
+					  .primaryColumn(coalescedPrimaryColumn)
+					  .validityDate(Optional.of(ColumnDateRange.of(rangeStart, rangeEnd)))
+					  .sqlSelects(context.getCarryThroughSelects())
+					  .build();
 	}
 
 	private TableOnConditionStep<Record> selfJoinWithShiftedRows(Field<Object> leftPrimaryColumn, Field<Object> rightPrimaryColumn, QueryStep rowNumberStep) {

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/NodeNoOverlapCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/NodeNoOverlapCte.java
@@ -58,11 +58,11 @@ class NodeNoOverlapCte extends DateAggregationCte {
 		Field<Date> asRangeEnd = end.as(DateAggregationCte.RANGE_END);
 		Field<Date> asRangeStart = start.as(DateAggregationCte.RANGE_START);
 		String intermediateTableCteName = dateAggregationTables.getPredecessor(getCteStep());
-		Selects nodeNoOverlapSelects = new Selects(
-				context.getPrimaryColumn(),
-				Optional.of(ColumnDateRange.of(asRangeStart, asRangeEnd)),
-				context.getCarryThroughSelects()
-		);
+		Selects nodeNoOverlapSelects = Selects.builder()
+											  .primaryColumn(context.getPrimaryColumn())
+											  .validityDate(Optional.of(ColumnDateRange.of(asRangeStart, asRangeEnd)))
+											  .sqlSelects(context.getCarryThroughSelects())
+											  .build();
 
 		Condition startNotNull = start.isNotNull();
 

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/OverlapCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/OverlapCte.java
@@ -32,11 +32,11 @@ class OverlapCte extends DateAggregationCte {
 				context.getDateAggregationDates(),
 				context.getFunctionProvider()
 		);
-		Selects overlapSelects = new Selects(
-				context.getPrimaryColumn(),
-				Optional.of(overlapValidityDate),
-				context.getCarryThroughSelects()
-		);
+		Selects overlapSelects = Selects.builder()
+										.primaryColumn(context.getPrimaryColumn())
+										.validityDate(Optional.of(overlapValidityDate))
+										.sqlSelects(context.getCarryThroughSelects())
+										.build();
 
 		SqlFunctionProvider functionProvider = context.getFunctionProvider();
 		Condition startBeforeEnd = functionProvider.greatest(allStarts).lessThan(functionProvider.least(allEnds));

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/PostgreSqlDateAggregator.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/PostgreSqlDateAggregator.java
@@ -37,11 +37,11 @@ public class PostgreSqlDateAggregator implements SqlDateAggregator {
 
 		ColumnDateRange aggregatedValidityDate = getAggregatedValidityDate(dateAggregationDates, dateAggregationAction, joinedStepCteName);
 
-		Selects dateAggregationSelects = new Selects(
-				joinedStep.getQualifiedSelects().getPrimaryColumn(),
-				Optional.ofNullable(aggregatedValidityDate),
-				QualifyingUtil.qualify(carryThroughSelects, joinedStepCteName)
-		);
+		Selects dateAggregationSelects = Selects.builder()
+												.primaryColumn(joinedStep.getQualifiedSelects().getPrimaryColumn())
+												.validityDate(Optional.ofNullable(aggregatedValidityDate))
+												.sqlSelects(QualifyingUtil.qualify(carryThroughSelects, joinedStepCteName))
+												.build();
 
 		return QueryStep.builder()
 						.cteName(joinedStepCteName + DATE_AGGREGATION_CTE_NAME)

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/RowNumberCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/aggregation/RowNumberCte.java
@@ -37,11 +37,11 @@ class RowNumberCte extends DateAggregationCte {
 		ArrayList<SqlSelect> selects = new ArrayList<>(context.getCarryThroughSelects());
 		selects.add(new FieldWrapper(rowNumber));
 
-		Selects rowNumberSelects = new Selects(
-				primaryColumn,
-				Optional.of(aggregatedValidityDate),
-				selects
-		);
+		Selects rowNumberSelects = Selects.builder()
+										  .primaryColumn(primaryColumn)
+										  .validityDate(Optional.of(aggregatedValidityDate))
+										  .sqlSelects(selects)
+										  .build();
 
 		return QueryStep.builder()
 						.selects(rowNumberSelects);

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/AggregationFilterCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/AggregationFilterCte.java
@@ -15,11 +15,12 @@ class AggregationFilterCte extends ConceptCte {
 	@Override
 	public QueryStep.QueryStepBuilder convertStep(ConceptCteContext conceptCteContext) {
 
-		Selects aggregationFilterSelects = Selects.qualified(
-				conceptCteContext.getConceptTables().getPredecessor(ConceptCteStep.AGGREGATION_FILTER),
-				conceptCteContext.getPrimaryColumn(),
-				getForAggregationFilterSelects(conceptCteContext)
-		);
+		String predecessorTableName = conceptCteContext.getConceptTables().getPredecessor(cteStep());
+		Selects aggregationFilterSelects = Selects.builder()
+												  .primaryColumn(conceptCteContext.getPrimaryColumn())
+												  .sqlSelects(getForAggregationFilterSelects(conceptCteContext))
+												  .build()
+												  .qualify(predecessorTableName);
 
 		List<Condition> aggregationFilterConditions = conceptCteContext.getFilters().stream()
 																	   .flatMap(conceptFilter -> conceptFilter.getFilters().getGroup().stream())

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/AggregationSelectCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/AggregationSelectCte.java
@@ -17,7 +17,10 @@ class AggregationSelectCte extends ConceptCte {
 																		   .distinct()
 																		   .collect(Collectors.toList());
 
-		Selects aggregationSelectSelects = new Selects(conceptCteContext.getPrimaryColumn(), requiredInAggregationFilterStep);
+		Selects aggregationSelectSelects = Selects.builder()
+												  .primaryColumn(conceptCteContext.getPrimaryColumn())
+												  .sqlSelects(requiredInAggregationFilterStep)
+												  .build();
 
 		return QueryStep.builder()
 						.selects(aggregationSelectSelects)

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/EventFilterCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/EventFilterCte.java
@@ -1,7 +1,6 @@
 package com.bakdata.conquery.sql.conversion.cqelement.concept;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.bakdata.conquery.sql.conversion.model.QueryStep;
 import com.bakdata.conquery.sql.conversion.model.Selects;
@@ -14,12 +13,13 @@ class EventFilterCte extends ConceptCte {
 	@Override
 	public QueryStep.QueryStepBuilder convertStep(ConceptCteContext conceptCteContext) {
 
-		Selects eventFilterSelects = Selects.qualified(
-				conceptCteContext.getConceptTables().getPredecessor(ConceptCteStep.EVENT_FILTER),
-				conceptCteContext.getPrimaryColumn(),
-				conceptCteContext.getValidityDate(),
-				getForAggregationSelectStep(conceptCteContext)
-		);
+		String predecessorTableName = conceptCteContext.getConceptTables().getPredecessor(cteStep());
+		Selects eventFilterSelects = Selects.builder()
+											.primaryColumn(conceptCteContext.getPrimaryColumn())
+											.validityDate(conceptCteContext.getValidityDate())
+											.sqlSelects(getForAggregationSelectStep(conceptCteContext))
+											.build()
+											.qualify(predecessorTableName);
 
 		List<Condition> eventFilterConditions = conceptCteContext.getFilters().stream()
 																 .flatMap(conceptFilter -> conceptFilter.getFilters().getEvent().stream())
@@ -34,8 +34,7 @@ class EventFilterCte extends ConceptCte {
 	private static List<SqlSelect> getForAggregationSelectStep(ConceptCteContext conceptCteContext) {
 		return conceptCteContext.allConceptSelects()
 								.flatMap(sqlSelects -> sqlSelects.getForAggregationSelectStep().stream())
-								.distinct()
-								.collect(Collectors.toList());
+								.toList();
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/FinalConceptCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/FinalConceptCte.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.bakdata.conquery.sql.conversion.cqelement.intervalpacking.IntervalPackingContext;
+import com.bakdata.conquery.sql.conversion.cqelement.intervalpacking.IntervalPackingTables;
 import com.bakdata.conquery.sql.conversion.model.ColumnDateRange;
 import com.bakdata.conquery.sql.conversion.model.LogicalOperation;
 import com.bakdata.conquery.sql.conversion.model.QueryStep;
@@ -25,7 +26,10 @@ class FinalConceptCte extends ConceptCte {
 														.toList();
 
 		if (conceptCteContext.getValidityDate().isEmpty() || conceptCteContext.isExcludedFromDateAggregation()) {
-			Selects finalConceptSelects = new Selects(conceptCteContext.getPrimaryColumn(), Optional.empty(), forFinalStep);
+			Selects finalConceptSelects = Selects.builder()
+												 .primaryColumn(conceptCteContext.getPrimaryColumn())
+												 .sqlSelects(forFinalStep)
+												 .build();
 			return QueryStep.builder()
 							.selects(finalConceptSelects);
 		}
@@ -40,12 +44,17 @@ class FinalConceptCte extends ConceptCte {
 
 	private QueryStep.QueryStepBuilder applyIntervalPacking(List<SqlSelect> forFinalStep, ConceptCteContext conceptCteContext) {
 
-		IntervalPackingContext intervalPackingContext = new IntervalPackingContext(
-				conceptCteContext.getConceptLabel(),
-				conceptCteContext.getPrimaryColumn(),
-				conceptCteContext.getValidityDate().get(),
-				conceptCteContext.getConceptTables()
-		);
+		String conceptLabel = conceptCteContext.getConceptLabel();
+		IntervalPackingTables intervalPackingTables =
+				IntervalPackingTables.forConcept(conceptLabel, conceptCteContext.getConceptTables());
+
+		IntervalPackingContext intervalPackingContext =
+				IntervalPackingContext.builder()
+									  .nodeLabel(conceptLabel)
+									  .primaryColumn(conceptCteContext.getPrimaryColumn())
+									  .validityDate(conceptCteContext.getValidityDate().get())
+									  .intervalPackingTables(intervalPackingTables)
+									  .build();
 
 		QueryStep finalIntervalPackingStep = conceptCteContext.getConversionContext()
 															  .getSqlDialect()
@@ -70,7 +79,11 @@ class FinalConceptCte extends ConceptCte {
 				conceptCteContext.getConversionContext()
 		);
 
-		Selects finalConceptSelects = new Selects(primaryColumn, validityDate, forFinalStep);
+		Selects finalConceptSelects = Selects.builder()
+											 .primaryColumn(primaryColumn)
+											 .validityDate(validityDate)
+											 .sqlSelects(forFinalStep)
+											 .build();
 
 		return QueryStep.builder()
 						.selects(finalConceptSelects)

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/PreprocessingCte.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/concept/PreprocessingCte.java
@@ -15,7 +15,11 @@ class PreprocessingCte extends ConceptCte {
 															.distinct()
 															.toList();
 
-		Selects preprocessingSelects = new Selects(conceptCteContext.getPrimaryColumn(), conceptCteContext.getValidityDate(), forPreprocessing);
+		Selects preprocessingSelects = Selects.builder()
+											  .primaryColumn(conceptCteContext.getPrimaryColumn())
+											  .validityDate(conceptCteContext.getValidityDate())
+											  .sqlSelects(forPreprocessing)
+											  .build();
 
 		return QueryStep.builder()
 						.selects(preprocessingSelects)

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/AnsiSqlIntervalPacker.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/AnsiSqlIntervalPacker.java
@@ -44,14 +44,14 @@ public class AnsiSqlIntervalPacker implements IntervalPacker {
 		ArrayList<SqlSelect> qualifiedSelects = new ArrayList<>(QualifyingUtil.qualify(context.getCarryThroughSelects(), sourceTableName));
 		qualifiedSelects.add(new FieldWrapper(previousEnd));
 
-		Selects previousEndSelects = new Selects(
-				primaryColumn,
-				Optional.of(validityDate),
-				qualifiedSelects
-		);
+		Selects previousEndSelects = Selects.builder()
+											.primaryColumn(primaryColumn)
+											.validityDate(Optional.of(validityDate))
+											.sqlSelects(qualifiedSelects)
+											.build();
 
 		return QueryStep.builder()
-						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingStep.PREVIOUS_END))
+						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingCteStep.PREVIOUS_END))
 						.selects(previousEndSelects)
 						.fromTable(QueryStep.toTableLike(sourceTableName))
 						.predecessors(context.getPredecessor() == null ? Collections.emptyList() : List.of(context.getPredecessor()))
@@ -78,14 +78,14 @@ public class AnsiSqlIntervalPacker implements IntervalPacker {
 		ArrayList<SqlSelect> qualifiedSelects = new ArrayList<>(QualifyingUtil.qualify(context.getCarryThroughSelects(), previousEndCteName));
 		qualifiedSelects.add(new FieldWrapper(rangeIndex));
 
-		Selects rangeIndexSelects = new Selects(
-				primaryColumn,
-				Optional.of(validityDate),
-				qualifiedSelects
-		);
+		Selects rangeIndexSelects = Selects.builder()
+										   .primaryColumn(primaryColumn)
+										   .validityDate(Optional.of(validityDate))
+										   .sqlSelects(qualifiedSelects)
+										   .build();
 
 		return QueryStep.builder()
-						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingStep.RANGE_INDEX))
+						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingCteStep.RANGE_INDEX))
 						.selects(rangeIndexSelects)
 						.fromTable(QueryStep.toTableLike(previousEndCteName))
 						.predecessors(List.of(previousEndStep))
@@ -104,11 +104,11 @@ public class AnsiSqlIntervalPacker implements IntervalPacker {
 		Field<BigDecimal> rangeIndex = DSL.field(DSL.name(rangeIndexCteName, IntervalPacker.RANGE_INDEX_FIELD_NAME), BigDecimal.class);
 
 		List<SqlSelect> qualifiedSelects = QualifyingUtil.qualify(context.getCarryThroughSelects(), rangeIndexCteName);
-		Selects intervalCompleteSelects = new Selects(
-				primaryColumn,
-				Optional.of(ColumnDateRange.of(rangeStart, rangeEnd)),
-				qualifiedSelects
-		);
+		Selects intervalCompleteSelects = Selects.builder()
+												 .primaryColumn(primaryColumn)
+												 .validityDate(Optional.of(ColumnDateRange.of(rangeStart, rangeEnd)))
+												 .sqlSelects(qualifiedSelects)
+												 .build();
 
 		// we group range start and end by range index
 		List<Field<?>> groupBySelects = new ArrayList<>();
@@ -117,7 +117,7 @@ public class AnsiSqlIntervalPacker implements IntervalPacker {
 		qualifiedSelects.stream().map(SqlSelect::select).forEach(groupBySelects::add);
 
 		return QueryStep.builder()
-						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingStep.INTERVAL_COMPLETE))
+						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingCteStep.INTERVAL_COMPLETE))
 						.selects(intervalCompleteSelects)
 						.fromTable(QueryStep.toTableLike(rangeIndexCteName))
 						.predecessors(List.of(rangeIndexStep))

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/IntervalPackingContext.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/IntervalPackingContext.java
@@ -6,55 +6,39 @@ import java.util.List;
 import javax.annotation.CheckForNull;
 
 import com.bakdata.conquery.sql.conversion.Context;
-import com.bakdata.conquery.sql.conversion.cqelement.concept.ConceptCteStep;
 import com.bakdata.conquery.sql.conversion.model.ColumnDateRange;
 import com.bakdata.conquery.sql.conversion.model.QueryStep;
 import com.bakdata.conquery.sql.conversion.model.SqlTables;
 import com.bakdata.conquery.sql.conversion.model.select.SqlSelect;
+import lombok.Builder;
 import lombok.Value;
 import org.jooq.Field;
 
 @Value
+@Builder
 public class IntervalPackingContext implements Context {
 
+	/**
+	 * A unique CTE label which will be suffixed with the interval packing CTE names.
+	 */
 	String nodeLabel;
-	Field<Object> primaryColumn;
-	ColumnDateRange validityDate;
-	QueryStep predecessor;
-	IntervalPackingTables intervalPackingTables;
-	List<SqlSelect> carryThroughSelects;
 
-	public IntervalPackingContext(
-			String conceptLabel,
-			Field<Object> primaryColumn,
-			ColumnDateRange validityDate,
-			SqlTables<ConceptCteStep> conceptTables
-	) {
-		this.nodeLabel = conceptLabel;
-		this.primaryColumn = primaryColumn;
-		this.validityDate = validityDate;
-		this.predecessor = null; // we don't need a predecessor because the interval packing steps will be joined with the other concept steps
-		this.intervalPackingTables = IntervalPackingTables.forConcept(conceptLabel, conceptTables);
-		this.carryThroughSelects = Collections.emptyList();
-	}
+	Field<Object> primaryColumn;
+
+	ColumnDateRange validityDate;
 
 	/**
-	 * @param nodeLabel            A unique CTE label which will be suffixed with the interval packing CTE names.
-	 * @param predeceasingStep        The predeceasing step containing the validity date which should be interval-packed.
-	 * @param carryThroughSelects    The selects you want to carry through all interval packing steps. They won't get touched besides qualifying.
+	 * An optional predecessor of the first interval packing CTE.
 	 */
-	public IntervalPackingContext(
-			String nodeLabel,
-			QueryStep predeceasingStep,
-			List<SqlSelect> carryThroughSelects
-	) {
-		this.nodeLabel = nodeLabel;
-		this.primaryColumn = predeceasingStep.getSelects().getPrimaryColumn();
-		this.validityDate = predeceasingStep.getSelects().getValidityDate().get();
-		this.predecessor = predeceasingStep;
-		this.carryThroughSelects = carryThroughSelects;
-		this.intervalPackingTables = IntervalPackingTables.forGenericQueryStep(nodeLabel, predeceasingStep);
-	}
+	QueryStep predecessor;
+
+	SqlTables<IntervalPackingCteStep> intervalPackingTables;
+
+	/**
+	 * The selects you want to carry through all interval packing steps. They won't get touched besides qualifying.
+	 */
+	@Builder.Default
+	List<SqlSelect> carryThroughSelects = Collections.emptyList();
 
 	@CheckForNull
 	public QueryStep getPredecessor() {

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/IntervalPackingCteStep.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/IntervalPackingCteStep.java
@@ -4,21 +4,21 @@ import com.bakdata.conquery.sql.conversion.model.CteStep;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-enum IntervalPackingStep implements CteStep {
+public enum IntervalPackingCteStep implements CteStep {
 
 	PREVIOUS_END("_previous_end", null),
 	RANGE_INDEX("_range_index", PREVIOUS_END),
 	INTERVAL_COMPLETE("_interval_complete", RANGE_INDEX);
 
 	private final String suffix;
-	private final IntervalPackingStep predecessor;
+	private final IntervalPackingCteStep predecessor;
 
 	public String cteName(String nodeLabel) {
 		return "%s%s".formatted(nodeLabel, this.suffix);
 	}
 
 	@Override
-	public IntervalPackingStep predecessor() {
+	public IntervalPackingCteStep predecessor() {
 		return this.predecessor;
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/IntervalPackingTables.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/IntervalPackingTables.java
@@ -6,11 +6,11 @@ import com.bakdata.conquery.sql.conversion.cqelement.concept.ConceptCteStep;
 import com.bakdata.conquery.sql.conversion.model.QueryStep;
 import com.bakdata.conquery.sql.conversion.model.SqlTables;
 
-class IntervalPackingTables extends SqlTables<IntervalPackingStep> {
+public class IntervalPackingTables extends SqlTables<IntervalPackingCteStep> {
 
-	public static final Set<IntervalPackingStep> REQUIRED_STEPS = Set.of(IntervalPackingStep.values());
+	public static final Set<IntervalPackingCteStep> REQUIRED_STEPS = Set.of(IntervalPackingCteStep.values());
 
-	private IntervalPackingTables(String nodeLabel, Set<IntervalPackingStep> requiredSteps, String rootTableName) {
+	private IntervalPackingTables(String nodeLabel, Set<IntervalPackingCteStep> requiredSteps, String rootTableName) {
 		super(nodeLabel, requiredSteps, rootTableName);
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/PostgreSqlIntervalPacker.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/cqelement/intervalpacking/PostgreSqlIntervalPacker.java
@@ -1,6 +1,5 @@
 package com.bakdata.conquery.sql.conversion.cqelement.intervalpacking;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,14 +31,14 @@ public class PostgreSqlIntervalPacker implements IntervalPacker {
 		ColumnDateRange aggregatedValidityDate = this.functionProvider.aggregated(qualifiedValidityDate)
 																	  .asValidityDateRange(context.getNodeLabel());
 
-		Selects selectsWithAggregatedValidityDate = new Selects(
-				primaryColumn,
-				Optional.of(aggregatedValidityDate),
-				Collections.emptyList()
-		);
+		Selects selectsWithAggregatedValidityDate = Selects.builder()
+														   .primaryColumn(primaryColumn)
+														   .validityDate(Optional.of(aggregatedValidityDate))
+														   .sqlSelects(context.getCarryThroughSelects())
+														   .build();
 
 		return QueryStep.builder()
-						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingStep.INTERVAL_COMPLETE))
+						.cteName(context.getIntervalPackingTables().cteName(IntervalPackingCteStep.INTERVAL_COMPLETE))
 						.selects(selectsWithAggregatedValidityDate)
 						.fromTable(QueryStep.toTableLike(sourceTableName))
 						.groupBy(List.of(primaryColumn))

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/QualifyingUtil.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/QualifyingUtil.java
@@ -3,7 +3,6 @@ package com.bakdata.conquery.sql.conversion.model;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.bakdata.conquery.sql.conversion.model.select.ExtractingSqlSelect;
 import com.bakdata.conquery.sql.conversion.model.select.SqlSelect;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
@@ -16,7 +15,7 @@ public class QualifyingUtil {
 
 	public static List<SqlSelect> qualify(List<SqlSelect> sqlSelects, String qualifier) {
 		return sqlSelects.stream()
-						 .map(sqlSelect -> ExtractingSqlSelect.fromSqlSelect(sqlSelect, qualifier))
+						 .map(sqlSelect -> sqlSelect.createReference(qualifier))
 						 .collect(Collectors.toList());
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/QueryStepJoiner.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/QueryStepJoiner.java
@@ -1,7 +1,6 @@
 package com.bakdata.conquery.sql.conversion.model;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -49,19 +48,32 @@ public class QueryStepJoiner {
 
 		DateAggregationDates dateAggregationDates = DateAggregationDates.forSteps(queriesToJoin);
 		if (dateAggregationAction == DateAggregationAction.BLOCK || dateAggregationDates.dateAggregationImpossible()) {
-			andQueryStep = andQueryStep.selects(new Selects(primaryColumn, mergedSelects));
+			Selects selects = Selects.builder()
+									 .primaryColumn(primaryColumn)
+									 .sqlSelects(mergedSelects)
+									 .build();
+			andQueryStep = andQueryStep.selects(selects);
 			return context.withQuerySteps(List.of(andQueryStep.build()));
 		}
 		// if there is only 1 child node containing a validity date, we just keep it as overall validity date for the joined node
 		else if (dateAggregationDates.getValidityDates().size() == 1) {
 			ColumnDateRange validityDate = dateAggregationDates.getValidityDates().get(0);
-			andQueryStep = andQueryStep.selects(new Selects(primaryColumn, Optional.ofNullable(validityDate), mergedSelects));
+			Selects selects = Selects.builder()
+									 .primaryColumn(primaryColumn)
+									 .validityDate(Optional.ofNullable(validityDate))
+									 .sqlSelects(mergedSelects)
+									 .build();
+			andQueryStep = andQueryStep.selects(selects);
 			return context.withQuerySteps(List.of(andQueryStep.build()));
 		}
 
 		List<SqlSelect> mergedSelectsWithAllValidityDates = new ArrayList<>(mergedSelects);
 		mergedSelectsWithAllValidityDates.addAll(dateAggregationDates.allStartsAndEnds());
-		andQueryStep = andQueryStep.selects(new Selects(primaryColumn, mergedSelectsWithAllValidityDates));
+		Selects selects = Selects.builder()
+								 .primaryColumn(primaryColumn)
+								 .sqlSelects(mergedSelectsWithAllValidityDates)
+								 .build();
+		andQueryStep = andQueryStep.selects(selects);
 
 		SqlDateAggregator sqlDateAggregator = context.getSqlDialect().getDateAggregator();
 		QueryStep mergeIntervalsStep = sqlDateAggregator.apply(

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/QueryStepJoiner.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/QueryStepJoiner.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.sql.conversion.model;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/select/ExtractingSqlSelect.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/select/ExtractingSqlSelect.java
@@ -21,15 +21,6 @@ public class ExtractingSqlSelect<V> implements SqlSelect {
 	@EqualsAndHashCode.Exclude
 	Class<V> columnClass;
 
-	@SuppressWarnings("unchecked")
-	public static <V> ExtractingSqlSelect<V> fromSqlSelect(SqlSelect select, String qualifier) {
-		return (ExtractingSqlSelect<V>) new ExtractingSqlSelect<>(
-				qualifier,
-				select.columnName(),
-				select.aliased().getType()
-		);
-	}
-
 	@Override
 	public Field<V> select() {
 		return DSL.field(DSL.name(table, column), columnClass);

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/select/SqlSelect.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/model/select/SqlSelect.java
@@ -7,13 +7,13 @@ public interface SqlSelect {
 
 	/**
 	 * @return The whole (aliased) SQL expression of this {@link SqlSelect}.
-	 * 	For example, {@code DSL.firstValue(DSL.field(DSL.name("foo", "bar"))).as("foobar")}.
+	 * For example, {@code DSL.firstValue(DSL.field(DSL.name("foo", "bar"))).as("foobar")}.
 	 */
 	Field<?> select();
 
 	/**
 	 * @return Aliased column name that can be used to reference the created select.
-	 *  For example, {@code DSL.field("foobar")}.
+	 * For example, {@code DSL.field("foobar")}.
 	 */
 	Field<?> aliased();
 
@@ -22,5 +22,16 @@ public interface SqlSelect {
 	 * For example, {@code "bar"}.
 	 */
 	String columnName();
+
+	/**
+	 * @return A reference to this {@link SqlSelect} qualified on the given qualifier.
+	 */
+	default ExtractingSqlSelect<?> createReference(String qualifier) {
+		return new ExtractingSqlSelect<>(
+				qualifier,
+				columnName(),
+				aliased().getType()
+		);
+	}
 
 }


### PR DESCRIPTION
@awildturtok Im Prinzip NoOp PR, die `Selects` Klasse nutzt jetzt einen `Builder` statt verschieden Konstruktoren.