### PR TITLE
remove parameterization so subclasses can use an initializer

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/io/jackson/Initializing.java
+++ b/backend/src/main/java/com/bakdata/conquery/io/jackson/Initializing.java
@@ -11,12 +11,14 @@ import com.fasterxml.jackson.databind.util.StdConverter;
  *  }
  * </pre>
  * @param <T>
+ * @implNote Every class that inherits from an initializing class needs to define its own Converter.
+ * Otherwise, the class is parsed as the super class, and its overrides are not called.
  */
-public interface Initializing<T extends Initializing<T>> {
+public interface Initializing {
 
-	T init();
+	void init();
 
-	class Converter<T extends Initializing<T>> extends StdConverter<T, T> {
+	class Converter<T extends Initializing> extends StdConverter<T, T> {
 
 		@Override
 		public T convert(T value) {

--- a/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/tree/TreeConcept.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/datasets/concepts/tree/TreeConcept.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @CPSType(id = "TREE", base = Concept.class)
 @JsonDeserialize(converter = TreeConcept.TreeConceptInitializer.class)
-public class TreeConcept extends Concept<ConceptTreeConnector> implements ConceptTreeNode<ConceptId>, SelectHolder<UniversalSelect>, Initializing<TreeConcept> {
+public class TreeConcept extends Concept<ConceptTreeConnector> implements ConceptTreeNode<ConceptId>, SelectHolder<UniversalSelect>, Initializing {
 
 	@JsonIgnore
 	@Getter
@@ -90,7 +90,7 @@ public class TreeConcept extends Concept<ConceptTreeConnector> implements Concep
 		return conceptPrefix != null && conceptPrefix[0] == 0;
 	}
 
-	public TreeConcept init() {
+	public void init() {
 		setLocalId(0);
 		localIdMap.add(this);
 
@@ -124,8 +124,6 @@ public class TreeConcept extends Concept<ConceptTreeConnector> implements Concep
 
 			openList.addAll((openList.get(i)).getChildren());
 		}
-
-		return this;
 	}
 
 	public ConceptElement findMostSpecificChild(String stringValue, CalculatedValue<Map<String, Object>> rowMap) throws ConceptConfigurationException {

--- a/backend/src/main/java/com/bakdata/conquery/models/index/InternToExternMapper.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/index/InternToExternMapper.java
@@ -12,7 +12,7 @@ public interface InternToExternMapper extends NamespacedIdentifiable<InternToExt
 
 	boolean initialized();
 
-	InternToExternMapper init();
+	void init();
 
 	String external(String internalValue);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/index/MapInternToExternMapper.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/index/MapInternToExternMapper.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.TestOnly;
 @Getter
 @JsonDeserialize(converter = MapInternToExternMapper.Initializer.class )
 @EqualsAndHashCode(callSuper = true)
-public class MapInternToExternMapper extends NamedImpl<InternToExternMapperId> implements InternToExternMapper, NamespacedIdentifiable<InternToExternMapperId>, Initializing<MapInternToExternMapper> {
+public class MapInternToExternMapper extends NamedImpl<InternToExternMapperId> implements InternToExternMapper, NamespacedIdentifiable<InternToExternMapperId>, Initializing {
 
 
 	// We inject the service as a non-final property so, jackson will never try to create a serializer for it (in contrast to constructor injection)
@@ -88,11 +88,11 @@ public class MapInternToExternMapper extends NamedImpl<InternToExternMapperId> i
 
 
 	@Override
-	public synchronized MapInternToExternMapper init() {
+	public synchronized void init() {
 
 		if (mapIndex == null && config == null) {
 			log.trace("Injections were null. Skipping init, because class was deserialized by a test object mapper");
-			return this;
+			return;
 		}
 
 		dataset = storage.getDataset();
@@ -114,8 +114,6 @@ public class MapInternToExternMapper extends NamedImpl<InternToExternMapperId> i
 				log.warn("Unable to get index: {} (enable TRACE for exception)", key, (Exception) (log.isTraceEnabled() ? e : null));
 			}
 		});
-
-		return this;
 	}
 
 


### PR DESCRIPTION
Before subclassing e.g. `TreeConcept` did not work because java did not allow `SubTreeConcept implement Initializing<SubTreeConcept>`

Without a distinct `Initializing.Convert` for `SubTreeConcept` it would be parsed as a `TreeConcept` and none of its Method overrides would be called.