### PR TITLE
Fix FAILED executions in SQL mode

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlExecutionManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlExecutionManager.java
@@ -78,6 +78,11 @@ public class SqlExecutionManager extends ExecutionManager<SqlExecutionResult> {
 									managedQuery.setLastResultCount(((long) result.getRowCount()));
 									managedQuery.finish(ExecutionState.DONE);
 									runningExecutions.remove(managedQuery.getId());
+								})
+								.exceptionally(e -> {
+									managedQuery.finish(ExecutionState.FAILED);
+									runningExecutions.remove(managedQuery.getId());
+									return null;
 								});
 	}
 


### PR DESCRIPTION
Bisher sind die `Executions` sonst nie auf den `FAILED` State gesetzt worden, weil die Fehler in den `CompletableFutures` nicht behandelt wurden.