### PR TITLE
Feature/short cut admin UI login

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/auth/ConqueryAuthenticationInfo.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/ConqueryAuthenticationInfo.java
@@ -1,5 +1,9 @@
 package com.bakdata.conquery.models.auth;
 
+import java.net.URI;
+
+import javax.annotation.Nullable;
+
 import com.bakdata.conquery.models.auth.entities.Subject;
 import com.bakdata.conquery.models.auth.util.SubjectPrincipalCollection;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
@@ -29,12 +33,25 @@ public class ConqueryAuthenticationInfo implements AuthenticationInfo {
 	/**
 	 * A realm can indicate whether a logout button is shown for the user or not
 	 */
-	private final boolean displayLogout; 
+	private final boolean displayLogout;
 
-	public ConqueryAuthenticationInfo(Subject subject, Object credentials, ConqueryAuthenticationRealm realm, boolean displayLogout) {
+	/**
+	 * An uri a user can be redirected to perform an external logout.
+	 */
+	@Nullable
+	private final URI frontChannelLogout;
+
+	public ConqueryAuthenticationInfo(
+			Subject subject,
+			Object credentials,
+			ConqueryAuthenticationRealm realm,
+			boolean displayLogout,
+			@Nullable URI frontChannelLogout
+	) {
 		this.credentials = credentials;
 		this.displayLogout = displayLogout;
 		principals = new SubjectPrincipalCollection(subject, realm);
+		this.frontChannelLogout = frontChannelLogout;
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/conquerytoken/ConqueryTokenRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/conquerytoken/ConqueryTokenRealm.java
@@ -81,7 +81,7 @@ public class ConqueryTokenRealm extends AuthenticatingRealm implements ConqueryA
 
 		final User user = getUserOrThrowUnknownAccount(storage, userId);
 
-		return new ConqueryAuthenticationInfo(user, token, this, true);
+		return new ConqueryAuthenticationInfo(user, token, this, true, null);
 	}
 
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/develop/DefaultInitialUserRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/develop/DefaultInitialUserRealm.java
@@ -1,11 +1,11 @@
 package com.bakdata.conquery.models.auth.develop;
 
 import com.bakdata.conquery.io.storage.MetaStorage;
-import com.bakdata.conquery.models.auth.entities.User;
-import com.bakdata.conquery.models.config.auth.AuthorizationConfig;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationInfo;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
+import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.auth.util.SkippingCredentialsMatcher;
+import com.bakdata.conquery.models.config.auth.AuthorizationConfig;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authc.AuthenticationException;
@@ -60,6 +60,6 @@ public class DefaultInitialUserRealm extends AuthenticatingRealm implements Conq
 		}
 		DevelopmentToken devToken = (DevelopmentToken) token;
 		final User user = getUserOrThrowUnknownAccount(storage, devToken.getPrincipal());
-		return new ConqueryAuthenticationInfo(user, devToken.getCredentials(), this, true);
+		return new ConqueryAuthenticationInfo(user, devToken.getCredentials(), this, true, null);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/develop/DevAuthConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/develop/DevAuthConfig.java
@@ -1,11 +1,12 @@
 package com.bakdata.conquery.models.auth.develop;
 
-import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSType;
+import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
 import com.bakdata.conquery.models.auth.entities.User;
+import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.auth.AuthenticationRealmFactory;
-import com.bakdata.conquery.models.config.auth.AuthenticationRealmFactory;
+import io.dropwizard.setup.Environment;
 
 /**
  * Default configuration for the auth system. Sets up all other default components.
@@ -15,15 +16,15 @@ import com.bakdata.conquery.models.config.auth.AuthenticationRealmFactory;
 public class DevAuthConfig implements AuthenticationRealmFactory {
 		
 	@Override
-	public ConqueryAuthenticationRealm createRealm(ManagerNode managerNode) {
-		User defaultUser = managerNode.getConfig()
+	public ConqueryAuthenticationRealm createRealm(Environment environment, ConqueryConfig config, AuthorizationController authorizationController) {
+		User defaultUser = config
 									  .getAuthorizationRealms()
 									  .getInitialUsers()
 									  .get(0)
-									  .createOrOverwriteUser(managerNode.getStorage());
+									  .createOrOverwriteUser(authorizationController.getStorage());
 
-		managerNode.getAuthController().getAuthenticationFilter().registerTokenExtractor(new UserIdTokenExtractor(defaultUser));
+		authorizationController.getAuthenticationFilter().registerTokenExtractor(new UserIdTokenExtractor(defaultUser));
 
-		return new DefaultInitialUserRealm(managerNode.getStorage());
+		return new DefaultInitialUserRealm(authorizationController.getStorage());
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/FilteredUser.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/FilteredUser.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import com.bakdata.conquery.models.identifiable.ids.specific.PermissionOwnerId;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Subject.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/Subject.java
@@ -1,16 +1,15 @@
 package com.bakdata.conquery.models.auth.entities;
 
-import com.bakdata.conquery.models.auth.ConqueryAuthenticationInfo;
-import com.bakdata.conquery.models.auth.permissions.Ability;
-import com.bakdata.conquery.models.auth.permissions.Authorized;
-import com.bakdata.conquery.models.auth.permissions.ConqueryPermission;
-import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
-import lombok.NonNull;
-
 import java.security.Principal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+
+import com.bakdata.conquery.models.auth.ConqueryAuthenticationInfo;
+import com.bakdata.conquery.models.auth.permissions.Ability;
+import com.bakdata.conquery.models.auth.permissions.Authorized;
+import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
+import lombok.NonNull;
 
 /**
  * An interface for classes that facade a user or represent a user.
@@ -35,6 +34,8 @@ public interface Subject extends Principal {
 	boolean isOwner(Authorized object);
 
 	boolean isDisplayLogout();
+
+	ConqueryAuthenticationInfo getAuthenticationInfo();
 
 	void setAuthenticationInfo(ConqueryAuthenticationInfo info);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/entities/User.java
@@ -154,6 +154,13 @@ public class User extends PermissionOwner<UserId> implements Principal, RoleOwne
 		shiroUserAdapter.getAuthenticationInfo().set(info);
 	}
 
+
+	@JsonIgnore
+	@Override
+	public ConqueryAuthenticationInfo getAuthenticationInfo() {
+		return shiroUserAdapter.getAuthenticationInfo().get();
+	}
+
 	@Override
 	@JsonIgnore
 	public User getUser() {
@@ -169,7 +176,7 @@ public class User extends PermissionOwner<UserId> implements Principal, RoleOwne
 
 		@Getter
 		private final ThreadLocal<ConqueryAuthenticationInfo> authenticationInfo =
-				ThreadLocal.withInitial(() -> new ConqueryAuthenticationInfo(User.this, null, null, false));
+				ThreadLocal.withInitial(() -> new ConqueryAuthenticationInfo(User.this, null, null, false, null));
 
 		@Override
 		public void checkPermission(Permission permission) throws AuthorizationException {

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/oidc/IntrospectionDelegatingRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/oidc/IntrospectionDelegatingRealm.java
@@ -122,7 +122,8 @@ public class IntrospectionDelegatingRealm extends AuthenticatingRealm implements
 
 		final User user = storage.getUser(userId);
 
-		return new ConqueryAuthenticationInfo(user, token, this, true);
+		final String logoutEndpoint = authProviderConf.getAuthClient(true).getServerConfiguration().getLogoutEndpoint();
+		return new ConqueryAuthenticationInfo(user, token, this, true, URI.create(logoutEndpoint));
 	}
 
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/oidc/JwtPkceVerifyingRealm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/oidc/JwtPkceVerifyingRealm.java
@@ -111,7 +111,7 @@ public class JwtPkceVerifyingRealm extends AuthenticatingRealm implements Conque
 		User user = storage.getUser(userId);
 		if (user != null) {
 			log.trace("Successfully authenticated user {}", userId);
-			return new ConqueryAuthenticationInfo(user, token, this, true);
+			return new ConqueryAuthenticationInfo(user, token, this, true, idpConfiguration.logoutEndpoint());
 		}
 
 		// Try alternative ids
@@ -125,7 +125,7 @@ public class JwtPkceVerifyingRealm extends AuthenticatingRealm implements Conque
 			user = storage.getUser(userId);
 			if (user != null) {
 				log.trace("Successfully mapped subject {} using user id {}", subject, userId);
-				return new ConqueryAuthenticationInfo(user, token, this, true);
+				return new ConqueryAuthenticationInfo(user, token, this, true, idpConfiguration.logoutEndpoint());
 			}
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/auth/web/DefaultAuthFilter.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/auth/web/DefaultAuthFilter.java
@@ -1,5 +1,16 @@
 package com.bakdata.conquery.models.auth.web;
 
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Priority;
+import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.SecurityContext;
+
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
@@ -15,16 +26,6 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
-
-import javax.annotation.Priority;
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.Priorities;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.PreMatching;
-import javax.ws.rs.core.SecurityContext;
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * This filter hooks into dropwizard's request handling to extract and process
@@ -71,7 +72,7 @@ public class DefaultAuthFilter extends AuthFilter<AuthenticationToken, Subject> 
 					continue;
 				}
 				// Success an extracted token could be authenticated
-				log.trace("Authentication was successfull for token type {}", token.getClass().getName());
+				log.trace("Authentication was successful for token type {}", token.getClass().getName());
 				return;
 			} catch (AuthenticationException e) {
 				// This is the shiro way to indicate that authentication failed

--- a/backend/src/main/java/com/bakdata/conquery/models/config/auth/AuthenticationRealmFactory.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/auth/AuthenticationRealmFactory.java
@@ -1,11 +1,12 @@
 package com.bakdata.conquery.models.config.auth;
 
-import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSBase;
+import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
+import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.apache.shiro.realm.AuthenticatingRealm;
+import io.dropwizard.setup.Environment;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, property = "type")
 @CPSBase
@@ -13,9 +14,12 @@ public interface AuthenticationRealmFactory {
 	
 	/**
 	 * Gets the realm specified in the configuration.
+	 *
+	 * @param environment
+	 * @param config
+	 * @param authorizationController
 	 * @return The realm.
-	 * @param managerNode
 	 */
 	@JsonIgnore
-	ConqueryAuthenticationRealm createRealm(ManagerNode managerNode);
+	ConqueryAuthenticationRealm createRealm(Environment environment, ConqueryConfig config, AuthorizationController authorizationController);
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/config/auth/LocalAuthenticationConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/auth/LocalAuthenticationConfig.java
@@ -11,14 +11,15 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.UriBuilder;
 
 import com.bakdata.conquery.apiv1.RequestHelper;
-import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.Jackson;
+import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
 import com.bakdata.conquery.models.auth.basic.JWTokenHandler;
 import com.bakdata.conquery.models.auth.basic.LocalAuthenticationRealm;
 import com.bakdata.conquery.models.auth.basic.UserAuthenticationManagementProcessor;
 import com.bakdata.conquery.models.auth.web.RedirectingAuthFilter;
+import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.XodusConfig;
 import com.bakdata.conquery.resources.admin.AdminServlet;
 import com.bakdata.conquery.resources.admin.rest.UserAuthenticationManagementResource;
@@ -28,6 +29,7 @@ import com.password4j.BcryptFunction;
 import com.password4j.BenchmarkResult;
 import com.password4j.SystemChecker;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
 import io.dropwizard.validation.ValidationMethod;
@@ -41,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LocalAuthenticationConfig implements AuthenticationRealmFactory {
 
-	public static final String REDIRECT_URI = "redirect_uri";
 	public static final int BCRYPT_MAX_MILLISECONDS = 300;
 	/**
 	 * Configuration for the password store. An encryption for the store itself might be set here.
@@ -67,7 +68,7 @@ public class LocalAuthenticationConfig implements AuthenticationRealmFactory {
 	boolean isStorageEncrypted() {
 		// Check if a cipher is configured for xodus according to https://github.com/JetBrains/xodus/wiki/Database-Encryption
 		// in the config
-		if(passwordStoreConfig.getCipherId() != null){
+		if (passwordStoreConfig.getCipherId() != null) {
 			return true;
 		}
 
@@ -76,9 +77,9 @@ public class LocalAuthenticationConfig implements AuthenticationRealmFactory {
 	}
 	
 	@Override
-	public ConqueryAuthenticationRealm createRealm(ManagerNode manager) {
+	public ConqueryAuthenticationRealm createRealm(Environment environment, ConqueryConfig config, AuthorizationController authorizationController) {
 		// Token extractor is not needed because this realm depends on the ConqueryTokenRealm
-		manager.getAuthController().getAuthenticationFilter().registerTokenExtractor(JWTokenHandler::extractToken);
+		authorizationController.getAuthenticationFilter().registerTokenExtractor(JWTokenHandler::extractToken);
 
 		log.info("Performing benchmark for default hash function (bcrypt) with max_milliseconds={}", BCRYPT_MAX_MILLISECONDS);
 		final BenchmarkResult<BcryptFunction> result = SystemChecker.benchmarkBcrypt(BCRYPT_MAX_MILLISECONDS);
@@ -91,26 +92,26 @@ public class LocalAuthenticationConfig implements AuthenticationRealmFactory {
 		log.info("Using bcrypt with {} logarithmic rounds. Elapsed time={}", rounds, realElapsed);
 
 		LocalAuthenticationRealm realm = new LocalAuthenticationRealm(
-				manager.getValidator(),
+				environment.getValidator(),
 				Jackson.copyMapperAndInjectables(Jackson.BINARY_MAPPER),
-				manager.getAuthController().getConqueryTokenRealm(),
+				authorizationController.getConqueryTokenRealm(),
 				storeName,
 				directory,
 				passwordStoreConfig,
 				jwtDuration,
 				prototype
 		);
-		UserAuthenticationManagementProcessor processor = new UserAuthenticationManagementProcessor(realm, manager.getStorage());
+		UserAuthenticationManagementProcessor processor = new UserAuthenticationManagementProcessor(realm, authorizationController.getStorage());
 
 		// Register resources for users to exchange username and password for an access token
-		registerAdminUnprotectedAuthenticationResources(manager.getUnprotectedAuthAdmin(), realm);
-		registerApiUnprotectedAuthenticationResources(manager.getUnprotectedAuthApi(), realm);
+		registerAdminUnprotectedAuthenticationResources(authorizationController.getUnprotectedAuthAdmin(), realm);
+		registerApiUnprotectedAuthenticationResources(authorizationController.getUnprotectedAuthApi(), realm);
 
-		registerAuthenticationAdminResources(manager.getAdmin().getJerseyConfig(), processor);
+		registerAuthenticationAdminResources(authorizationController.getAdminServlet().getJerseyConfig(), processor);
 
 		// Add login schema for admin end
-		final RedirectingAuthFilter redirectingAuthFilter = manager.getAuthController().getRedirectingAuthFilter();
-		redirectingAuthFilter.getLoginInitiators().add(loginProvider(manager.getUnprotectedAuthAdmin()));
+		final RedirectingAuthFilter redirectingAuthFilter = authorizationController.getRedirectingAuthFilter();
+		redirectingAuthFilter.getLoginInitiators().add(loginProvider(authorizationController.getUnprotectedAuthAdmin()));
 
 		return realm;
 	}
@@ -119,7 +120,9 @@ public class LocalAuthenticationConfig implements AuthenticationRealmFactory {
 		return (ContainerRequestContext request) -> {
 			return UriBuilder.fromPath(unprotectedAuthAdmin.getUrlPattern())
 							 .path(LoginResource.class)
-							 .queryParam(REDIRECT_URI, UriBuilder.fromUri(RequestHelper.getRequestURL(request)).path(AdminServlet.ADMIN_UI).build())
+							 .queryParam(RedirectingAuthFilter.REDIRECT_URI, UriBuilder.fromUri(RequestHelper.getRequestURL(request))
+																					   .path(AdminServlet.ADMIN_UI)
+																					   .build())
 							 .build();
 		};
 

--- a/backend/src/main/java/com/bakdata/conquery/models/config/auth/OIDCAuthorizationCodeFlowRealmFactory.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/auth/OIDCAuthorizationCodeFlowRealmFactory.java
@@ -1,8 +1,10 @@
 package com.bakdata.conquery.models.config.auth;
 
-import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSType;
+import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
+import com.bakdata.conquery.models.config.ConqueryConfig;
+import io.dropwizard.setup.Environment;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +21,7 @@ public class OIDCAuthorizationCodeFlowRealmFactory implements AuthenticationReal
 	private IntrospectionDelegatingRealmFactory client;
 
 	@Override
-	public ConqueryAuthenticationRealm createRealm(ManagerNode managerNode) {
-		return client.createRealm(managerNode);
+	public ConqueryAuthenticationRealm createRealm(Environment environment, ConqueryConfig config, AuthorizationController authorizationController) {
+		return client.createRealm(environment, authorizationController);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/config/auth/OIDCResourceOwnerPasswordCredentialRealmFactory.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/auth/OIDCResourceOwnerPasswordCredentialRealmFactory.java
@@ -1,12 +1,14 @@
 package com.bakdata.conquery.models.config.auth;
 
-import com.bakdata.conquery.commands.ManagerNode;
 import com.bakdata.conquery.io.cps.CPSType;
+import com.bakdata.conquery.models.auth.AuthorizationController;
 import com.bakdata.conquery.models.auth.ConqueryAuthenticationRealm;
 import com.bakdata.conquery.models.auth.oidc.passwordflow.IdpDelegatingAccessTokenCreator;
+import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.resources.unprotected.LoginResource;
 import com.bakdata.conquery.resources.unprotected.TokenResource;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import io.dropwizard.setup.Environment;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -25,16 +27,16 @@ public class OIDCResourceOwnerPasswordCredentialRealmFactory implements Authenti
 
 
 	@Override
-	public ConqueryAuthenticationRealm createRealm(ManagerNode managerNode) {
+	public ConqueryAuthenticationRealm createRealm(Environment environment, ConqueryConfig config, AuthorizationController authorizationController) {
 
 		// Register processor that does the actual exchange of user credentials for an access token
 		IdpDelegatingAccessTokenCreator idpDelegatingAccessTokenCreator = new IdpDelegatingAccessTokenCreator(client);
 
 		// Register resources for users to exchange username and password for an access token
-		registerAdminUnprotectedAuthenticationResources(managerNode.getUnprotectedAuthAdmin(), idpDelegatingAccessTokenCreator);
-		registerApiUnprotectedAuthenticationResources(managerNode.getUnprotectedAuthApi(), idpDelegatingAccessTokenCreator);
+		registerAdminUnprotectedAuthenticationResources(authorizationController.getUnprotectedAuthAdmin(), idpDelegatingAccessTokenCreator);
+		registerApiUnprotectedAuthenticationResources(authorizationController.getUnprotectedAuthApi(), idpDelegatingAccessTokenCreator);
 
-		return client.createRealm(managerNode);
+		return client.createRealm(environment, authorizationController);
 	}
 
 	public void registerAdminUnprotectedAuthenticationResources(DropwizardResourceConfig jerseyConfig, IdpDelegatingAccessTokenCreator idpDelegatingAccessTokenCreator) {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
@@ -73,6 +73,7 @@ public class AdminServlet {
 		jerseyConfigUI.setUrlPattern("/admin-ui");
 
 		RESTServer.configure(manager.getConfig(), jerseyConfig);
+		RESTServer.configure(manager.getConfig(), jerseyConfigUI);
 
 		final AdminEnvironment admin = manager.getEnvironment().admin();
 		admin.addServlet(ADMIN_SERVLET_PATH, new ServletContainer(jerseyConfig)).addMapping("/" + ADMIN_SERVLET_PATH + "/*");
@@ -122,8 +123,7 @@ public class AdminServlet {
 					.register(IdRefPathParamConverterProvider.class)
 					.register(new MultiPartFeature())
 					.register(IdParamConverter.Provider.INSTANCE)
-					.register(authCookieFilter)
-					.register(manager.getAuthController().getAuthenticationFilter());
+					.register(authCookieFilter);
 
 
 		jerseyConfigUI.register(new ViewMessageBodyWriter(manager.getEnvironment().metrics(), Collections.singleton(Freemarker.HTML_RENDERER)))
@@ -138,8 +138,7 @@ public class AdminServlet {
 					  })
 					  .register(AdminPermissionFilter.class)
 					  .register(IdRefPathParamConverterProvider.class)
-					  .register(authCookieFilter)
-					  .register(manager.getAuthController().getRedirectingAuthFilter());
+					  .register(authCookieFilter);
 		;
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
@@ -18,10 +18,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
@@ -29,13 +26,10 @@ import com.bakdata.conquery.apiv1.execution.FullExecutionStatus;
 import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
 import com.bakdata.conquery.io.storage.MetaStorage;
 import com.bakdata.conquery.models.auth.entities.Subject;
-import com.bakdata.conquery.models.config.auth.AuthenticationConfig;
 import com.bakdata.conquery.models.error.ConqueryError;
 import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.jobs.JobManagerStatus;
 import com.bakdata.conquery.models.messages.network.specific.CancelJobMessage;
-import com.bakdata.conquery.models.worker.DatasetRegistry;
-import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.resources.admin.ui.AdminUIResource;
 import io.dropwizard.auth.Auth;
@@ -102,14 +96,6 @@ public class AdminResource {
 	}
 
 	@GET
-	@Path("logout")
-	public Response logout(@Context ContainerRequestContext requestContext) {
-		// Invalidate all cookies. At the moment the adminEnd uses cookies only for authentication, so this does not interfere with other things
-		final NewCookie[] expiredCookies = requestContext.getCookies().keySet().stream().map(AuthenticationConfig::expireCookie).toArray(NewCookie[]::new);
-		return Response.ok().cookie(expiredCookies).build();
-	}
-
-	@GET
 	@Path("/queries")
 	public FullExecutionStatus[] getQueries(@Auth Subject currentUser, @QueryParam("limit") OptionalLong maybeLimit, @QueryParam("since") Optional<String> maybeSince) {
 
@@ -117,7 +103,6 @@ public class AdminResource {
 		final long limit = maybeLimit.orElse(100);
 
 		final MetaStorage storage = processor.getStorage();
-		final DatasetRegistry<? extends Namespace> datasetRegistry = processor.getDatasetRegistry();
 
 
 		return storage.getAllExecutions().stream()

--- a/backend/src/main/java/com/bakdata/conquery/resources/unprotected/LoginResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/unprotected/LoginResource.java
@@ -1,15 +1,19 @@
 package com.bakdata.conquery.resources.unprotected;
 
-import javax.ws.rs.*;
+import java.net.URI;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
-import com.bakdata.conquery.models.config.auth.LocalAuthenticationConfig;
+import com.bakdata.conquery.models.auth.web.RedirectingAuthFilter;
 import com.bakdata.conquery.resources.admin.ui.model.UIView;
 import io.dropwizard.views.View;
-
-import java.net.URI;
 
 @Path("/login")
 @Produces(MediaType.TEXT_HTML)
@@ -19,7 +23,7 @@ public class LoginResource {
 	private ContainerRequestContext request;
 	
 	@GET
-	public View getLoginPage(@QueryParam(LocalAuthenticationConfig.REDIRECT_URI) URI redirectUri){
+	public View getLoginPage(@QueryParam(RedirectingAuthFilter.REDIRECT_URI) URI redirectUri) {
 		final String requestAuthority = request.getUriInfo().getBaseUri().getAuthority();
 		final String redirectAuthority = redirectUri.getAuthority();
 		if (!requestAuthority.equals(redirectAuthority)){

--- a/backend/src/main/resources/assets/custom/js/script.js
+++ b/backend/src/main/resources/assets/custom/js/script.js
@@ -118,24 +118,19 @@ function loginClickHandler() {
 		})
 		.then((json) => {
 			var searchParams = new URLSearchParams(window.location.search);
-			searchParams.set("access_token", json.access_token);
+			var redirect = new URL(searchParams.get("redirect_uri"))
+			redirect.searchParams.append("access_token", json.access_token)
+
 			// This triggers a page reload
-			window.location.search = searchParams.toString();
-		}
-		)
+			window.location = redirect.toString();
+		})
 		.catch(function (error) {
 			var p = document.createElement('p');
 			p.appendChild(
 				document.createTextNode('Error: ' + error.message)
 			);
-			document.body.insertBefore(p, myImage);
+			document.getElementById('login-form').insertBefore(p, document.getElementById('login-button'));
 		});
-}
-
-function logout() {
-	event.preventDefault();
-	rest('/admin/logout')
-		.then(function () { location.reload() });
 }
 
 function postFile(event, url) {

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/login.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/login.html.ftl
@@ -17,7 +17,7 @@
 		  <p class="h1 text-center mb-3 display-4">Conquery</p>
 		  <p class="text-center lead">Admin Login</p>
 		  <p class="h3 text-center font-weight-normal">Please sign in</p>
-		  <form>
+		  <form id="login-form">
 			  <div class="form-group">
 				<label for="inputEmail">Username</label>
 				<input type="text" id="inputEmail" autocomplete="username" class="form-control" placeholder="Enter username" required autofocus>

--- a/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/template.html.ftl
+++ b/backend/src/main/resources/com/bakdata/conquery/resources/admin/ui/templates/template.html.ftl
@@ -80,7 +80,7 @@
 			</div>
 
 			<div class="pl-2">
-				<button type="button" class="btn btn-secondary" onclick="logout()">Logout</button>
+				<a href="/admin-ui/logout" class="btn btn-secondary">Logout</a>
 			</div>
 		</nav>
 

--- a/backend/src/test/java/com/bakdata/conquery/api/StoredQueriesProcessorTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/StoredQueriesProcessorTest.java
@@ -35,7 +35,6 @@ import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.config.CsvResultProvider;
 import com.bakdata.conquery.models.config.ExcelResultProvider;
 import com.bakdata.conquery.models.config.ParquetResultProvider;
-import com.bakdata.conquery.models.config.auth.DevelopmentAuthorizationConfig;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.datasets.SecondaryIdDescription;
 import com.bakdata.conquery.models.execution.ExecutionState;
@@ -51,13 +50,13 @@ import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.DistributedNamespace;
 import com.bakdata.conquery.util.NonPersistentStoreFactory;
 import com.google.common.collect.ImmutableList;
+import io.dropwizard.setup.Environment;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class StoredQueriesProcessorTest {
 	private static final MetaStorage STORAGE = new NonPersistentStoreFactory().createMetaStorage();
-	// Marked Unused, but does inject itself.
-	public static final AuthorizationController AUTHORIZATION_CONTROLLER = new AuthorizationController(STORAGE, new DevelopmentAuthorizationConfig());
 
 	public static final ConqueryConfig CONFIG = new ConqueryConfig();
 	private static final DatasetRegistry<DistributedNamespace> datasetRegistry = new DatasetRegistry<>(0, CONFIG, null, null, null);
@@ -116,6 +115,11 @@ public class StoredQueriesProcessorTest {
 			mockManagedConceptQueryFrontEnd(USERS[1], QUERY_ID_10, DONE, DATASET_0, 2_000_000L)        // included, but no result url for xlsx (result has too many rows)
 
 	);
+
+	@BeforeAll
+	public static void beforeAll() {
+		new AuthorizationController(STORAGE, CONFIG, new Environment(StoredQueriesProcessorTest.class.getSimpleName()), null);
+	}
 
 
 	@Test

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
@@ -33,7 +33,6 @@ import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
 import com.bakdata.conquery.models.auth.permissions.FormConfigPermission;
 import com.bakdata.conquery.models.auth.permissions.FormPermission;
 import com.bakdata.conquery.models.config.ConqueryConfig;
-import com.bakdata.conquery.models.config.auth.DevelopmentAuthorizationConfig;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.forms.configs.FormConfig;
 import com.bakdata.conquery.models.forms.configs.FormConfig.FormConfigFullRepresentation;
@@ -54,6 +53,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.dropwizard.jersey.validation.Validators;
+import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -123,7 +123,7 @@ public class FormConfigTest {
 		((MutableInjectableValues) FormConfigProcessor.getMAPPER().getInjectableValues())
 				.add(IdResolveContext.class, namespacesMock);
 		processor = new FormConfigProcessor(validator, storage, namespacesMock);
-		controller = new AuthorizationController(storage, new DevelopmentAuthorizationConfig());
+		controller = new AuthorizationController(storage, config, new Environment(this.getClass().getSimpleName()), null);
 		controller.start();
 	}
 

--- a/backend/src/test/java/com/bakdata/conquery/models/auth/IntrospectionDelegatingRealmTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/auth/IntrospectionDelegatingRealmTest.java
@@ -9,6 +9,7 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.Parameter.param;
 import static org.mockserver.model.ParameterBody.params;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -93,6 +94,7 @@ public class IntrospectionDelegatingRealmTest {
 	public static final KeycloakGroup
 			KEYCLOAK_GROUP_2 =
 			new KeycloakGroup(UUID.randomUUID().toString(), "Group2", "g2", Map.of(GROUP_ID_ATTRIBUTE, new GroupId(GROUPNAME_2).toString()), Set.of());
+	public static final URI FRONT_CHANNEL_LOGOUT = URI.create("http://localhost:1080/realms/test_realm/protocol/openid-connect/logout");
 
 	private static OIDCMockServer OIDC_SERVER;
 	private static TestRealm REALM;
@@ -206,7 +208,7 @@ public class IntrospectionDelegatingRealmTest {
 				.usingRecursiveComparison()
 				.ignoringFields(ConqueryAuthenticationInfo.Fields.credentials)
 				.ignoringFieldsOfTypes(User.ShiroUserAdapter.class)
-			.isEqualTo(new ConqueryAuthenticationInfo(USER_1, USER1_TOKEN_WRAPPED, REALM, true));
+				.isEqualTo(new ConqueryAuthenticationInfo(USER_1, USER1_TOKEN_WRAPPED, REALM, true, FRONT_CHANNEL_LOGOUT));
 		assertThat(STORAGE.getAllUsers()).containsOnly(new User(USER_1_NAME, USER_1_NAME, STORAGE));
 	}
 	
@@ -219,7 +221,7 @@ public class IntrospectionDelegatingRealmTest {
 		assertThat(info)
 			.usingRecursiveComparison()
 			.ignoringFields(ConqueryAuthenticationInfo.Fields.credentials)
-			.isEqualTo(new ConqueryAuthenticationInfo(USER_1, USER1_TOKEN_WRAPPED, REALM, true));
+			.isEqualTo(new ConqueryAuthenticationInfo(USER_1, USER1_TOKEN_WRAPPED, REALM, true, FRONT_CHANNEL_LOGOUT));
 		assertThat(STORAGE.getAllUsers()).containsOnly(USER_1);
 	}
 	
@@ -229,7 +231,7 @@ public class IntrospectionDelegatingRealmTest {
 
 		AuthenticationInfo info = REALM.doGetAuthenticationInfo(USER_2_TOKEN_WRAPPED);
 
-		final ConqueryAuthenticationInfo expected = new ConqueryAuthenticationInfo(USER_2, USER_2_TOKEN_WRAPPED, REALM, true);
+		final ConqueryAuthenticationInfo expected = new ConqueryAuthenticationInfo(USER_2, USER_2_TOKEN_WRAPPED, REALM, true, FRONT_CHANNEL_LOGOUT);
 		assertThat(info)
 			.usingRecursiveComparison()
 			.isEqualTo(expected);
@@ -251,7 +253,7 @@ public class IntrospectionDelegatingRealmTest {
 		assertThat(info)
 			.usingRecursiveComparison()
 			.ignoringFields(ConqueryAuthenticationInfo.Fields.credentials)
-			.isEqualTo(new ConqueryAuthenticationInfo(USER_3, USER_3_TOKEN_WRAPPED, REALM, true));
+			.isEqualTo(new ConqueryAuthenticationInfo(USER_3, USER_3_TOKEN_WRAPPED, REALM, true, FRONT_CHANNEL_LOGOUT));
 		assertThat(STORAGE.getAllUsers()).containsOnly(USER_3);
 		assertThat(STORAGE.getAllGroups()).hasSize(1); // Pre-existing group 
 		assertThat(STORAGE.getGroup(new GroupId(GROUPNAME_1)).getMembers()).doesNotContain(new UserId(USER_3_NAME));

--- a/backend/src/test/java/com/bakdata/conquery/models/auth/oidc/JwtPkceVerifyingRealmTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/auth/oidc/JwtPkceVerifyingRealmTest.java
@@ -56,7 +56,7 @@ class JwtPkceVerifyingRealmTest {
 
 		// Create the realm
 		REALM = new JwtPkceVerifyingRealm(
-				() -> Optional.of(new JwtPkceVerifyingRealmFactory.IdpConfiguration(Map.of(KEY_ID, PUBLIC_KEY), URI.create("auth"), URI.create("token"), HTTP_REALM_URL)),
+				() -> Optional.of(new JwtPkceVerifyingRealmFactory.IdpConfiguration(Map.of(KEY_ID, PUBLIC_KEY), URI.create("auth"), URI.create("token"), URI.create("logout"), HTTP_REALM_URL)),
 				AUDIENCE,
 				List.of(JwtPkceVerifyingRealmFactory.ScriptedTokenChecker.create("t.getOtherClaims().get(\"groups\").equals(\"conquery\")")),
 				List.of(ALTERNATIVE_ID_CLAIM),

--- a/backend/src/test/resources/tests/endpoints/adminEndpointInfo.json
+++ b/backend/src/test/resources/tests/endpoints/adminEndpointInfo.json
@@ -286,11 +286,6 @@
   },
   {
     "method": "GET",
-    "path": "/logout",
-    "clazz": "AdminResource"
-  },
-  {
-    "method": "GET",
     "path": "/jobs/",
     "clazz": "AdminResource"
   },

--- a/backend/src/test/resources/tests/endpoints/adminUIEndpointInfo.json
+++ b/backend/src/test/resources/tests/endpoints/adminUIEndpointInfo.json
@@ -93,5 +93,10 @@
     "method": "GET",
     "path": "/index-service",
     "clazz": "IndexServiceUIResource"
+  },
+  {
+    "method": "GET",
+    "path": "/logout",
+    "clazz": "AdminUIResource"
   }
 ]


### PR DESCRIPTION
One problem surfaces with this one: the logout does not seem to work anymore.

Until now logout worked by simply deleting the backend cookies and the user landed back on the `logins availiabe` site.
Now since only the backend-cookies are removed not the keycloak-cookies, the user is redirected immediatialy to keycloak successfully login again.

Looking into implement logout using the keycloak logout url.