### PR TITLE
Hotfix: restore history after new preview release

### DIFF
--- a/frontend/src/js/button/QueryResultHistoryButton.tsx
+++ b/frontend/src/js/button/QueryResultHistoryButton.tsx
@@ -6,6 +6,8 @@ import { useDispatch, useSelector } from "react-redux";
 import type { StateT } from "../app/reducers";
 import { openHistory, useNewHistorySession } from "../entity-history/actions";
 
+import { ColumnDescription } from "../api/types";
+import { useGetAuthorizedUrl } from "../authorization/useAuthorizedUrl";
 import IconButton from "./IconButton";
 
 const SxIconButton = styled(IconButton)`
@@ -13,17 +15,22 @@ const SxIconButton = styled(IconButton)`
   height: 35px;
 `;
 
-interface PropsT {
+export const QueryResultHistoryButton = ({
+  url,
+  label,
+  columns,
+}: {
+  columns: ColumnDescription[];
   label: string;
-}
-
-export const QueryResultHistoryButton = ({ label }: PropsT) => {
+  url: string;
+}) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const isLoading = useSelector<StateT, boolean>(
     (state) => state.entityHistory.isLoading,
   );
 
+  const getAuthorizedUrl = useGetAuthorizedUrl();
   const newHistorySession = useNewHistorySession();
 
   return (
@@ -31,7 +38,7 @@ export const QueryResultHistoryButton = ({ label }: PropsT) => {
       icon={isLoading ? faSpinner : faListUl}
       frame
       onClick={async () => {
-        await newHistorySession(label);
+        await newHistorySession(getAuthorizedUrl(url), columns, label);
         dispatch(openHistory());
       }}
     >

--- a/frontend/src/js/query-runner/QueryResults.tsx
+++ b/frontend/src/js/query-runner/QueryResults.tsx
@@ -12,6 +12,7 @@ import { isEmpty } from "../common/helpers/commonHelper";
 import FaIcon from "../icon/FaIcon";
 import { canViewEntityPreview, canViewQueryPreview } from "../user/selectors";
 
+import { exists } from "../common/helpers/exists";
 import DownloadResultsDropdownButton from "./DownloadResultsDropdownButton";
 
 const Root = styled("div")`
@@ -48,9 +49,11 @@ const QueryResults: FC<PropsT> = ({
   resultLabel,
   resultUrls,
   resultCount,
+  resultColumns,
   queryType,
 }) => {
   const { t } = useTranslation();
+  const csvUrl = resultUrls.find(({ url }) => url.endsWith("csv"));
   const canViewHistory = useSelector<StateT, boolean>(canViewEntityPreview);
   const canViewPreview = useSelector<StateT, boolean>(canViewQueryPreview);
 
@@ -70,7 +73,13 @@ const QueryResults: FC<PropsT> = ({
         </LgText>
       )}
       {canViewPreview && <PreviewButton />}
-      {canViewHistory && <QueryResultHistoryButton label={resultLabel} />}
+      {!!csvUrl && canViewHistory && exists(resultColumns) && (
+        <QueryResultHistoryButton
+          columns={resultColumns}
+          url={csvUrl.url}
+          label={resultLabel}
+        />
+      )}
       {resultUrls.length > 0 && (
         <DownloadResultsDropdownButton resultUrls={resultUrls} />
       )}


### PR DESCRIPTION
This mostly restores the previous behavior where the entity history was loading a CSV file – not using apache arrow.

I've tried migrating this forward, but the apache arrow client seems barely documented and not very intuitive to use, so for now: going back to CSV for the history.

The issue this was breaking was the preview PR and in particular [these changes](https://github.com/ingef/conquery/pull/3327/files#diff-8b001a4ffa94babbd26d92afc98385a90bbf6e564caaa1a6575cceff99807e3eR136)