### PR TITLE
Simplify Table rendering. Move allocations out of Cell-functions, avoiding unnecessary allocations

### DIFF
--- a/frontend/src/js/api/api.ts
+++ b/frontend/src/js/api/api.ts
@@ -418,7 +418,7 @@ export const useGetResult = () => {
     [authToken],
   );
   return useCallback(
-    (queryId: string, limit = 1000) => {
+    (queryId: string, limit: number) => {
       const url =
         `/result/arrow/${queryId}.arrs?` +
         new URLSearchParams({ limit: limit.toString() });

--- a/frontend/src/js/preview/Table.tsx
+++ b/frontend/src/js/preview/Table.tsx
@@ -77,7 +77,7 @@ export default memo(function Table({
           key: field.name,
           render: (value: string | Vector) => {
             const rendered = renderer(value);
-            return <span title={rendered as string}>{rendered}</span>;
+            return <span title={rendered}>{rendered}</span>;
           },
         };
       }),

--- a/frontend/src/js/preview/Table.tsx
+++ b/frontend/src/js/preview/Table.tsx
@@ -62,25 +62,28 @@ export default memo(function Table({
   queryData,
 }: Props) {
   const rootRef = useRef<HTMLDivElement>(null);
-  const { getRenderFunctionByFieldName } = useCustomTableRenderers(queryData as GetQueryResponseDoneT);
+  const { getRenderFunctionByFieldName } = useCustomTableRenderers(
+    queryData as GetQueryResponseDoneT,
+  );
 
   const columns = useMemo(
     () =>
       arrowReader.schema?.fields.map((field) => {
-        const renderer = getRenderFunctionByFieldName(field.name)
-        
-        return ({
-        title: field.name.charAt(0).toUpperCase() + field.name.slice(1),
-        dataIndex: field.name,
-        key: field.name,
-        render: (value: string | Vector) => {
-          const rendered = renderer(value)
-          return <span title={rendered as string}>{rendered}</span>;
-        },
-      })}),
-    [arrowReader.schema, getRenderFunctionByFieldName, queryData],
+        const renderer = getRenderFunctionByFieldName(field.name);
+
+        return {
+          title: field.name.charAt(0).toUpperCase() + field.name.slice(1),
+          dataIndex: field.name,
+          key: field.name,
+          render: (value: string | Vector) => {
+            const rendered = renderer(value);
+            return <span title={rendered as string}>{rendered}</span>;
+          },
+        };
+      }),
+    [arrowReader.schema, getRenderFunctionByFieldName],
   );
-  
+
   const loadedTableData = useMemo(
     () => new ArrowTable(initialTableData.value).toArray(),
     [initialTableData],

--- a/frontend/src/js/preview/actions.ts
+++ b/frontend/src/js/preview/actions.ts
@@ -81,7 +81,7 @@ export function useLoadPreviewData() {
 
     try {
       const arrowReader = await AsyncRecordBatchStreamReader.from(
-        getResult(queryId),
+        getResult(queryId, 100),
       );
       const loadInitialData = async () => {
         await arrowReader.open();

--- a/frontend/src/js/preview/tableUtils.ts
+++ b/frontend/src/js/preview/tableUtils.ts
@@ -4,9 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { CurrencyConfigT, GetQueryResponseDoneT } from "../api/types";
 import { StateT } from "../app/reducers";
-import {
-  NUMBER_TYPES, currencyFromSymbol
-} from "./util";
+import { NUMBER_TYPES, currencyFromSymbol } from "./util";
 
 export type CellValue = string | Vector;
 
@@ -16,16 +14,19 @@ export function useCustomTableRenderers(queryData: GetQueryResponseDoneT) {
     (state) => state.startup.config.currency,
   );
 
-  const dateFormatter = new Intl.DateTimeFormat(navigator.language, {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  })
-  
-  const currencyFormatter = new Intl.NumberFormat(navigator.language, { style: "currency", currency: currencyFromSymbol(currencyConfig.unit) })
-
   const getRenderFunction = useCallback(
     (cellType: string): ((value: CellValue) => string) => {
+      const dateFormatter = new Intl.DateTimeFormat(navigator.language, {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+      });
+
+      const currencyFormatter = new Intl.NumberFormat(navigator.language, {
+        style: "currency",
+        currency: currencyFromSymbol(currencyConfig.unit),
+      });
+
       if (cellType.indexOf("LIST") == 0) {
         const listType = cellType.match(/LIST\[(?<listtype>.*)\]/)?.groups?.[
           "listtype"
@@ -44,55 +45,56 @@ export function useCustomTableRenderers(queryData: GetQueryResponseDoneT) {
         const numnberFormatter = new Intl.NumberFormat(navigator.language, {
           maximumFractionDigits: 2,
           minimumFractionDigits: cellType == "INTEGER" ? 0 : 2,
-        })
-      
+        });
+
         return (value) => {
           if (value && !isNaN(value as unknown as number)) {
-            return numnberFormatter.format(value as unknown as number)
+            return numnberFormatter.format(value as unknown as number);
           }
           return "";
         };
       } else if (cellType == "DATE") {
         return (value) => dateFormatter.format(value as unknown as Date);
       } else if (cellType == "DATE_RANGE") {
-      
         return (value) => {
-          const vector = value as unknown as { min: Date, max: Date };
-      
+          const vector = value as unknown as { min: Date; max: Date };
+
           const min = dateFormatter.format(vector.min);
           const max = dateFormatter.format(vector.max);
-      
+
           if (min == max) {
-            return min
+            return min;
           }
-      
+
           return `${min} - ${max}`;
         };
-      } else if (cellType == "MONEY") {      
+      } else if (cellType == "MONEY") {
         return (value) => {
           if (value && !isNaN(value as unknown as number)) {
-            return currencyFormatter.format(value as unknown as number)
+            return currencyFormatter.format(value as unknown as number);
           }
-          return ""
+          return "";
         };
       } else if (cellType == "BOOLEAN") {
         return (value) => (value ? t("common.true") : t("common.false"));
       }
 
-      return (value) => value ? value as string : ""
+      return (value) => (value ? (value as string) : "");
     },
     [currencyConfig.unit, t],
   );
 
   const getRenderFunctionByFieldName = useCallback(
     (fieldName: string): ((value: CellValue) => string) => {
-      const cellType = (queryData as GetQueryResponseDoneT).columnDescriptions?.find((x) => x.label == fieldName)?.type;
-      
+      const cellType = (
+        queryData as GetQueryResponseDoneT
+      ).columnDescriptions?.find((x) => x.label == fieldName)?.type;
+
       if (cellType) {
         return getRenderFunction(cellType);
       }
 
-      return (value) => value ? value as string : ""
+      return (value) => (value ? (value as string) : "");
     },
     [getRenderFunction, queryData],
   );

--- a/frontend/src/js/preview/util.ts
+++ b/frontend/src/js/preview/util.ts
@@ -5,14 +5,8 @@ export const NUMBER_TYPES = ["NUMERIC", "INTEGER"];
 export const NUMBER_STATISTICS_TYPES = [...NUMBER_TYPES, "MONEY"];
 
 export function currencyFromSymbol(symbol: string): string {
-  //TODO this is a workaround until the backend sends currency-codes
-  if (symbol == "€") {
-    return "EUR";
-  }
-
-  if (symbol == "$") {
-    return "USD";
-  }
+  // TODO: this is a workaround until the backend sends currency-codes
+  if (symbol === "€") return "EUR";
 
   return "USD";
 }

--- a/frontend/src/js/preview/util.ts
+++ b/frontend/src/js/preview/util.ts
@@ -4,19 +4,17 @@ export const NUMBER_TYPES = ["NUMERIC", "INTEGER"];
 
 export const NUMBER_STATISTICS_TYPES = [...NUMBER_TYPES, "MONEY"];
 
-
-
-export function currencyFromSymbol(symbol: string) : string {
+export function currencyFromSymbol(symbol: string): string {
   //TODO this is a workaround until the backend sends currency-codes
-  if(symbol == "€"){
-    return "EUR"
+  if (symbol == "€") {
+    return "EUR";
   }
 
-  if(symbol == "$"){
-    return "USD"
+  if (symbol == "$") {
+    return "USD";
   }
 
-  return "USD"
+  return "USD";
 }
 
 export function formatNumber(
@@ -31,7 +29,6 @@ export function formatNumber(
     minimumFractionDigits: forceFractionDigits ? precision : undefined,
   }).format(num);
 }
-
 
 export function previewStatsIsBarStats(
   stats: PreviewStatistics,

--- a/frontend/src/js/preview/util.ts
+++ b/frontend/src/js/preview/util.ts
@@ -1,10 +1,23 @@
-import { t } from "i18next";
 import { BarStatistics, DateStatistics, PreviewStatistics } from "../api/types";
-import { parseDate } from "../common/helpers/dateHelper";
 
 export const NUMBER_TYPES = ["NUMERIC", "INTEGER"];
 
 export const NUMBER_STATISTICS_TYPES = [...NUMBER_TYPES, "MONEY"];
+
+
+
+export function currencyFromSymbol(symbol: string) : string {
+  //TODO this is a workaround until the backend sends currency-codes
+  if(symbol == "€"){
+    return "EUR"
+  }
+
+  if(symbol == "$"){
+    return "USD"
+  }
+
+  return "USD"
+}
 
 export function formatNumber(
   num: number,
@@ -19,21 +32,6 @@ export function formatNumber(
   }).format(num);
 }
 
-export function formatDate(date: string | undefined) {
-  if (date) {
-    const parsedDate = parseDate(date, "yyyy-MM-dd");
-    return parsedDate ? toFullLocaleDateString(parsedDate) : date;
-  }
-  return t("preview.dateError");
-}
-
-export function toFullLocaleDateString(date: Date) {
-  return date.toLocaleDateString(navigator.language, {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}
 
 export function previewStatsIsBarStats(
   stats: PreviewStatistics,


### PR DESCRIPTION
Die Methoden auszulagern fehlt mir die Zeit aktuell, würde den Code aber deutlich lesbarer machen.
Ich werde demnächst einen PR stellen, indem ich das mit der currency-Code richtig implementiere, dann ist das auch sauberer.