### PR TITLE
Use java.nio.file.Files::createDirectories to create the dumpfile parent

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/io/storage/xodus/stores/SerializingStore.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/storage/xodus/stores/SerializingStore.java
@@ -296,12 +296,7 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 		}
 
 		try {
-			/*
-			 Files::createDirectories creates a directory by creating all nonexistent parent directories first.
-			 Each directory creation attempt uses Files::createDirectory, through Files::createAndCheckIsDirectory.
-			 Files::createDirectory is atomic and Files::createAndCheckIsDirectory catches and ignores FileAlreadyExistsException for directories.
-			 Thus, after leaving Files::createDirectories the parent of dumpfile exists.
-			 */
+			// This will create all necessary parent directories.
 			Files.createDirectories(dumpfile.toPath().getParent());
 
 			// Should be a redundant check, due to the above reasoning
@@ -310,8 +305,7 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 			}
 		}
 		catch (IOException e) {
-			// Files::createDirectories throws java.io.IOException
-			throw new IllegalStateException("Could not create `%s` due to an IOException:%s".formatted(dumpfile.getParentFile(), e.getMessage()));
+			log.warn("Could not create `{}`", dumpfile.getParentFile(), e);
 		}
 
 		// Write json

--- a/backend/src/main/java/com/bakdata/conquery/io/storage/xodus/stores/SerializingStore.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/storage/xodus/stores/SerializingStore.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
@@ -276,7 +277,7 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 	}
 
 	/**
-	 * Dumps the content of an unreadable value to a file as a json (it tries to parse it as an object and than tries to dump it as a json).
+	 * Dumps the content of an unreadable value to a file as a json (it tries to parse it as an object and then tries to dump it as a json).
 	 *
 	 * @param gzippedObj        The object to dump.
 	 * @param keyOfDump         The key under which the unreadable value is accessible. It is used for the file name.
@@ -294,9 +295,23 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 			return;
 		}
 
-		if (!dumpfile.getParentFile().exists() && !dumpfile.getParentFile().mkdirs()) {
-			//TODO this seems to occur sometimes, is it maybe just a race condition?
-			throw new IllegalStateException("Could not create `%s`.".formatted(dumpfile.getParentFile()));
+		try {
+			/*
+			 Files::createDirectories creates a directory by creating all nonexistent parent directories first.
+			 Each directory creation attempt uses Files::createDirectory, through Files::createAndCheckIsDirectory.
+			 Files::createDirectory is atomic and Files::createAndCheckIsDirectory catches and ignores FileAlreadyExistsException for directories.
+			 Thus, after leaving Files::createDirectories the parent of dumpfile exists.
+			 */
+			Files.createDirectories(dumpfile.toPath().getParent());
+
+			// Should be a redundant check, due to the above reasoning
+			if (!dumpfile.getParentFile().exists()) {
+				throw new IllegalStateException("Could not create `%s`.".formatted(dumpfile.getParentFile()));
+			}
+		}
+		catch (IOException e) {
+			// Files::createDirectories throws java.io.IOException
+			throw new IllegalStateException("Could not create `%s` due to an IOException:%s".formatted(dumpfile.getParentFile(), e.getMessage()));
 		}
 
 		// Write json
@@ -351,7 +366,7 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 
 	/**
 	 * Iterates a given consumer over the entries of this store.
-	 * Depending on the {@link XodusStoreFactory} corrupt entries may be dump to a file and/or removed from the store.
+	 * Depending on the {@link XodusStoreFactory} corrupt entries may be dumped to a file and/or removed from the store.
 	 * These entries are not submitted to the consumer.
 	 *
 	 * @implNote This method is concurrent!
@@ -420,7 +435,8 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 			result.incrTotalProcessed();
 
 			// Try to read the key first
-			key = getDeserializedAndDumpFailed(keyRaw, SerializingStore.this::readKey, () -> new String(keyRaw.getBytesUnsafe()), valueRaw, "Could not parse key [{}]");
+			key =
+					getDeserializedAndDumpFailed(keyRaw, SerializingStore.this::readKey, () -> new String(keyRaw.getBytesUnsafe()), valueRaw, "Could not parse key [{}]");
 			if (key == null) {
 				result.incrFailedKeys();
 				return keyRaw;
@@ -433,7 +449,8 @@ public class SerializingStore<KEY, VALUE> implements Store<KEY, VALUE> {
 				result.incrFailedValues();
 				return keyRaw;
 			}
-		}catch(Exception e){
+		}
+		catch (Exception e) {
 			log.error("Failed processing key/value", e);
 			return keyRaw;
 		}


### PR DESCRIPTION
`Files::createDirectories` creates a directory by creating all nonexistent parent directories first.
Each directory creation attempt uses `Files::createDirectory` through `Files::createAndCheckIsDirectory`.
`Files::createDirectory` is atomic and `Files::createAndCheckIsDirectory` catches and ignores `FileAlreadyExistsException` for directories.
Thus, after leaving `Files::createDirectories` the parent of `dumpfile` exists.