### PR TITLE
Implement saved queries for SQL connector

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -36,6 +36,7 @@ import com.bakdata.conquery.apiv1.execution.OverviewExecutionStatus;
 import com.bakdata.conquery.apiv1.execution.ResultAsset;
 import com.bakdata.conquery.apiv1.query.CQElement;
 import com.bakdata.conquery.apiv1.query.ConceptQuery;
+import com.bakdata.conquery.apiv1.query.EditorQuery;
 import com.bakdata.conquery.apiv1.query.ExternalUpload;
 import com.bakdata.conquery.apiv1.query.ExternalUploadResult;
 import com.bakdata.conquery.apiv1.query.Query;
@@ -168,11 +169,11 @@ public class QueryProcessor {
 	 */
 	private static boolean canFrontendRender(ManagedExecution q) {
 		//TODO FK: should this be used to fill into canExpand instead of hiding the Executions?
-		if (!(q instanceof ManagedQuery)) {
+		if (!(q instanceof EditorQuery)) {
 			return false;
 		}
 
-		final Query query = ((ManagedQuery) q).getQuery();
+		final Query query = ((EditorQuery) q).getQuery();
 
 		if (query instanceof ConceptQuery) {
 			return isFrontendStructure(((ConceptQuery) query).getRoot());

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/query/EditorQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/query/EditorQuery.java
@@ -1,0 +1,28 @@
+package com.bakdata.conquery.apiv1.query;
+
+import com.bakdata.conquery.apiv1.execution.ExecutionStatus;
+import com.bakdata.conquery.io.cps.CPSType;
+import com.bakdata.conquery.models.query.ManagedQuery;
+import com.bakdata.conquery.sql.conquery.SqlManagedQuery;
+
+/**
+ * Common abstraction for intersecting parts of {@link ManagedQuery} and {@link SqlManagedQuery}.
+ */
+public interface EditorQuery {
+
+	Query getQuery();
+
+	Long getLastResultCount();
+
+	default void enrichStatusBase(ExecutionStatus status) {
+		status.setNumberOfResults(getLastResultCount());
+
+		Query query = getQuery();
+		status.setQueryType(query.getClass().getAnnotation(CPSType.class).id());
+
+		if (query instanceof SecondaryIdQuery) {
+			status.setSecondaryId(((SecondaryIdQuery) query).getSecondaryId().getId());
+		}
+	}
+
+}

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/query/concept/specific/CQReusedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/query/concept/specific/CQReusedQuery.java
@@ -8,12 +8,12 @@ import javax.annotation.Nullable;
 import javax.validation.Valid;
 
 import com.bakdata.conquery.apiv1.query.CQElement;
+import com.bakdata.conquery.apiv1.query.EditorQuery;
 import com.bakdata.conquery.apiv1.query.Query;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.View;
 import com.bakdata.conquery.models.error.ConqueryError;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
-import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.QueryExecutionContext;
 import com.bakdata.conquery.models.query.QueryPlanContext;
 import com.bakdata.conquery.models.query.QueryResolveContext;
@@ -48,7 +48,7 @@ public class CQReusedQuery extends CQElement {
 	private ManagedExecutionId queryId;
 
 	@JsonIgnore
-	private ManagedQuery query;
+	private EditorQuery query;
 
 	@JsonView(View.InternalCommunication.class)
 	private Query resolvedQuery;
@@ -74,14 +74,11 @@ public class CQReusedQuery extends CQElement {
 
 	@Override
 	public void resolve(QueryResolveContext context) {
-		query = ((ManagedQuery) context.getStorage().getExecution(queryId));
-
-		if(query == null){
+		query = (EditorQuery) context.getStorage().getExecution(queryId);
+		if (query == null) {
 			throw new ConqueryError.ExecutionCreationResolveError(queryId);
 		}
-
 		resolvedQuery = query.getQuery();
-
 		// Yey recursion, because the query might consist of another CQReusedQuery or CQExternal
 		resolvedQuery.resolve(context);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -9,9 +9,9 @@ import java.util.stream.Stream;
 
 import com.bakdata.conquery.apiv1.execution.ExecutionStatus;
 import com.bakdata.conquery.apiv1.execution.FullExecutionStatus;
+import com.bakdata.conquery.apiv1.query.EditorQuery;
 import com.bakdata.conquery.apiv1.query.Query;
 import com.bakdata.conquery.apiv1.query.QueryDescription;
-import com.bakdata.conquery.apiv1.query.SecondaryIdQuery;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQConcept;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQReusedQuery;
 import com.bakdata.conquery.apiv1.query.concept.specific.external.CQExternal;
@@ -47,7 +47,7 @@ import lombok.extern.slf4j.Slf4j;
 @ToString(callSuper = true)
 @Slf4j
 @CPSType(base = ManagedExecution.class, id = "MANAGED_QUERY")
-public class ManagedQuery extends ManagedExecution implements SingleTableResult, InternalExecution<ShardResult> {
+public class ManagedQuery extends ManagedExecution implements EditorQuery, SingleTableResult, InternalExecution<ShardResult> {
 
 	// Needs to be resolved externally before being executed
 	private Query query;
@@ -126,13 +126,7 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 	@Override
 	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status) {
 		super.setStatusBase(subject, status);
-		status.setNumberOfResults(lastResultCount);
-
-		status.setQueryType(query.getClass().getAnnotation(CPSType.class).id());
-
-		if (query instanceof SecondaryIdQuery) {
-			status.setSecondaryId(((SecondaryIdQuery) query).getSecondaryId().getId());
-		}
+		enrichStatusBase(status);
 	}
 
 	protected void setAdditionalFieldsForStatusWithColumnDescription(Subject subject, FullExecutionStatus status) {

--- a/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlManagedQuery.java
@@ -4,10 +4,13 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import com.bakdata.conquery.apiv1.execution.ExecutionStatus;
+import com.bakdata.conquery.apiv1.query.EditorQuery;
 import com.bakdata.conquery.apiv1.query.Query;
 import com.bakdata.conquery.apiv1.query.QueryDescription;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.storage.MetaStorage;
+import com.bakdata.conquery.models.auth.entities.Subject;
 import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ExecutionState;
@@ -22,12 +25,13 @@ import com.bakdata.conquery.sql.conversion.model.SqlQuery;
 import com.bakdata.conquery.sql.execution.SqlExecutionResult;
 import com.bakdata.conquery.util.QueryUtils;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 @Setter
 @Getter
 @CPSType(base = ManagedExecution.class, id = "SQL_QUERY")
-public class SqlManagedQuery extends ManagedExecution implements SingleTableResult {
+public class SqlManagedQuery extends ManagedExecution implements EditorQuery, SingleTableResult {
 
 	private Query query;
 	private SqlQuery sqlQuery;
@@ -82,6 +86,12 @@ public class SqlManagedQuery extends ManagedExecution implements SingleTableResu
 	@Override
 	public long resultRowCount() {
 		return result.getRowCount();
+	}
+
+	@Override
+	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status) {
+		super.setStatusBase(subject, status);
+		enrichStatusBase(status);
 	}
 
 	public void finish(final SqlExecutionResult result) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/AbstractQueryEngineTest.java
@@ -14,6 +14,7 @@ import javax.validation.UnexpectedTypeException;
 import javax.ws.rs.core.Response;
 
 import com.bakdata.conquery.apiv1.AdditionalMediaTypes;
+import com.bakdata.conquery.apiv1.query.EditorQuery;
 import com.bakdata.conquery.apiv1.query.Query;
 import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.common.ResourceFile;
@@ -21,14 +22,12 @@ import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
-import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.SingleTableResult;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfo;
 import com.bakdata.conquery.models.query.results.EntityResult;
 import com.bakdata.conquery.models.query.results.MultilineEntityResult;
 import com.bakdata.conquery.resources.api.ResultCsvResource;
 import com.bakdata.conquery.resources.hierarchies.HierarchyHelper;
-import com.bakdata.conquery.sql.conquery.SqlManagedQuery;
 import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.powerlibraries.io.In;
@@ -89,15 +88,11 @@ public abstract class AbstractQueryEngineTest extends ConqueryTestSpec {
 		// check that getLastResultCount returns the correct size
 		if (executionResult.streamResults().noneMatch(MultilineEntityResult.class::isInstance)) {
 			long lastResultCount;
-			// TODO find common abstraction for Sql/ManagedQuery
-			if (executionResult instanceof ManagedQuery managedQuery) {
-				lastResultCount = managedQuery.getLastResultCount();
-			}
-			else if (executionResult instanceof SqlManagedQuery sqlManagedQuery) {
-				lastResultCount = sqlManagedQuery.getLastResultCount();
+			if (executionResult instanceof EditorQuery editorQuery) {
+				lastResultCount = editorQuery.getLastResultCount();
 			}
 			else {
-				throw new UnexpectedTypeException("Did not expect a ManagedExecution of type %s.".formatted(execution.getClass()));
+				throw new UnexpectedTypeException("Did expect an EditorQuery, but got element of type %s.".formatted(execution.getClass()));
 			}
 			assertThat(lastResultCount).as("Result count for %s is not as expected.", this).isEqualTo(expected.size() - 1);
 		}

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/SqlTestDataImporter.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/SqlTestDataImporter.java
@@ -1,19 +1,24 @@
 package com.bakdata.conquery.integration.json;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 import com.bakdata.conquery.integration.common.RequiredData;
+import com.bakdata.conquery.integration.common.RequiredSecondaryId;
 import com.bakdata.conquery.integration.common.RequiredTable;
 import com.bakdata.conquery.integration.json.filter.FilterTest;
 import com.bakdata.conquery.integration.sql.CsvTableImporter;
+import com.bakdata.conquery.models.datasets.SecondaryIdDescription;
 import com.bakdata.conquery.models.datasets.Table;
 import com.bakdata.conquery.models.datasets.concepts.Concept;
 import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class SqlTestDataImporter implements TestDataImporter {
 
@@ -22,11 +27,9 @@ public class SqlTestDataImporter implements TestDataImporter {
 	@Override
 	public void importQueryTestData(StandaloneSupport support, QueryTest test) throws Exception {
 		RequiredData content = test.getContent();
-		importTables(support, content);
+		importTables(support, content.getTables(), true);
 		importConcepts(support, test.getRawConcepts());
-		for (RequiredTable table : content.getTables()) {
-			csvTableImporter.importTableIntoDatabase(table);
-		}
+		importTableContents(support, content.getTables());
 	}
 
 	@Override
@@ -39,18 +42,37 @@ public class SqlTestDataImporter implements TestDataImporter {
 		throw new UnsupportedOperationException("Not implemented yet.");
 	}
 
-	private void importTables(StandaloneSupport support, RequiredData content) {
-		for (RequiredTable rTable : content.getTables()) {
-			final Table table = rTable.toTable(support.getDataset(), support.getNamespaceStorage().getCentralRegistry());
+	@Override
+	public void importSecondaryIds(StandaloneSupport support, List<RequiredSecondaryId> secondaryIds) {
+		for (RequiredSecondaryId required : secondaryIds) {
+			final SecondaryIdDescription description =
+					required.toSecondaryId(support.getDataset(), support.getDatasetRegistry().findRegistry(support.getDataset().getId()));
+			support.getDatasetsProcessor().addSecondaryId(support.getNamespace(), description);
+		}
+	}
+
+	@Override
+	public void importTables(StandaloneSupport support, List<RequiredTable> tables, boolean autoConcept) throws JSONException {
+		for (RequiredTable requiredTable : tables) {
+			final Table table = requiredTable.toTable(support.getDataset(), support.getNamespaceStorage().getCentralRegistry());
 			support.getNamespaceStorage().addTable(table);
 		}
 	}
 
-	private void importConcepts(StandaloneSupport support, ArrayNode rawConcepts) throws IOException, JSONException {
+	@Override
+	public void importConcepts(StandaloneSupport support, ArrayNode rawConcepts) throws JSONException, IOException {
 		List<Concept<?>> concepts =
 				ConqueryTestSpec.parseSubTreeList(support, rawConcepts, Concept.class, concept -> concept.setDataset(support.getDataset()));
 		for (Concept<?> concept : concepts) {
 			support.getNamespaceStorage().updateConcept(concept);
 		}
 	}
+
+	@Override
+	public void importTableContents(StandaloneSupport support, Collection<RequiredTable> tables) throws Exception {
+		for (RequiredTable table : tables) {
+			csvTableImporter.importTableIntoDatabase(table);
+		}
+	}
+
 }

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/TestDataImporter.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/TestDataImporter.java
@@ -1,7 +1,15 @@
 package com.bakdata.conquery.integration.json;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import com.bakdata.conquery.integration.common.RequiredSecondaryId;
+import com.bakdata.conquery.integration.common.RequiredTable;
 import com.bakdata.conquery.integration.json.filter.FilterTest;
+import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.util.support.StandaloneSupport;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 public interface TestDataImporter {
 
@@ -10,6 +18,14 @@ public interface TestDataImporter {
 	void importFormTestData(StandaloneSupport support, FormTest formTest) throws Exception;
 
 	void importFilterTestData(StandaloneSupport support, FilterTest filterTest) throws Exception;
+
+	void importSecondaryIds(StandaloneSupport support, List<RequiredSecondaryId> secondaryIds);
+
+	void importTables(StandaloneSupport support, List<RequiredTable> tables, boolean autoConcept) throws JSONException;
+
+	void importConcepts(StandaloneSupport support, ArrayNode rawConcepts) throws JSONException, IOException;
+
+	void importTableContents(StandaloneSupport support, Collection<RequiredTable> tables) throws Exception;
 
 	@FunctionalInterface
 	interface CheckedRunnable<E extends Exception> extends Runnable {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/WorkerTestDataImporter.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/WorkerTestDataImporter.java
@@ -1,15 +1,23 @@
 package com.bakdata.conquery.integration.json;
 
-import static com.bakdata.conquery.integration.common.LoadingUtil.*;
+import static com.bakdata.conquery.integration.common.LoadingUtil.importInternToExternMappers;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
+import com.bakdata.conquery.integration.common.LoadingUtil;
 import com.bakdata.conquery.integration.common.RequiredData;
+import com.bakdata.conquery.integration.common.RequiredSecondaryId;
+import com.bakdata.conquery.integration.common.RequiredTable;
 import com.bakdata.conquery.integration.json.filter.FilterTest;
 import com.bakdata.conquery.models.datasets.concepts.tree.ConceptTreeConnector;
+import com.bakdata.conquery.models.exceptions.JSONException;
 import com.bakdata.conquery.models.messages.namespaces.specific.UpdateMatchingStatsMessage;
 import com.bakdata.conquery.models.worker.DistributedNamespace;
 import com.bakdata.conquery.util.support.StandaloneSupport;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 public class WorkerTestDataImporter implements TestDataImporter {
 
@@ -21,13 +29,13 @@ public class WorkerTestDataImporter implements TestDataImporter {
 		importSecondaryIds(support, content.getSecondaryIds());
 		importInternToExternMappers(support, test.getInternToExternMappings());
 
-		waitUntilDone(support, () -> importSearchIndexes(support, test.getSearchIndexes()));
-		waitUntilDone(support, () -> importTables(support, content.getTables(), content.isAutoConcept()));
-		waitUntilDone(support, () -> importConcepts(support, test.getRawConcepts()));
-		waitUntilDone(support, () -> importTableContents(support, content.getTables()));
-		waitUntilDone(support, () -> importIdMapping(support, content));
-		waitUntilDone(support, () -> importPreviousQueries(support, content, support.getTestUser()));
-		waitUntilDone(support, () -> updateMatchingStats(support));
+		waitUntilDone(support, () -> LoadingUtil.importSearchIndexes(support, test.getSearchIndexes()));
+		waitUntilDone(support, () -> LoadingUtil.importTables(support, content.getTables(), content.isAutoConcept()));
+		waitUntilDone(support, () -> LoadingUtil.importConcepts(support, test.getRawConcepts()));
+		waitUntilDone(support, () -> LoadingUtil.importTableContents(support, content.getTables()));
+		waitUntilDone(support, () -> LoadingUtil.importIdMapping(support, content));
+		waitUntilDone(support, () -> LoadingUtil.importPreviousQueries(support, content, support.getTestUser()));
+		waitUntilDone(support, () -> LoadingUtil.updateMatchingStats(support));
 
 		sendUpdateMatchingStatsMessage(support);
 	}
@@ -37,12 +45,12 @@ public class WorkerTestDataImporter implements TestDataImporter {
 
 		RequiredData content = test.getContent();
 
-		waitUntilDone(support, () -> importSecondaryIds(support, content.getSecondaryIds()));
-		waitUntilDone(support, () -> importTables(support, content.getTables(), content.isAutoConcept()));
-		waitUntilDone(support, () -> importConcepts(support, test.getRawConcepts()));
-		waitUntilDone(support, () -> importTableContents(support, content.getTables()));
-		waitUntilDone(support, () -> importIdMapping(support, content));
-		waitUntilDone(support, () -> importPreviousQueries(support, content, support.getTestUser()));
+		waitUntilDone(support, () -> LoadingUtil.importSecondaryIds(support, content.getSecondaryIds()));
+		waitUntilDone(support, () -> LoadingUtil.importTables(support, content.getTables(), content.isAutoConcept()));
+		waitUntilDone(support, () -> LoadingUtil.importConcepts(support, test.getRawConcepts()));
+		waitUntilDone(support, () -> LoadingUtil.importTableContents(support, content.getTables()));
+		waitUntilDone(support, () -> LoadingUtil.importIdMapping(support, content));
+		waitUntilDone(support, () -> LoadingUtil.importPreviousQueries(support, content, support.getTestUser()));
 	}
 
 	@Override
@@ -50,9 +58,9 @@ public class WorkerTestDataImporter implements TestDataImporter {
 
 		RequiredData content = test.getContent();
 
-		importInternToExternMappers(support, test.getInternToExternMappings());
-		importSearchIndexes(support, test.getSearchIndices());
-		waitUntilDone(support, () -> importTables(support, content.getTables(), content.isAutoConcept()));
+		LoadingUtil.importInternToExternMappers(support, test.getInternToExternMappings());
+		LoadingUtil.importSearchIndexes(support, test.getSearchIndices());
+		waitUntilDone(support, () -> LoadingUtil.importTables(support, content.getTables(), content.isAutoConcept()));
 
 		test.setConnector(ConqueryTestSpec.parseSubTree(
 								  support,
@@ -63,9 +71,29 @@ public class WorkerTestDataImporter implements TestDataImporter {
 		);
 		test.getConcept().setConnectors(Collections.singletonList((ConceptTreeConnector) test.getConnector()));
 
-		waitUntilDone(support, () -> uploadConcept(support, support.getDataset(), test.getConcept()));
-		waitUntilDone(support, () -> importTableContents(support, content.getTables()));
-		waitUntilDone(support, () -> updateMatchingStats(support));
+		waitUntilDone(support, () -> LoadingUtil.uploadConcept(support, support.getDataset(), test.getConcept()));
+		waitUntilDone(support, () -> LoadingUtil.importTableContents(support, content.getTables()));
+		waitUntilDone(support, () -> LoadingUtil.updateMatchingStats(support));
+	}
+
+	@Override
+	public void importSecondaryIds(StandaloneSupport support, List<RequiredSecondaryId> secondaryIds) {
+		waitUntilDone(support, () -> LoadingUtil.importSecondaryIds(support, secondaryIds));
+	}
+
+	@Override
+	public void importTables(StandaloneSupport support, List<RequiredTable> tables, boolean autoConcept) throws JSONException {
+		waitUntilDone(support, () -> LoadingUtil.importTables(support, tables, autoConcept));
+	}
+
+	@Override
+	public void importConcepts(StandaloneSupport support, ArrayNode rawConcepts) throws JSONException, IOException {
+		waitUntilDone(support, () -> LoadingUtil.importConcepts(support, rawConcepts));
+	}
+
+	@Override
+	public void importTableContents(StandaloneSupport support, Collection<RequiredTable> tables) throws Exception {
+		waitUntilDone(support, () -> LoadingUtil.importTableContents(support, tables));
 	}
 
 	private void waitUntilDone(StandaloneSupport support, CheckedRunnable<?> runnable) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/sql/programmatic/SqlReusedQueryTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/sql/programmatic/SqlReusedQueryTest.java
@@ -1,0 +1,93 @@
+package com.bakdata.conquery.integration.sql.programmatic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+
+import com.bakdata.conquery.apiv1.execution.FullExecutionStatus;
+import com.bakdata.conquery.apiv1.query.ConceptQuery;
+import com.bakdata.conquery.apiv1.query.Query;
+import com.bakdata.conquery.apiv1.query.concept.specific.CQReusedQuery;
+import com.bakdata.conquery.integration.common.IntegrationUtils;
+import com.bakdata.conquery.integration.json.JsonIntegrationTest;
+import com.bakdata.conquery.integration.json.QueryTest;
+import com.bakdata.conquery.integration.tests.ProgrammaticIntegrationTest;
+import com.bakdata.conquery.integration.tests.ReusedQueryTest;
+import com.bakdata.conquery.io.storage.MetaStorage;
+import com.bakdata.conquery.models.datasets.Dataset;
+import com.bakdata.conquery.models.execution.ExecutionState;
+import com.bakdata.conquery.models.execution.ManagedExecution;
+import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
+import com.bakdata.conquery.resources.ResourceConstants;
+import com.bakdata.conquery.resources.api.QueryResource;
+import com.bakdata.conquery.resources.hierarchies.HierarchyHelper;
+import com.bakdata.conquery.util.support.StandaloneSupport;
+import com.bakdata.conquery.util.support.TestConquery;
+import com.github.powerlibraries.io.In;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This test duplicates parts of the {@link com.bakdata.conquery.integration.tests.ReusedQueryTest}, which itself is not SQL-ready yet, because it uses
+ * secondary ID's in its test. As soon as the SQL connector supports secondary ID's, this test can be removed.
+ */
+@Slf4j
+public class SqlReusedQueryTest implements ProgrammaticIntegrationTest {
+
+	@Override
+	public Set<StandaloneSupport.Mode> forModes() {
+		return Set.of(StandaloneSupport.Mode.SQL);
+	}
+
+	@Override
+	public void execute(String name, TestConquery testConquery) throws Exception {
+
+		final StandaloneSupport conquery = testConquery.getSupport(name);
+
+		final String testJson = In.resource("/tests/sql/filter/count_distinct/count_distinct.json").withUTF8().readAll();
+
+		final Dataset dataset = conquery.getDataset();
+		final QueryTest test = JsonIntegrationTest.readJson(dataset, testJson);
+
+		ReusedQueryTest.importManually(conquery, test);
+
+		final Query query = IntegrationUtils.parseQuery(conquery, test.getRawQuery());
+		final ManagedExecutionId id = IntegrationUtils.assertQueryResult(conquery, query, 2L, ExecutionState.DONE, conquery.getTestUser(), 201);
+
+		assertThat(id).isNotNull();
+
+		final MetaStorage metaStorage = conquery.getMetaStorage();
+		final ManagedExecution execution = metaStorage.getExecution(id);
+
+		// Normal reuse
+		{
+
+			final ConceptQuery reused = new ConceptQuery(new CQReusedQuery(execution.getId()));
+
+			IntegrationUtils.assertQueryResult(conquery, reused, 2L, ExecutionState.DONE, conquery.getTestUser(), 201);
+		}
+
+		// Reuse by API
+		{
+			final URI reexecuteUri =
+					HierarchyHelper.hierarchicalPath(conquery.defaultApiURIBuilder(), QueryResource.class, "reexecute")
+								   .buildFromMap(Map.of(
+										   ResourceConstants.DATASET, conquery.getDataset().getName(),
+										   ResourceConstants.QUERY, execution.getId().toString()
+								   ));
+
+			final FullExecutionStatus status = conquery.getClient().target(reexecuteUri)
+													   .request(MediaType.APPLICATION_JSON)
+													   .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE))
+													   .readEntity(FullExecutionStatus.class);
+
+			assertThat(status.getStatus()).isIn(ExecutionState.RUNNING, ExecutionState.DONE);
+
+		}
+	}
+
+}


### PR DESCRIPTION
@awildturtok @thoniTUB Nachdem ich auf die dritte Stelle gestoßen bin, an der es notwendig gewesen wäre, entweder auf eine `ManagedQuery` oder eine `SqlManagedQuery` zu casten, hatten wir das Gefühl, dass es jetzt notwendig ist, eine gemeinsame Abstraktion zwischen einer `ManagedQuery` und einer `SqlManagedQuery` einzuführen.
Allerdings sind wir uns unsicher, ob diese Abstraktion der `EditorQuery` passt und wollten das nochmal zur Diskussion stellen 😄 