### PR TITLE
Improve how we load and reset entity history

### DIFF
--- a/frontend/src/js/entity-history/actions.ts
+++ b/frontend/src/js/entity-history/actions.ts
@@ -29,6 +29,7 @@ import { useDatasetId } from "../dataset/selectors";
 import { loadCSV, parseCSVWithHeaderToObj } from "../file/csv";
 import { setMessage } from "../snack-message/actions";
 
+import { canViewEntityPreview } from "../user/selectors";
 import { EntityEvent, EntityId } from "./reducer";
 import { isDateColumn, isSourceColumn } from "./timeline/util";
 
@@ -50,11 +51,18 @@ export const loadDefaultHistoryParamsSuccess = createAction(
 
 export const useLoadDefaultHistoryParams = () => {
   const dispatch = useDispatch();
+
+  const canViewHistory = useSelector<StateT, boolean>(canViewEntityPreview);
+  const canViewHistoryRef = useRef(canViewHistory);
+  canViewHistoryRef.current = canViewHistory;
+
   const getEntityHistoryDefaultParams = useGetEntityHistoryDefaultParams();
 
   return useCallback(
     async (datasetId: DatasetT["id"]) => {
       try {
+        if (!canViewHistoryRef.current) return;
+
         const result = await getEntityHistoryDefaultParams(datasetId);
 
         dispatch(loadDefaultHistoryParamsSuccess(result));

--- a/frontend/src/js/entity-history/reducer.ts
+++ b/frontend/src/js/entity-history/reducer.ts
@@ -113,6 +113,7 @@ export default function reducer(
     case getType(resetHistory):
       return {
         ...state,
+        defaultParams: initialState.defaultParams,
         label: "",
         columns: {},
         columnDescriptions: [],

--- a/frontend/src/js/startup/useStartup.ts
+++ b/frontend/src/js/startup/useStartup.ts
@@ -15,12 +15,15 @@ export const useStartup = ({ ready }: { ready?: boolean }) => {
   const loadMe = useLoadMe();
 
   useEffect(() => {
-    dispatch(resetMessage());
+    async function load() {
+      dispatch(resetMessage());
 
-    if (ready) {
-      loadConfig();
-      loadDatasets();
-      loadMe();
+      if (ready) {
+        await Promise.all([loadMe(), loadConfig()]);
+
+        loadDatasets();
+      }
     }
+    load();
   }, [dispatch, ready, loadConfig, loadDatasets, loadMe]);
 };


### PR DESCRIPTION
- Always load /me (including permissions) before loading datasets and entity history
- Check history view permissions before loading /entity-preview
- Reset entity-preview state when history is being reset

This should ensure that no old entity-preview config is being used when switching the dataset and that there's no attempt at loading entity-preview, when there's no permission to viewing the history.