### PR TITLE
makes IndexService a singleton, shared between namespaces

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/mode/ManagerProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/ManagerProvider.java
@@ -4,6 +4,7 @@ import javax.validation.Validator;
 
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.models.config.ConqueryConfig;
+import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
@@ -28,11 +29,14 @@ public interface ManagerProvider {
 
 	static <N extends Namespace> DatasetRegistry<N> createDatasetRegistry(NamespaceHandler<N> namespaceHandler, ConqueryConfig config,
 																		  InternalObjectMapperCreator creator) {
+
+		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
 		DatasetRegistry<N> datasetRegistry = new DatasetRegistry<>(
 				config.getCluster().getEntityBucketSize(),
 				config,
 				creator,
-				namespaceHandler
+				namespaceHandler,
+				indexService
 		);
 		MetaStorage storage = new MetaStorage(config.getStorage(), datasetRegistry);
 		datasetRegistry.setMetaStorage(storage);

--- a/backend/src/main/java/com/bakdata/conquery/mode/NamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/NamespaceHandler.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public interface NamespaceHandler<N extends Namespace> {
 
-	N createNamespace(NamespaceStorage storage, MetaStorage metaStorage);
+	N createNamespace(NamespaceStorage storage, MetaStorage metaStorage, IndexService indexService);
 
 	void removeNamespace(DatasetId id, N namespace);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/NamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/NamespaceHandler.java
@@ -29,9 +29,8 @@ public interface NamespaceHandler<N extends Namespace> {
 	/**
 	 * Creates the {@link NamespaceSetupData} that is shared by all {@link Namespace} types.
 	 */
-	static NamespaceSetupData createNamespaceSetup(NamespaceStorage storage, final ConqueryConfig config, final InternalObjectMapperCreator mapperCreator) {
+	static NamespaceSetupData createNamespaceSetup(NamespaceStorage storage, final ConqueryConfig config, final InternalObjectMapperCreator mapperCreator, IndexService indexService) {
 		List<Injectable> injectables = new ArrayList<>();
-		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
 		injectables.add(indexService);
 		ObjectMapper persistenceMapper = mapperCreator.createInternalObjectMapper(View.Persistence.Manager.class);
 		ObjectMapper communicationMapper = mapperCreator.createInternalObjectMapper(View.InternalCommunication.class);

--- a/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterManagerProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterManagerProvider.java
@@ -11,7 +11,6 @@ import com.bakdata.conquery.mode.ManagerProvider;
 import com.bakdata.conquery.mode.NamespaceHandler;
 import com.bakdata.conquery.mode.StorageListener;
 import com.bakdata.conquery.models.config.ConqueryConfig;
-import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.worker.ClusterHealthCheck;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
@@ -27,8 +26,7 @@ public class ClusterManagerProvider implements ManagerProvider {
 		final JobManager jobManager = ManagerProvider.newJobManager(config);
 		final InternalObjectMapperCreator creator = ManagerProvider.newInternalObjectMapperCreator(config, environment.getValidator());
 		final ClusterState clusterState = new ClusterState();
-		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
-		final NamespaceHandler<DistributedNamespace> namespaceHandler = new ClusterNamespaceHandler(clusterState, config, creator, indexService);
+		final NamespaceHandler<DistributedNamespace> namespaceHandler = new ClusterNamespaceHandler(clusterState, config, creator);
 		final DatasetRegistry<DistributedNamespace> datasetRegistry = ManagerProvider.createDatasetRegistry(namespaceHandler, config, creator);
 		creator.init(datasetRegistry);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterManagerProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterManagerProvider.java
@@ -11,6 +11,7 @@ import com.bakdata.conquery.mode.ManagerProvider;
 import com.bakdata.conquery.mode.NamespaceHandler;
 import com.bakdata.conquery.mode.StorageListener;
 import com.bakdata.conquery.models.config.ConqueryConfig;
+import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.worker.ClusterHealthCheck;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
@@ -26,7 +27,8 @@ public class ClusterManagerProvider implements ManagerProvider {
 		final JobManager jobManager = ManagerProvider.newJobManager(config);
 		final InternalObjectMapperCreator creator = ManagerProvider.newInternalObjectMapperCreator(config, environment.getValidator());
 		final ClusterState clusterState = new ClusterState();
-		final NamespaceHandler<DistributedNamespace> namespaceHandler = new ClusterNamespaceHandler(clusterState, config, creator);
+		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
+		final NamespaceHandler<DistributedNamespace> namespaceHandler = new ClusterNamespaceHandler(clusterState, config, creator, indexService);
 		final DatasetRegistry<DistributedNamespace> datasetRegistry = ManagerProvider.createDatasetRegistry(namespaceHandler, config, creator);
 		creator.init(datasetRegistry);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
@@ -3,10 +3,11 @@ package com.bakdata.conquery.mode.cluster;
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.io.storage.NamespaceStorage;
 import com.bakdata.conquery.mode.InternalObjectMapperCreator;
-import com.bakdata.conquery.mode.NamespaceSetupData;
 import com.bakdata.conquery.mode.NamespaceHandler;
+import com.bakdata.conquery.mode.NamespaceSetupData;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
+import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.messages.network.specific.AddWorker;
 import com.bakdata.conquery.models.messages.network.specific.RemoveWorker;
 import com.bakdata.conquery.models.query.DistributedExecutionManager;
@@ -21,9 +22,11 @@ public class ClusterNamespaceHandler implements NamespaceHandler<DistributedName
 	private final ConqueryConfig config;
 	private final InternalObjectMapperCreator mapperCreator;
 
+	private final IndexService indexService;
+
 	@Override
 	public DistributedNamespace createNamespace(NamespaceStorage storage, final MetaStorage metaStorage) {
-		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(storage, config, mapperCreator);
+		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(storage, config, mapperCreator, indexService);
 		DistributedExecutionManager executionManager = new DistributedExecutionManager(metaStorage, clusterState);
 		WorkerHandler workerHandler = new WorkerHandler(namespaceData.getCommunicationMapper(), storage);
 		clusterState.getWorkerHandlers().put(storage.getDataset().getId(), workerHandler);

--- a/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
@@ -22,10 +22,8 @@ public class ClusterNamespaceHandler implements NamespaceHandler<DistributedName
 	private final ConqueryConfig config;
 	private final InternalObjectMapperCreator mapperCreator;
 
-	private final IndexService indexService;
-
 	@Override
-	public DistributedNamespace createNamespace(NamespaceStorage storage, final MetaStorage metaStorage) {
+	public DistributedNamespace createNamespace(NamespaceStorage storage, final MetaStorage metaStorage, IndexService indexService) {
 		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(storage, config, mapperCreator, indexService);
 		DistributedExecutionManager executionManager = new DistributedExecutionManager(metaStorage, clusterState);
 		WorkerHandler workerHandler = new WorkerHandler(namespaceData.getCommunicationMapper(), storage);

--- a/backend/src/main/java/com/bakdata/conquery/mode/local/LocalManagerProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/local/LocalManagerProvider.java
@@ -11,6 +11,7 @@ import com.bakdata.conquery.mode.ManagerProvider;
 import com.bakdata.conquery.mode.NamespaceHandler;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.SqlConnectorConfig;
+import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.LocalNamespace;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
@@ -34,8 +35,8 @@ public class LocalManagerProvider implements ManagerProvider {
 		DSLContext dslContext = DslContextFactory.create(sqlConnectorConfig);
 		SqlDialect sqlDialect = createSqlDialect(sqlConnectorConfig, dslContext);
 		SqlContext sqlContext = new SqlContext(sqlConnectorConfig, sqlDialect);
-
-		NamespaceHandler<LocalNamespace> namespaceHandler = new LocalNamespaceHandler(config, creator, sqlContext);
+		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
+		NamespaceHandler<LocalNamespace> namespaceHandler = new LocalNamespaceHandler(config, creator, sqlContext, indexService);
 		DatasetRegistry<LocalNamespace> datasetRegistry = ManagerProvider.createDatasetRegistry(namespaceHandler, config, creator);
 		creator.init(datasetRegistry);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/local/LocalManagerProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/local/LocalManagerProvider.java
@@ -11,7 +11,6 @@ import com.bakdata.conquery.mode.ManagerProvider;
 import com.bakdata.conquery.mode.NamespaceHandler;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.SqlConnectorConfig;
-import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.LocalNamespace;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
@@ -35,8 +34,7 @@ public class LocalManagerProvider implements ManagerProvider {
 		DSLContext dslContext = DslContextFactory.create(sqlConnectorConfig);
 		SqlDialect sqlDialect = createSqlDialect(sqlConnectorConfig, dslContext);
 		SqlContext sqlContext = new SqlContext(sqlConnectorConfig, sqlDialect);
-		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
-		NamespaceHandler<LocalNamespace> namespaceHandler = new LocalNamespaceHandler(config, creator, sqlContext, indexService);
+		NamespaceHandler<LocalNamespace> namespaceHandler = new LocalNamespaceHandler(config, creator, sqlContext);
 		DatasetRegistry<LocalNamespace> datasetRegistry = ManagerProvider.createDatasetRegistry(namespaceHandler, config, creator);
 		creator.init(datasetRegistry);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
@@ -7,6 +7,7 @@ import com.bakdata.conquery.mode.NamespaceHandler;
 import com.bakdata.conquery.mode.NamespaceSetupData;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
+import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.worker.LocalNamespace;
 import com.bakdata.conquery.sql.SqlContext;
@@ -20,9 +21,11 @@ public class LocalNamespaceHandler implements NamespaceHandler<LocalNamespace> {
 	private final InternalObjectMapperCreator mapperCreator;
 	private final SqlContext sqlContext;
 
+	private final IndexService indexService;
+
 	@Override
 	public LocalNamespace createNamespace(NamespaceStorage namespaceStorage, MetaStorage metaStorage) {
-		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(namespaceStorage, config, mapperCreator);
+		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(namespaceStorage, config, mapperCreator, indexService);
 		ExecutionManager executionManager = new SqlExecutionManager(sqlContext, metaStorage);
 		return new LocalNamespace(
 				namespaceData.getPreprocessMapper(),

--- a/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
@@ -21,10 +21,8 @@ public class LocalNamespaceHandler implements NamespaceHandler<LocalNamespace> {
 	private final InternalObjectMapperCreator mapperCreator;
 	private final SqlContext sqlContext;
 
-	private final IndexService indexService;
-
 	@Override
-	public LocalNamespace createNamespace(NamespaceStorage namespaceStorage, MetaStorage metaStorage) {
+	public LocalNamespace createNamespace(NamespaceStorage namespaceStorage, MetaStorage metaStorage, IndexService indexService) {
 		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(namespaceStorage, config, mapperCreator, indexService);
 		ExecutionManager executionManager = new SqlExecutionManager(sqlContext, metaStorage);
 		return new LocalNamespace(

--- a/backend/src/main/java/com/bakdata/conquery/models/index/IndexService.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/index/IndexService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -154,6 +155,10 @@ public class IndexService implements Injectable {
 
 	public CacheStats getStatistics() {
 		return mappings.stats();
+	}
+
+	public Set<IndexKey<?>> getLoadedIndexes() {
+		return mappings.asMap().keySet();
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/index/IndexService.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/index/IndexService.java
@@ -13,6 +13,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Functions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
 import com.univocity.parsers.common.IterableResult;
 import com.univocity.parsers.common.ParsingContext;
@@ -35,7 +36,7 @@ public class IndexService implements Injectable {
 
 	private final CsvParserSettings csvParserSettings;
 
-	private final LoadingCache<IndexKey<?>, Index<?>> mappings = CacheBuilder.newBuilder().build(new CacheLoader<>() {
+	private final LoadingCache<IndexKey<?>, Index<?>> mappings = CacheBuilder.newBuilder().recordStats().build(new CacheLoader<>() {
 		@Override
 		public Index<?> load(@NotNull IndexKey<?> key) throws Exception {
 			log.info("Started to parse mapping {}", key);
@@ -73,7 +74,7 @@ public class IndexService implements Injectable {
 					catch (IllegalArgumentException e) {
 						log.warn("Skipping mapping '{}'->'{}' in row {}, because there was already a mapping",
 								 internalValue, externalValue, csvParser.getContext().currentLine(),
-								 (Exception) (log.isTraceEnabled() ? e : null)
+								 (Exception) (log.isTraceEnabled() ? e : null) // Cast to Exception to satisfy format-string check
 						);
 					}
 				}
@@ -149,6 +150,10 @@ public class IndexService implements Injectable {
 		catch (ExecutionException e) {
 			throw new IllegalStateException(String.format("Unable to build index from index configuration: %s)", key), e);
 		}
+	}
+
+	public CacheStats getStatistics() {
+		return mappings.stats();
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/index/MapIndexKey.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/index/MapIndexKey.java
@@ -7,7 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @EqualsAndHashCode(callSuper = true)
-@ToString
+@ToString(callSuper = true)
 public class MapIndexKey extends AbstractIndexKey<MapIndex> {
 
 	private final String externalTemplate;

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -23,6 +24,7 @@ import com.bakdata.conquery.models.datasets.PreviewConfig;
 import com.bakdata.conquery.models.identifiable.CentralRegistry;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.mapping.EntityIdMap;
+import com.bakdata.conquery.models.index.IndexKey;
 import com.bakdata.conquery.models.index.IndexService;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -114,6 +116,10 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 
 	public Collection<N> getDatasets() {
 		return datasets.values();
+	}
+
+	public Set<IndexKey<?>> getLoadedIndexes() {
+		return indexService.getLoadedIndexes();
 	}
 
 	public CacheStats getIndexServiceStatistics() {

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
@@ -23,8 +23,10 @@ import com.bakdata.conquery.models.datasets.PreviewConfig;
 import com.bakdata.conquery.models.identifiable.CentralRegistry;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
 import com.bakdata.conquery.models.identifiable.mapping.EntityIdMap;
+import com.bakdata.conquery.models.index.IndexService;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.cache.CacheStats;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -49,6 +51,8 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 	private MetaStorage metaStorage;
 	private final NamespaceHandler<N> namespaceHandler;
 
+	private final IndexService indexService;
+
 
 	public N createNamespace(Dataset dataset, Validator validator) throws IOException {
 		// Prepare empty storage
@@ -66,7 +70,7 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 	}
 
 	public N createNamespace(NamespaceStorage datasetStorage) {
-		final N namespace = namespaceHandler.createNamespace(datasetStorage, metaStorage);
+		final N namespace = namespaceHandler.createNamespace(datasetStorage, metaStorage, indexService);
 		add(namespace);
 		return namespace;
 	}
@@ -112,6 +116,10 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 		return datasets.values();
 	}
 
+	public CacheStats getIndexServiceStatistics() {
+		return indexService.getStatistics();
+	}
+
 	@Override
 	public void close() {
 		for (Namespace namespace : datasets.values()) {
@@ -130,4 +138,7 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 		return super.inject(values).add(DatasetRegistry.class, this);
 	}
 
+	public void resetIndexService() {
+		indexService.evictCache();
+	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/ResourceConstants.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/ResourceConstants.java
@@ -23,6 +23,7 @@ public class ResourceConstants {
 	public static final String GROUPS_PATH_ELEMENT = "groups";
 	public static final String USERS_PATH_ELEMENT = "users";
 	public static final String ROLES_PATH_ELEMENT = "roles";
+	public static final String INDEX_SERVICE_PATH_ELEMENT = "index-service";
 	public static final String AUTH_OVERVIEW_PATH_ELEMENT = "auth-overview";
 	public static final String USER_ID = "userId";
 	public static final String ROLE_ID = "roleId";

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
@@ -36,6 +36,7 @@ import com.bakdata.conquery.resources.admin.ui.AuthOverviewUIResource;
 import com.bakdata.conquery.resources.admin.ui.ConceptsUIResource;
 import com.bakdata.conquery.resources.admin.ui.DatasetsUIResource;
 import com.bakdata.conquery.resources.admin.ui.GroupUIResource;
+import com.bakdata.conquery.resources.admin.ui.IndexServiceUIResource;
 import com.bakdata.conquery.resources.admin.ui.RoleUIResource;
 import com.bakdata.conquery.resources.admin.ui.TablesUIResource;
 import com.bakdata.conquery.resources.admin.ui.UserUIResource;
@@ -166,7 +167,8 @@ public class AdminServlet {
 				.register(TablesUIResource.class)
 				.register(ConceptsUIResource.class)
 				.register(ConnectorUIResource.class)
-				.register(AuthOverviewUIResource.class);
+				.register(AuthOverviewUIResource.class)
+				.register(IndexServiceUIResource.class);
 
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -32,6 +32,7 @@ import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.util.ConqueryEscape;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.cache.CacheStats;
 import com.google.common.collect.Multimap;
 import com.univocity.parsers.csv.CsvWriter;
 import groovy.lang.GroovyShell;
@@ -302,5 +303,14 @@ public class AdminProcessor {
 		catch (Exception e) {
 			return ExceptionUtils.getStackTrace(e);
 		}
+	}
+
+	public CacheStats getIndexServiceStatistics() {
+		return datasetRegistry.getIndexServiceStatistics();
+	}
+
+	public void resetIndexService() {
+		log.info("Resetting index service");
+		datasetRegistry.resetIndexService();
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -4,6 +4,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ScheduledExecutorService;
@@ -25,6 +26,7 @@ import com.bakdata.conquery.models.auth.permissions.ConqueryPermission;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.exceptions.ValidatorHelper;
+import com.bakdata.conquery.models.index.IndexKey;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.jobs.JobManagerStatus;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
@@ -303,6 +305,10 @@ public class AdminProcessor {
 		catch (Exception e) {
 			return ExceptionUtils.getStackTrace(e);
 		}
+	}
+
+	public Set<IndexKey<?>> getLoadedIndexes() {
+		return datasetRegistry.getLoadedIndexes();
 	}
 
 	public CacheStats getIndexServiceStatistics() {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
@@ -1,5 +1,6 @@
 package com.bakdata.conquery.resources.admin.rest;
 
+import static com.bakdata.conquery.resources.ResourceConstants.INDEX_SERVICE_PATH_ELEMENT;
 import static com.bakdata.conquery.resources.ResourceConstants.JOB_ID;
 
 import java.time.LocalDate;
@@ -136,5 +137,11 @@ public class AdminResource {
 						  }
 					  })
 					  .toArray(FullExecutionStatus[]::new);
+	}
+
+	@POST
+	@Path("/" + INDEX_SERVICE_PATH_ELEMENT + "/reset")
+	public void resetIndexService() {
+		processor.resetIndexService();
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/UIProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/UIProcessor.java
@@ -42,6 +42,7 @@ import com.bakdata.conquery.resources.admin.ui.model.FrontendUserContent;
 import com.bakdata.conquery.resources.admin.ui.model.ImportStatistics;
 import com.bakdata.conquery.resources.admin.ui.model.TableStatistics;
 import com.bakdata.conquery.resources.admin.ui.model.UIContext;
+import com.google.common.cache.CacheStats;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -68,6 +69,10 @@ public class UIProcessor {
 
 	public UIContext getUIContext() {
 		return new UIContext(adminProcessor.getNodeProvider());
+	}
+
+	public CacheStats getIndexServiceStatistics() {
+		return adminProcessor.getIndexServiceStatistics();
 	}
 
 	public FrontendAuthOverview getAuthOverview() {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/UIProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/UIProcessor.java
@@ -32,6 +32,7 @@ import com.bakdata.conquery.models.datasets.concepts.tree.TreeConcept;
 import com.bakdata.conquery.models.dictionary.Dictionary;
 import com.bakdata.conquery.models.events.CBlock;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
+import com.bakdata.conquery.models.index.IndexKey;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.resources.admin.ui.model.FrontendAuthOverview;
@@ -69,6 +70,10 @@ public class UIProcessor {
 
 	public UIContext getUIContext() {
 		return new UIContext(adminProcessor.getNodeProvider());
+	}
+
+	public Set<IndexKey<?>> getLoadedIndexes() {
+		return getAdminProcessor().getLoadedIndexes();
 	}
 
 	public CacheStats getIndexServiceStatistics() {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/AdminUIResource.java
@@ -1,20 +1,17 @@
 package com.bakdata.conquery.resources.admin.ui;
 
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
 import com.bakdata.conquery.resources.admin.rest.UIProcessor;
 import com.bakdata.conquery.resources.admin.ui.model.UIView;
 import io.dropwizard.views.View;
 import lombok.RequiredArgsConstructor;
 
 @Produces(MediaType.TEXT_HTML)
-@Consumes({ExtraMimeTypes.JSON_STRING, ExtraMimeTypes.SMILE_STRING})
 @Path("/")
 @RequiredArgsConstructor(onConstructor_=@Inject)
 public class AdminUIResource {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/IndexServiceUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/IndexServiceUIResource.java
@@ -40,6 +40,4 @@ public class IndexServiceUIResource {
 		private final CacheStats stats;
 		private final Set<IndexKey<?>> indexes;
 	}
-
-	;
 }

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/IndexServiceUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/IndexServiceUIResource.java
@@ -1,0 +1,28 @@
+package com.bakdata.conquery.resources.admin.ui;
+
+import static com.bakdata.conquery.resources.ResourceConstants.INDEX_SERVICE_PATH_ELEMENT;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.bakdata.conquery.resources.admin.rest.UIProcessor;
+import com.bakdata.conquery.resources.admin.ui.model.UIView;
+import io.dropwizard.views.View;
+import lombok.RequiredArgsConstructor;
+
+@Produces(MediaType.TEXT_HTML)
+@Path("/")
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class IndexServiceUIResource {
+
+	private final UIProcessor uiProcessor;
+
+	@GET
+	@Path(INDEX_SERVICE_PATH_ELEMENT)
+	public View getScript() {
+		return new UIView<>("indexService.html.ftl", uiProcessor.getUIContext(), uiProcessor.getIndexServiceStatistics());
+	}
+}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/IndexServiceUIResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/ui/IndexServiceUIResource.java
@@ -2,15 +2,20 @@ package com.bakdata.conquery.resources.admin.ui;
 
 import static com.bakdata.conquery.resources.ResourceConstants.INDEX_SERVICE_PATH_ELEMENT;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.bakdata.conquery.models.index.IndexKey;
 import com.bakdata.conquery.resources.admin.rest.UIProcessor;
 import com.bakdata.conquery.resources.admin.ui.model.UIView;
+import com.google.common.cache.CacheStats;
 import io.dropwizard.views.View;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @Produces(MediaType.TEXT_HTML)
@@ -22,7 +27,19 @@ public class IndexServiceUIResource {
 
 	@GET
 	@Path(INDEX_SERVICE_PATH_ELEMENT)
-	public View getScript() {
-		return new UIView<>("indexService.html.ftl", uiProcessor.getUIContext(), uiProcessor.getIndexServiceStatistics());
+	public View getIndexService() {
+		final IndexServiceUIContent content = new IndexServiceUIContent(uiProcessor.getIndexServiceStatistics(), uiProcessor.getLoadedIndexes());
+		return new UIView<>("indexService.html.ftl", uiProcessor.getUIContext(), content);
 	}
+
+	/**
+	 * Data container for freemarker. Cannot use records yet: <a href="https://issues.apache.org/jira/browse/FREEMARKER-183">record issue</a>
+	 */
+	@Data
+	public static class IndexServiceUIContent {
+		private final CacheStats stats;
+		private final Set<IndexKey<?>> indexes;
+	}
+
+	;
 }

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/dataset.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/dataset.html.ftl
@@ -79,6 +79,7 @@
         type="button"
         class="btn btn-secondary"
         onclick="rest('/admin/datasets/${c.ds.id}/update-matching-stats',{method: 'post'})"
+        data-cy="update-matching-stats"
       >
         Update Matching Stats
       </button>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/datasets.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/datasets.html.ftl
@@ -27,7 +27,7 @@
 
 			<div id="all_datasets" class="mt-1">
 				<h3>All Datasets</h3>
-				<@table.table columns=columns items=c?sort_by("name") link="/admin-ui/datasets/" deleteButton=deleteDatasetButton />
+				<@table.table columns=columns items=c?sort_by("name") link="/admin-ui/datasets/" deleteButton=deleteDatasetButton cypressId="datasets"/>
 			</div>
 
 		</div>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/indexService.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/indexService.html.ftl
@@ -9,13 +9,20 @@
 				<h3>Statistics</h3>
 				<#assign columns=["name", "value" ]>
 					<#assign items=[
-						{"name":"Hit count", "value":c.hitCount()}
-						{"name":"Miss count", "value":c.missCount()},
-						{"name":"Eviction count", "value":c.evictionCount()},
-						{"name":"Load success count", "value":c.loadSuccessCount()},
-						{"name":"Load exception count", "value":c.loadExceptionCount()},
-						{"name":"Total load time", "value":c.totalLoadTime()}
+						{"name":"Hit count", "value":c.getStats().hitCount()}
+						{"name":"Miss count", "value":c.getStats().missCount()},
+						{"name":"Eviction count", "value":c.getStats().evictionCount()},
+						{"name":"Load success count", "value":c.getStats().loadSuccessCount()},
+						{"name":"Load exception count", "value":c.getStats().loadExceptionCount()},
+						{"name":"Total load time", "value":c.getStats().totalLoadTime()}
 						]>
+						<@table.table columns=columns items=items />
+			</div>
+
+			<div id="index-service-indexes" class="mt-1">
+				<h3>Indexes</h3>
+				<#assign columns=["csv", "internalColumn", "externalTemplate" ]>
+					<#assign items=c.getIndexes() >
 						<@table.table columns=columns items=items />
 			</div>
 		</div>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/indexService.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/indexService.html.ftl
@@ -1,0 +1,34 @@
+<#import "templates/template.html.ftl" as layout>
+<#import "templates/table.html.ftl" as table>
+<@layout.layout>
+	<div class="row">
+		<div class="col">
+			<h1>Index Service</h1>
+			<a data-test-id="delete-btn-index" href="" onclick="resetIndexService()" class="btn btn-danger">Reset Index <i class="fas fa-trash-alt" ></i></a>
+			<div id="index-service-stats" class="mt-1">
+				<h3>Statistics</h3>
+				<#assign columns=["name", "value" ]>
+					<#assign items=[
+						{"name":"Hit count", "value":c.hitCount()}
+						{"name":"Miss count", "value":c.missCount()},
+						{"name":"Eviction count", "value":c.evictionCount()},
+						{"name":"Load success count", "value":c.loadSuccessCount()},
+						{"name":"Load exception count", "value":c.loadExceptionCount()},
+						{"name":"Total load time", "value":c.totalLoadTime()}
+						]>
+						<@table.table columns=columns items=items />
+			</div>
+		</div>
+	</div>
+	<script type="application/javascript">
+		function resetIndexService() {
+			event.preventDefault();
+			fetch('/${ctx.staticUriElem.ADMIN_SERVLET_PATH}/${ctx.staticUriElem.INDEX_SERVICE_PATH_ELEMENT}/reset', {
+				method: 'post',
+				credentials: 'same-origin',
+				headers: {'Content-Type': 'application/json'},
+			
+		}).then(function() {location.reload()});
+		}
+	</script>
+</@layout.layout>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/indexService.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/indexService.html.ftl
@@ -16,14 +16,14 @@
 						{"name":"Load exception count", "value":c.getStats().loadExceptionCount()},
 						{"name":"Total load time", "value":c.getStats().totalLoadTime()}
 						]>
-						<@table.table columns=columns items=items />
+						<@table.table columns=columns items=items cypressId="statistics"/>
 			</div>
 
 			<div id="index-service-indexes" class="mt-1">
 				<h3>Indexes</h3>
-				<#assign columns=["csv", "internalColumn", "externalTemplate" ]>
-					<#assign items=c.getIndexes() >
-						<@table.table columns=columns items=items />
+				<#assign columns=["csv", "internalColumn", "externalTemplates" ]>
+					<#assign items=c.getIndexes()?sort_by('csv') >
+						<@table.table columns=columns items=items cypressId="indexes" />
 			</div>
 		</div>
 	</div>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/table.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/table.html.ftl
@@ -1,9 +1,12 @@
 <#import "copyableText.html.ftl" as copyableText>
 
-<#macro table columns items deleteButton="" link="" renderers={}>
+<#macro table columns items deleteButton="" link="" renderers={} cypressId="">
   <div class="row">
     <div class="col m-0 table-responsive">
-      <table class="table table-sm table-striped text-break">
+      <#if cypressId?has_content>
+        <#assign cypressIdAttr="data-cy=\""+cypressId+"\"" >
+      </#if>
+      <table class="table table-sm table-striped text-break" ${(cypressIdAttr!"")?no_esc}>
         <thead class="text-nowrap">
           <tr>
             <#list columns as column>
@@ -48,6 +51,14 @@
                     <#else>
                       <#stop "Expected macro for deleteButton">
                     </#if>
+                  </td>
+                <#elseif item[column]?is_sequence >
+                  <td scope="row">
+                    <ul>
+                      <#list item[column] as data>
+                        <li>${data}</li>
+                      </#list>
+                    </ul>
                   </td>
                 <#else>
                   <td scope="row">${item[column]}</td>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/template.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/template.html.ftl
@@ -34,6 +34,9 @@
 						<a class="nav-link" href="/admin-ui/datasets">Datasets</a>
 					</li>
 					<li class="nav-item">
+						<a class="nav-link" href="/${ctx.staticUriElem.ADMIN_UI_SERVLET_PATH}/${ctx.staticUriElem.INDEX_SERVICE_PATH_ELEMENT}">Index Service</a>
+					</li>
+					<li class="nav-item">
 						<a class="nav-link" href="/admin-ui/jobs">Jobs</a>
 					</li>
 					<li class="nav-item">

--- a/backend/src/test/java/com/bakdata/conquery/api/StoredQueriesProcessorTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/StoredQueriesProcessorTest.java
@@ -60,7 +60,7 @@ public class StoredQueriesProcessorTest {
 	public static final AuthorizationController AUTHORIZATION_CONTROLLER = new AuthorizationController(STORAGE, new DevelopmentAuthorizationConfig());
 
 	public static final ConqueryConfig CONFIG = new ConqueryConfig();
-	private static final DatasetRegistry<DistributedNamespace> datasetRegistry = new DatasetRegistry<>(0, CONFIG, null, null);
+	private static final DatasetRegistry<DistributedNamespace> datasetRegistry = new DatasetRegistry<>(0, CONFIG, null, null, null);
 	private static final QueryProcessor processor = new QueryProcessor(datasetRegistry, STORAGE, CONFIG);
 
 	private static final Dataset DATASET_0 = new Dataset() {{

--- a/backend/src/test/java/com/bakdata/conquery/io/AbstractSerializationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/AbstractSerializationTest.java
@@ -14,6 +14,7 @@ import com.bakdata.conquery.mode.InternalObjectMapperCreator;
 import com.bakdata.conquery.mode.cluster.ClusterNamespaceHandler;
 import com.bakdata.conquery.mode.cluster.ClusterState;
 import com.bakdata.conquery.models.config.ConqueryConfig;
+import com.bakdata.conquery.models.index.IndexService;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.DistributedNamespace;
 import com.bakdata.conquery.util.NonPersistentStoreFactory;
@@ -38,7 +39,9 @@ public abstract class AbstractSerializationTest {
 	@BeforeEach
 	public void before() {
 		InternalObjectMapperCreator creator = new InternalObjectMapperCreator(config, validator);
-		datasetRegistry = new DatasetRegistry<>(0, config, null, new ClusterNamespaceHandler(new ClusterState(), config, creator));
+		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
+		final ClusterNamespaceHandler clusterNamespaceHandler = new ClusterNamespaceHandler(new ClusterState(), config, creator, indexService);
+		datasetRegistry = new DatasetRegistry<>(0, config, null, clusterNamespaceHandler);
 		metaStorage = new MetaStorage(new NonPersistentStoreFactory(), datasetRegistry);
 		datasetRegistry.setMetaStorage(metaStorage);
 		creator.init(datasetRegistry);

--- a/backend/src/test/java/com/bakdata/conquery/io/AbstractSerializationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/AbstractSerializationTest.java
@@ -40,8 +40,8 @@ public abstract class AbstractSerializationTest {
 	public void before() {
 		InternalObjectMapperCreator creator = new InternalObjectMapperCreator(config, validator);
 		final IndexService indexService = new IndexService(config.getCsv().createCsvParserSettings());
-		final ClusterNamespaceHandler clusterNamespaceHandler = new ClusterNamespaceHandler(new ClusterState(), config, creator, indexService);
-		datasetRegistry = new DatasetRegistry<>(0, config, null, clusterNamespaceHandler);
+		final ClusterNamespaceHandler clusterNamespaceHandler = new ClusterNamespaceHandler(new ClusterState(), config, creator);
+		datasetRegistry = new DatasetRegistry<>(0, config, null, clusterNamespaceHandler, indexService);
 		metaStorage = new MetaStorage(new NonPersistentStoreFactory(), datasetRegistry);
 		datasetRegistry.setMetaStorage(metaStorage);
 		creator.init(datasetRegistry);

--- a/backend/src/test/java/com/bakdata/conquery/io/jackson/serializer/IdRefrenceTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/jackson/serializer/IdRefrenceTest.java
@@ -39,7 +39,7 @@ public class IdRefrenceTest {
 		registry.register(dataset);
 		registry.register(table);
 
-		final DatasetRegistry<DistributedNamespace> datasetRegistry = new DatasetRegistry<>(0, null, null, null);
+		final DatasetRegistry<DistributedNamespace> datasetRegistry = new DatasetRegistry<>(0, null, null, null, null);
 
 		final MetaStorage metaStorage = new MetaStorage(new NonPersistentStoreFactory(),datasetRegistry);
 

--- a/backend/src/test/resources/tests/endpoints/adminEndpointInfo.json
+++ b/backend/src/test/resources/tests/endpoints/adminEndpointInfo.json
@@ -215,6 +215,11 @@
     "clazz": "GroupResource"
   },
   {
+    "method": "POST",
+    "path": "/index-service/reset",
+    "clazz": "AdminResource"
+  },
+  {
     "method": "DELETE",
     "path": "/permissions/{ownerId}",
     "clazz": "PermissionResource"

--- a/backend/src/test/resources/tests/endpoints/adminUIEndpointInfo.json
+++ b/backend/src/test/resources/tests/endpoints/adminUIEndpointInfo.json
@@ -88,5 +88,10 @@
     "method": "GET",
     "path": "/auth-overview",
     "clazz": "AuthOverviewUIResource"
+  },
+  {
+    "method": "GET",
+    "path": "/index-service",
+    "clazz": "IndexServiceUIResource"
   }
 ]


### PR DESCRIPTION
Prevents parsing resources for external mappings and filtering multiple times for the same purpose