### PR TITLE
adds endpoint for form backend version info

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/frontend/FrontendConfiguration.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/frontend/FrontendConfiguration.java
@@ -10,17 +10,16 @@ import com.bakdata.conquery.models.config.IdColumnConfig;
 /**
  * API Response for the dynamic configuration of the frontend
  *
- * @param version      backend version
- * @param currency     currency representation
- * @param queryUpload  identifier specific column configuration for the query upload
- * @param manualUrl    url to a user manual
- * @param contactEmail typical a mailto-url
+ * @param version             backend version
+ * @param formBackendVersions mapping of form backend ids to their versions (version can be null)
+ * @param currency            currency representation
+ * @param queryUpload         identifier specific column configuration for the query upload
+ * @param manualUrl           url to a user manual
+ * @param contactEmail        typical a mailto-url
  */
 public record FrontendConfiguration(
-		// Backend version
 		String version,
 
-		// Form backend id -> version
 		Map<String, String> formBackendVersions,
 		FrontendConfig.CurrencyConfig currency,
 		IdColumnConfig queryUpload,

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/frontend/FrontendConfiguration.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/frontend/FrontendConfiguration.java
@@ -2,6 +2,7 @@ package com.bakdata.conquery.apiv1.frontend;
 
 import java.net.URL;
 import java.time.LocalDate;
+import java.util.Map;
 
 import com.bakdata.conquery.models.config.FrontendConfig;
 import com.bakdata.conquery.models.config.IdColumnConfig;
@@ -16,7 +17,11 @@ import com.bakdata.conquery.models.config.IdColumnConfig;
  * @param contactEmail typical a mailto-url
  */
 public record FrontendConfiguration(
+		// Backend version
 		String version,
+
+		// Form backend id -> version
+		Map<String, String> formBackendVersions,
 		FrontendConfig.CurrencyConfig currency,
 		IdColumnConfig queryUpload,
 		URL manualUrl,

--- a/backend/src/main/java/com/bakdata/conquery/io/external/form/ExternalFormBackendApi.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/external/form/ExternalFormBackendApi.java
@@ -43,11 +43,12 @@ public class ExternalFormBackendApi {
 	private final WebTarget getStatusTarget;
 	private final WebTarget cancelTaskTarget;
 	private final WebTarget getHealthTarget;
+	private final WebTarget getVersionTarget;
 	private final Function<User, String> tokenCreator;
 	private final WebTarget baseTarget;
 	private final URL conqueryApiUrl;
 
-	public ExternalFormBackendApi(Client client, URI baseURI, String formConfigPath, String postFormPath, String statusTemplatePath, String cancelTaskPath, String healthCheckPath, Function<User, String> tokenCreator, URL conqueryApiUrl, AuthenticationClientFilterProvider authFilterProvider) {
+	public ExternalFormBackendApi(Client client, URI baseURI, String formConfigPath, String postFormPath, String statusTemplatePath, String cancelTaskPath, String healthCheckPath, String versionPath, Function<User, String> tokenCreator, URL conqueryApiUrl, AuthenticationClientFilterProvider authFilterProvider) {
 
 		this.client = client;
 		this.tokenCreator = tokenCreator;
@@ -65,6 +66,7 @@ public class ExternalFormBackendApi {
 		cancelTaskTarget = baseTarget.path(cancelTaskPath);
 
 		getHealthTarget = baseTarget.path(healthCheckPath);
+		getVersionTarget = baseTarget.path(versionPath);
 	}
 
 	public List<ObjectNode> getFormConfigs() {
@@ -125,6 +127,10 @@ public class ExternalFormBackendApi {
 
 	public HealthCheck createHealthCheck() {
 		return new HttpHealthCheck(getHealthTarget.getUri().toString(), client);
+	}
+
+	public String getVersion() {
+		return getVersionTarget.request(MediaType.APPLICATION_JSON_TYPE).get(FormBackendVersion.class).getVersion();
 	}
 
 	public ExternalTaskState cancelTask(UUID taskId) {

--- a/backend/src/main/java/com/bakdata/conquery/io/external/form/FormBackendVersion.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/external/form/FormBackendVersion.java
@@ -1,0 +1,8 @@
+package com.bakdata.conquery.io.external.form;
+
+import lombok.Data;
+
+@Data
+public class FormBackendVersion {
+	private String version;
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/config/FormBackendConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/FormBackendConfig.java
@@ -120,6 +120,8 @@ public class FormBackendConfig implements PluginConfig, MultiInstancePlugin {
 			log.warn("Unable to retrieve version from form backend '{}'. Enable trace logging for more info", getId(), (Exception) (log.isTraceEnabled()
 																																	? e
 																																	: null));
+			// Set place holder
+			VersionInfo.INSTANCE.setFormBackendVersion(getId(), "no-version-available");
 		}
 
 	}

--- a/backend/src/main/java/com/bakdata/conquery/resources/api/ConfigResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/api/ConfigResource.java
@@ -36,6 +36,7 @@ public class ConfigResource {
 		final FrontendConfig frontendConfig = config.getFrontend();
 		return new FrontendConfiguration(
 				VersionInfo.INSTANCE.getProjectVersion(),
+				VersionInfo.INSTANCE.getFormBackendVersions(),
 				frontendConfig.getCurrency(),
 				idColumns,
 				frontendConfig.getManualUrl(),

--- a/backend/src/main/java/com/bakdata/conquery/util/VersionInfo.java
+++ b/backend/src/main/java/com/bakdata/conquery/util/VersionInfo.java
@@ -2,40 +2,50 @@ package com.bakdata.conquery.util;
 
 import java.io.BufferedReader;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import com.github.powerlibraries.io.In;
-
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-@ToString @Getter @Slf4j
+@ToString
+@Getter
+@Slf4j
 public class VersionInfo {
-	
+
 	public final static VersionInfo INSTANCE = new VersionInfo();
-	
+
 	private ZonedDateTime buildTime;
 	private String projectVersion;
-	
+
+	// Form backend id -> version
+	private final Map<String, String> formBackendVersions = new HashMap<>();
+
 	private VersionInfo() {
 		try {
 			Properties properties = new Properties();
-			try(BufferedReader in = In.resource("/git.properties").withUTF8().asReader()) {
+			try (BufferedReader in = In.resource("/git.properties").withUTF8().asReader()) {
 				properties.load(in);
 			}
-			
+
 			String timeProp = properties.getProperty("build.time");
 			try {
 				buildTime = ZonedDateTime.parse(timeProp);
 			}
-			catch(Exception e) {
+			catch (Exception e) {
 				log.error("Could not parse date time from git.properties", e);
 			}
-			projectVersion =properties.getProperty("project.version");
+			projectVersion = properties.getProperty("project.version");
 		}
 		catch (Exception e) {
 			throw new IllegalStateException("Could not read git properties information", e);
 		}
+	}
+
+	public String setFormBackendVersion(String formBackendId, String version) {
+		return formBackendVersions.put(formBackendId, version);
 	}
 }

--- a/backend/src/main/resources/com/bakdata/conquery/external/openapi-form-backend.yaml
+++ b/backend/src/main/resources/com/bakdata/conquery/external/openapi-form-backend.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.0
 info:
   title: Form Backend
-  version: 1.0.0
+  version: 1.0.1
   description: |
     API for generic external form backends in [Conquery](https://github.com/ingef/conquery).
-    
+
     An external form backend implements this API as a server.
     A Conquery instance is then configured to act as a client. The configuration might look like this:
     ```json
@@ -25,12 +25,12 @@ info:
       ]
     }
     ```
-    
+
     It is possible to override every path in this spec. The overrides must be configured in the above configuration accordingly (see [backend class](https://github.com/ingef/conquery/blob/develop/backend/src/main/java/com/bakdata/conquery/models/config/FormBackendConfig.java)).
-    
+
     Caution: The examples in this spec are used by a mock server in the ExternalFormBackendTest. Changes here might fail that test.
 servers:
-  - url: "{protocol}://{serverAndPort}:{port}/{basePath}"
+  - url: '{protocol}://{serverAndPort}:{port}/{basePath}'
     variables:
       protocol:
         default: https
@@ -42,7 +42,7 @@ servers:
         default: localhost
         description: Server address and optional port if it differs from the protocol's default
       basePath:
-        default: ""
+        default: ''
 tags:
   - name: Form Configuration
   - name: Task
@@ -65,14 +65,13 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/formConfig"
+                  $ref: '#/components/schemas/formConfig'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-
   /task:
     post:
       summary: Create a new form task
@@ -82,33 +81,31 @@ paths:
         - { }
       tags:
         - Task
-
       requestBody:
         description: Represents the form that should be executed
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/form"
+              $ref: '#/components/schemas/form'
       responses:
         '201':
           description: Form task was successfully created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/taskState"
+                $ref: '#/components/schemas/taskState'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-
   /task/{id}:
     parameters:
       - in: path
         name: id
         schema:
-          $ref: "#/components/schemas/taskId"
+          $ref: '#/components/schemas/taskId'
         required: true
         description: The task id
     get:
@@ -120,12 +117,12 @@ paths:
       tags:
         - Task
       responses:
-        "200":
+        '200':
           description: State of existing task
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/taskState"
+                $ref: '#/components/schemas/taskState'
         default:
           description: Unexpected error
           content:
@@ -137,7 +134,7 @@ paths:
       - in: path
         name: id
         schema:
-          $ref: "#/components/schemas/taskId"
+          $ref: '#/components/schemas/taskId'
         required: true
         description: The task id
     post:
@@ -149,33 +146,50 @@ paths:
       tags:
         - Task
       responses:
-        "200":
+        '200':
           description: State of the now cancelled task
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/taskState"
+                $ref: '#/components/schemas/taskState'
         default:
           description: Unexpected error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-
   /health:
     get:
-      summary: Request health State
+      summary: Request health state
       operationId: healthCheck
-      # Cannot do gobal auth and local overrides yet with mocker-server: https://github.com/mock-server/mockserver/issues/1315
       tags:
         - Operation
       responses:
-        "200":
+        '200':
           description: State of service health
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/health"
+                $ref: '#/components/schemas/health'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  /version:
+    get:
+      summary: Request version information
+      operationId: version
+      tags:
+        - Operation
+      responses:
+        '200':
+          description: Version of the form backend
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/version'
         default:
           description: Unexpected error
           content:
@@ -191,8 +205,8 @@ components:
         title:
           type: object
           example:
-            "en": "External Form"
-            "de": "External Form"
+            en: External Form
+            de: External Form
         type:
           type: string
           example: SOME_EXTERNAL_FORM
@@ -200,33 +214,31 @@ components:
           type: array
           items:
             type: object
-
       required:
         - type
         - title
       additionalProperties: true
       example:
-        "title":
-          "en": "External Form"
-          "de": "External Form"
-        "type": "SOME_EXTERNAL_FORM"
-        "fields":
-          - "label":
-              "en": "Cohort"
-              "de": "Kohorte"
-            "style":
-              "size": "h1"
-            "type": "HEADLINE"
+        title:
+          en: External Form
+          de: External Form
+        type: SOME_EXTERNAL_FORM
+        fields:
+          - label:
+              en: Cohort
+              de: Kohorte
+            style:
+              size: h1
+            type: HEADLINE
     taskId:
       type: string
       format: uuid
-
     form:
       type: object
       properties:
         type:
           type: string
-          example: "SOME_EXTERNAL_FORM"
+          example: SOME_EXTERNAL_FORM
       additionalProperties: true
       required:
         - type
@@ -234,9 +246,9 @@ components:
       type: object
       properties:
         id:
-          $ref: "#/components/schemas/taskId"
+          $ref: '#/components/schemas/taskId'
         status:
-          $ref: "#/components/schemas/taskStatus"
+          $ref: '#/components/schemas/taskStatus'
         progress:
           type: number
           nullable: true
@@ -245,19 +257,18 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/resultAsset"
+            $ref: '#/components/schemas/resultAsset'
         error:
-          $ref: "#/components/schemas/error"
+          $ref: '#/components/schemas/error'
       example:
-        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-        "status": "SUCCESS"
-        "progress": 1.0
-        "results":
-          - label: "Result"
-            url: "/result.txt"
-          - label: "Another Result"
-            url: "/another_result.txt"
-
+        id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        status: SUCCESS
+        progress: 1
+        results:
+          - label: Result
+            url: /result.txt
+          - label: Another Result
+            url: /another_result.txt
     taskStatus:
       type: string
       enum:
@@ -274,8 +285,8 @@ components:
           type: string
           format: url
       example:
-        label: "Result"
-        url: "/result.txt"
+        label: Result
+        url: /result.txt
     error:
       type: object
       properties:
@@ -289,11 +300,11 @@ components:
         context:
           type: object
       example:
-        id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-        code: "SOME_ERROR"
-        message: "This is a default template message, for a fallback. Use a template variable from the context like this: ${temp_var}"
+        id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        code: SOME_ERROR
+        message: 'This is a default template message, for a fallback. Use a template variable from the context like this: ${temp_var}'
         context:
-          temp_var: "resolved variable"
+          temp_var: resolved variable
     health:
       type: object
       properties:
@@ -304,6 +315,12 @@ components:
           example: I'm good
       required:
         - healthy
+    version:
+      type: object
+      properties:
+        version:
+          type: string
+          example: "3.2.1-ge966c285"
   securitySchemes:
     ApiKeyAuth:
       type: apiKey


### PR DESCRIPTION
Integrates a new endpoint `/version` for form backends to retrieve version information.

@Kadrian this adds a new member to the `/api/frontend` response:

``` java
// mapping of form backend id -> version (version can be null)
Map<String, String> formBackendVersions,
```

We'll probably need to coordinate this feature.