### PR TITLE
Fix SQL config defaults and validation

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/config/DatabaseConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/DatabaseConfig.java
@@ -2,9 +2,11 @@ package com.bakdata.conquery.models.config;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
 
 @Data
 @Builder
+@Jacksonized
 public class DatabaseConfig {
 
 	private static final String DEFAULT_PRIMARY_COLUMN = "pid";

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -39,7 +39,10 @@ public class SqlConnectorConfig {
 
 	@ValidationMethod(message = "At lease 1 DatabaseConfig has to be present if SqlConnector config is enabled")
 	public boolean isValidSqlConnectorConfig() {
-		return enabled && databaseConfigs != null && !databaseConfigs.isEmpty();
+		if (!enabled) {
+			return true;
+		}
+		return databaseConfigs != null && !databaseConfigs.isEmpty();
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.config;
 import java.util.Map;
 
 import com.bakdata.conquery.models.datasets.Dataset;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,9 +11,11 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.extern.jackson.Jacksonized;
 
 @Data
 @Builder
+@Jacksonized
 @NoArgsConstructor
 @AllArgsConstructor
 public class SqlConnectorConfig {

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.config;
 import java.util.Map;
 
 import com.bakdata.conquery.models.datasets.Dataset;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.dropwizard.validation.ValidationMethod;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
@@ -37,6 +38,7 @@ public class SqlConnectorConfig {
 		return databaseConfigs.get(dataset.getName());
 	}
 
+	@JsonIgnore
 	@ValidationMethod(message = "At lease 1 DatabaseConfig has to be present if SqlConnector config is enabled")
 	public boolean isValidSqlConnectorConfig() {
 		if (!enabled) {

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -29,7 +29,7 @@ public class SqlConnectorConfig {
 	 */
 	@NonNull
 	@Getter(AccessLevel.PRIVATE)
-	private Map<String, DatabaseConfig> databaseConfigs;
+	private Map<String, @Valid DatabaseConfig> databaseConfigs;
 
 	public DatabaseConfig getDatabaseConfig(Dataset dataset) {
 		return databaseConfigs.get(dataset.getName());

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -3,6 +3,7 @@ package com.bakdata.conquery.models.config;
 import java.util.Map;
 
 import com.bakdata.conquery.models.datasets.Dataset;
+import io.dropwizard.validation.ValidationMethod;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,7 +11,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
 @Data
@@ -30,12 +30,16 @@ public class SqlConnectorConfig {
 	/**
 	 * Keys must match the name of existing {@link Dataset}s.
 	 */
-	@NonNull
 	@Getter(AccessLevel.PRIVATE)
 	private Map<String, @Valid DatabaseConfig> databaseConfigs;
 
 	public DatabaseConfig getDatabaseConfig(Dataset dataset) {
 		return databaseConfigs.get(dataset.getName());
+	}
+
+	@ValidationMethod(message = "At lease 1 DatabaseConfig has to be present if SqlConnector config is enabled")
+	public boolean isValidSqlConnectorConfig() {
+		return enabled && databaseConfigs != null && !databaseConfigs.isEmpty();
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @Builder
@@ -26,6 +27,7 @@ public class SqlConnectorConfig {
 	/**
 	 * Keys must match the name of existing {@link Dataset}s.
 	 */
+	@NonNull
 	@Getter(AccessLevel.PRIVATE)
 	private Map<String, DatabaseConfig> databaseConfigs;
 

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/Table.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/Table.java
@@ -41,7 +41,7 @@ public class Table extends Labeled<TableId> implements NamespacedIdentifiable<Ta
 	 */
 	@Nullable
 	@JsonManagedReference
-	private Column primaryColum;
+	private Column primaryColumn;
 
 	@ValidationMethod(message = "More than one column map to the same secondaryId")
 	@JsonIgnore

--- a/backend/src/main/java/com/bakdata/conquery/util/TablePrimaryColumnUtil.java
+++ b/backend/src/main/java/com/bakdata/conquery/util/TablePrimaryColumnUtil.java
@@ -2,15 +2,17 @@ package com.bakdata.conquery.util;
 
 import com.bakdata.conquery.models.config.DatabaseConfig;
 import com.bakdata.conquery.models.datasets.Table;
+import lombok.extern.slf4j.Slf4j;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
+@Slf4j
 public class TablePrimaryColumnUtil {
 
-	public static Field<Object> findPrimaryColumn(Table table, DatabaseConfig sqlConfig) {
-		String primaryColumnName = table.getPrimaryColum() == null
-								   ? sqlConfig.getPrimaryColumn()
-								   : table.getPrimaryColum().getName();
+	public static Field<Object> findPrimaryColumn(Table table, DatabaseConfig databaseConfig) {
+		String primaryColumnName = table.getPrimaryColumn() == null
+								   ? databaseConfig.getPrimaryColumn()
+								   : table.getPrimaryColumn().getName();
 		return DSL.field(DSL.name(table.getName(), primaryColumnName));
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/util/TablePrimaryColumnUtil.java
+++ b/backend/src/main/java/com/bakdata/conquery/util/TablePrimaryColumnUtil.java
@@ -2,11 +2,9 @@ package com.bakdata.conquery.util;
 
 import com.bakdata.conquery.models.config.DatabaseConfig;
 import com.bakdata.conquery.models.datasets.Table;
-import lombok.extern.slf4j.Slf4j;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
-@Slf4j
 public class TablePrimaryColumnUtil {
 
 	public static Field<Object> findPrimaryColumn(Table table, DatabaseConfig databaseConfig) {

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/RequiredTable.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/RequiredTable.java
@@ -40,7 +40,7 @@ public class RequiredTable {
 
     public Table toTable(Dataset dataset, CentralRegistry centralRegistry) {
         Table table = new Table();
-		table.setPrimaryColum(primaryColumn.toColumn(table, centralRegistry));
+		table.setPrimaryColumn(primaryColumn.toColumn(table, centralRegistry));
         table.setDataset(dataset);
         table.setName(name);
         table.setColumns(Arrays.stream(columns)


### PR DESCRIPTION
Denkst du, es ergibt Sinn, in den Configs Konstruktoren einzuführen, die auf die default-Werte Rücksicht nehmen, z.B. so: 

```java
@Data
@Builder
public class DatabaseConfig {

	private static final String DEFAULT_PRIMARY_COLUMN = "pid";

	private Dialect dialect;

	private String databaseUsername;

	private String databasePassword;

	private String jdbcConnectionUrl;

	@Builder.Default
	private String primaryColumn = DEFAULT_PRIMARY_COLUMN;

	@JsonCreator
	public DatabaseConfig(
			@JsonProperty("dialect") Dialect dialect,
			@JsonProperty("databaseUsername") String databaseUsername,
			@JsonProperty("databasePassword") String databasePassword,
			@JsonProperty("jdbcConnectionUrl") String jdbcConnectionUrl,
			@JsonProperty("primaryColumn") String primaryColumn
	) {
		this.dialect = dialect;
		this.databaseUsername = databaseUsername;
		this.databasePassword = databasePassword;
		this.jdbcConnectionUrl = jdbcConnectionUrl;
		this.primaryColumn = (primaryColumn != null) ? primaryColumn : DEFAULT_PRIMARY_COLUMN;
	}

}
```

Oder gibt es dafür eine elegantere Lösung? Mir war das vorher nicht so klar, dass Jackson die defaults (lombok Builder.Default, aber auch statische Werte) nicht einfach übernimmt. 