### PR TITLE
enable healthcheck for sql connection

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
+++ b/backend/src/main/java/com/bakdata/conquery/commands/ManagerNode.java
@@ -241,7 +241,7 @@ public class ManagerNode implements Managed {
 		final Collection<NamespaceStorage> namespaceStorages = getConfig().getStorage().discoverNamespaceStorages();
 		for (NamespaceStorage namespaceStorage : namespaceStorages) {
 			loaders.submit(() -> {
-				registry.createNamespace(namespaceStorage, getMetaStorage());
+				registry.createNamespace(namespaceStorage, getMetaStorage(), getEnvironment());
 			});
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/NamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/NamespaceHandler.java
@@ -15,6 +15,7 @@ import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.query.FilterSearch;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.core.setup.Environment;
 
 /**
  * Handler of namespaces in a ConQuery instance.
@@ -23,7 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public interface NamespaceHandler<N extends Namespace> {
 
-	N createNamespace(NamespaceStorage storage, MetaStorage metaStorage, IndexService indexService);
+	N createNamespace(NamespaceStorage storage, MetaStorage metaStorage, IndexService indexService, Environment environment);
 
 	void removeNamespace(DatasetId id, N namespace);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
@@ -14,6 +14,7 @@ import com.bakdata.conquery.models.query.DistributedExecutionManager;
 import com.bakdata.conquery.models.worker.DistributedNamespace;
 import com.bakdata.conquery.models.worker.ShardNodeInformation;
 import com.bakdata.conquery.models.worker.WorkerHandler;
+import io.dropwizard.core.setup.Environment;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -23,7 +24,7 @@ public class ClusterNamespaceHandler implements NamespaceHandler<DistributedName
 	private final InternalObjectMapperCreator mapperCreator;
 
 	@Override
-	public DistributedNamespace createNamespace(NamespaceStorage storage, final MetaStorage metaStorage, IndexService indexService) {
+	public DistributedNamespace createNamespace(NamespaceStorage storage, final MetaStorage metaStorage, IndexService indexService, Environment environment) {
 		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(storage, config, mapperCreator, indexService);
 		DistributedExecutionManager executionManager = new DistributedExecutionManager(metaStorage, clusterState);
 		WorkerHandler workerHandler = new WorkerHandler(namespaceData.getCommunicationMapper(), storage);

--- a/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
@@ -24,6 +24,7 @@ import com.bakdata.conquery.sql.execution.ResultSetProcessor;
 import com.bakdata.conquery.sql.execution.ResultSetProcessorFactory;
 import com.bakdata.conquery.sql.execution.SqlExecutionResult;
 import com.bakdata.conquery.sql.execution.SqlExecutionService;
+import io.dropwizard.core.setup.Environment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -37,7 +38,7 @@ public class LocalNamespaceHandler implements NamespaceHandler<LocalNamespace> {
 	private final SqlDialectFactory dialectFactory;
 
 	@Override
-	public LocalNamespace createNamespace(NamespaceStorage namespaceStorage, MetaStorage metaStorage, IndexService indexService) {
+	public LocalNamespace createNamespace(NamespaceStorage namespaceStorage, MetaStorage metaStorage, IndexService indexService, Environment environment) {
 
 		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(namespaceStorage, config, mapperCreator, indexService);
 
@@ -45,7 +46,7 @@ public class LocalNamespaceHandler implements NamespaceHandler<LocalNamespace> {
 		SqlConnectorConfig sqlConnectorConfig = config.getSqlConnectorConfig();
 		DatabaseConfig databaseConfig = sqlConnectorConfig.getDatabaseConfig(namespaceStorage.getDataset());
 
-		DSLContextWrapper dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConnectorConfig);
+		DSLContextWrapper dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConnectorConfig, environment.healthChecks());
 		DSLContext dslContext = dslContextWrapper.getDslContext();
 		SqlDialect sqlDialect = dialectFactory.createSqlDialect(databaseConfig.getDialect());
 

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -1,11 +1,12 @@
 package com.bakdata.conquery.models.config;
 
 import java.util.Map;
+import jakarta.validation.Valid;
 
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.dropwizard.util.Duration;
 import io.dropwizard.validation.ValidationMethod;
-import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,6 +31,11 @@ public class SqlConnectorConfig {
 	 * Keys must match the name of existing {@link Dataset}s.
 	 */
 	private Map<String, @Valid DatabaseConfig> databaseConfigs;
+
+	/**
+	 * Timeout duration after which a database connection is considered unhealthy (defaults to connection timeout)
+	 */
+	private Duration connectivityCheckTimeout;
 
 	public DatabaseConfig getDatabaseConfig(Dataset dataset) {
 		return databaseConfigs.get(dataset.getName());

--- a/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/worker/DatasetRegistry.java
@@ -28,6 +28,7 @@ import com.bakdata.conquery.models.index.IndexService;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheStats;
+import io.dropwizard.core.setup.Environment;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +51,7 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 
 	private final IndexService indexService;
 
-	public N createNamespace(Dataset dataset, MetaStorage metaStorage) throws IOException {
+	public N createNamespace(Dataset dataset, MetaStorage metaStorage, Environment environment) throws IOException {
 		// Prepare empty storage
 		NamespaceStorage datasetStorage = new NamespaceStorage(config.getStorage(), "dataset_" + dataset.getName());
 		final ObjectMapper persistenceMapper = internalObjectMapperCreator.createInternalObjectMapper(View.Persistence.Manager.class);
@@ -63,11 +64,11 @@ public class DatasetRegistry<N extends Namespace> extends IdResolveContext imple
 		datasetStorage.setPreviewConfig(new PreviewConfig());
 		datasetStorage.close();
 
-		return createNamespace(datasetStorage, metaStorage);
+		return createNamespace(datasetStorage, metaStorage, environment);
 	}
 
-	public N createNamespace(NamespaceStorage datasetStorage, MetaStorage metaStorage) {
-		final N namespace = namespaceHandler.createNamespace(datasetStorage, metaStorage, indexService);
+	public N createNamespace(NamespaceStorage datasetStorage, MetaStorage metaStorage, Environment environment) {
+		final N namespace = namespaceHandler.createNamespace(datasetStorage, metaStorage, indexService, environment);
 		add(namespace);
 		return namespace;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/AdminServlet.java
@@ -19,8 +19,28 @@ import com.bakdata.conquery.models.auth.web.csrf.CsrfTokenSetFilter;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
-import com.bakdata.conquery.resources.admin.rest.*;
-import com.bakdata.conquery.resources.admin.ui.*;
+import com.bakdata.conquery.resources.admin.rest.AdminConceptsResource;
+import com.bakdata.conquery.resources.admin.rest.AdminDatasetProcessor;
+import com.bakdata.conquery.resources.admin.rest.AdminDatasetResource;
+import com.bakdata.conquery.resources.admin.rest.AdminDatasetsResource;
+import com.bakdata.conquery.resources.admin.rest.AdminProcessor;
+import com.bakdata.conquery.resources.admin.rest.AdminResource;
+import com.bakdata.conquery.resources.admin.rest.AdminTablesResource;
+import com.bakdata.conquery.resources.admin.rest.AuthOverviewResource;
+import com.bakdata.conquery.resources.admin.rest.GroupResource;
+import com.bakdata.conquery.resources.admin.rest.PermissionResource;
+import com.bakdata.conquery.resources.admin.rest.RoleResource;
+import com.bakdata.conquery.resources.admin.rest.UIProcessor;
+import com.bakdata.conquery.resources.admin.rest.UserResource;
+import com.bakdata.conquery.resources.admin.ui.AdminUIResource;
+import com.bakdata.conquery.resources.admin.ui.AuthOverviewUIResource;
+import com.bakdata.conquery.resources.admin.ui.ConceptsUIResource;
+import com.bakdata.conquery.resources.admin.ui.DatasetsUIResource;
+import com.bakdata.conquery.resources.admin.ui.GroupUIResource;
+import com.bakdata.conquery.resources.admin.ui.IndexServiceUIResource;
+import com.bakdata.conquery.resources.admin.ui.RoleUIResource;
+import com.bakdata.conquery.resources.admin.ui.TablesUIResource;
+import com.bakdata.conquery.resources.admin.ui.UserUIResource;
 import com.bakdata.conquery.resources.admin.ui.model.ConnectorUIResource;
 import io.dropwizard.core.setup.AdminEnvironment;
 import io.dropwizard.jersey.DropwizardResourceConfig;
@@ -79,12 +99,12 @@ public class AdminServlet {
 
 		adminDatasetProcessor = new AdminDatasetProcessor(
 				manager.getConfig(),
-				manager.getValidator(),
 				manager.getDatasetRegistry(),
 				manager.getMetaStorage(),
 				manager.getJobManager(),
 				manager.getImportHandler(),
-				manager.getStorageListener()
+				manager.getStorageListener(),
+				manager.getEnvironment()
 		);
 
 		jerseyConfig.register(new AbstractBinder() {

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetProcessor.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import jakarta.inject.Inject;
-import jakarta.validation.Validator;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
@@ -42,6 +41,7 @@ import com.bakdata.conquery.models.jobs.JobManager;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.univocity.parsers.csv.CsvParser;
+import io.dropwizard.core.setup.Environment;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -58,12 +58,13 @@ public class AdminDatasetProcessor {
 	private static final String ABBREVIATION_MARKER = "\u2026";
 
 	private final ConqueryConfig config;
-	private final Validator validator;
 	private final DatasetRegistry<? extends Namespace> datasetRegistry;
 	private final MetaStorage metaStorage;
 	private final JobManager jobManager;
 	private final ImportHandler importHandler;
 	private final StorageListener storageListener;
+	private final Environment environment;
+
 
 
 	/**
@@ -76,7 +77,7 @@ public class AdminDatasetProcessor {
 			throw new WebApplicationException("Dataset already exists", Response.Status.CONFLICT);
 		}
 
-		return datasetRegistry.createNamespace(dataset, metaStorage).getDataset();
+		return datasetRegistry.createNamespace(dataset, metaStorage, environment).getDataset();
 	}
 
 	/**
@@ -168,7 +169,7 @@ public class AdminDatasetProcessor {
 			throw new WebApplicationException("Table already exists", Response.Status.CONFLICT);
 		}
 
-		ValidatorHelper.failOnError(log, validator.validate(table));
+		ValidatorHelper.failOnError(log, environment.getValidator().validate(table));
 
 		namespace.getStorage().addTable(table);
 		storageListener.onAddTable(table);
@@ -194,7 +195,7 @@ public class AdminDatasetProcessor {
 	 */
 	public synchronized void addConcept(@NonNull Dataset dataset, @NonNull Concept<?> concept, boolean force) {
 		concept.setDataset(dataset);
-		ValidatorHelper.failOnError(log, validator.validate(concept));
+		ValidatorHelper.failOnError(log, environment.getValidator().validate(concept));
 
 		if (datasetRegistry.get(dataset.getId()).getStorage().hasConcept(concept.getId())) {
 			if (!force) {
@@ -215,7 +216,7 @@ public class AdminDatasetProcessor {
 	public void setPreviewConfig(PreviewConfig previewConfig, Namespace namespace) {
 		log.info("Received new {}", previewConfig);
 
-		ValidatorHelper.failOnError(log, getValidator().validate(previewConfig));
+		ValidatorHelper.failOnError(log, environment.getValidator().validate(previewConfig));
 
 		namespace.getStorage().setPreviewConfig(previewConfig);
 	}
@@ -327,7 +328,7 @@ public class AdminDatasetProcessor {
 	}
 
 	public void addInternToExternMapping(Namespace namespace, InternToExternMapper internToExternMapper) {
-		ValidatorHelper.failOnError(log, validator.validate(internToExternMapper));
+		ValidatorHelper.failOnError(log, environment.getValidator().validate(internToExternMapper));
 
 		if (namespace.getStorage().getInternToExternMapper(internToExternMapper.getId()) != null) {
 			throw new WebApplicationException("InternToExternMapping already exists", Response.Status.CONFLICT);
@@ -371,7 +372,7 @@ public class AdminDatasetProcessor {
 	public void addSearchIndex(Namespace namespace, SearchIndex searchIndex) {
 		searchIndex.setDataset(namespace.getDataset());
 
-		ValidatorHelper.failOnError(log, validator.validate(searchIndex));
+		ValidatorHelper.failOnError(log, environment.getValidator().validate(searchIndex));
 
 		if (namespace.getStorage().getSearchIndex(searchIndex.getId()) != null) {
 			throw new WebApplicationException("InternToExternMapping already exists", Response.Status.CONFLICT);

--- a/backend/src/main/java/com/bakdata/conquery/sql/DslContextFactory.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/DslContextFactory.java
@@ -24,6 +24,10 @@ public class DslContextFactory {
 
 		if (healthCheckRegistry != null) {
 			hikariConfig.setHealthCheckRegistry(healthCheckRegistry);
+			if (connectorConfig.getConnectivityCheckTimeout() != null) {
+				long connectivityTimeoutMs = connectorConfig.getConnectivityCheckTimeout().toMilliseconds();
+				hikariConfig.addHealthCheckProperty("connectivityCheckTimeoutMs", Long.toString(connectivityTimeoutMs));
+			}
 		}
 
 		HikariDataSource hikariDataSource = new HikariDataSource(hikariConfig);

--- a/backend/src/main/java/com/bakdata/conquery/sql/DslContextFactory.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/DslContextFactory.java
@@ -1,7 +1,10 @@
 package com.bakdata.conquery.sql;
 
+import javax.annotation.Nullable;
+
 import com.bakdata.conquery.models.config.DatabaseConfig;
 import com.bakdata.conquery.models.config.SqlConnectorConfig;
+import com.codahale.metrics.health.HealthCheckRegistry;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.jooq.DSLContext;
@@ -12,12 +15,16 @@ import org.jooq.impl.DSL;
 
 public class DslContextFactory {
 
-	public static DSLContextWrapper create(DatabaseConfig config, SqlConnectorConfig connectorConfig) {
+	public static DSLContextWrapper create(DatabaseConfig config, SqlConnectorConfig connectorConfig, @Nullable HealthCheckRegistry healthCheckRegistry) {
 
 		HikariConfig hikariConfig = new HikariConfig();
 		hikariConfig.setJdbcUrl(config.getJdbcConnectionUrl());
 		hikariConfig.setUsername(config.getDatabaseUsername());
 		hikariConfig.setPassword(config.getDatabasePassword());
+
+		if (healthCheckRegistry != null) {
+			hikariConfig.setHealthCheckRegistry(healthCheckRegistry);
+		}
 
 		HikariDataSource hikariDataSource = new HikariDataSource(hikariConfig);
 

--- a/backend/src/test/java/com/bakdata/conquery/integration/sql/dialect/HanaSqlIntegrationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/sql/dialect/HanaSqlIntegrationTests.java
@@ -177,7 +177,7 @@ public class HanaSqlIntegrationTests extends IntegrationTests {
 												.databasePassword(hanaContainer.getPassword())
 												.build();
 			this.sqlConnectorConfig = new TestSqlConnectorConfig(databaseConfig);
-			this.dslContextWrapper = DslContextFactory.create(this.databaseConfig, sqlConnectorConfig);
+			this.dslContextWrapper = DslContextFactory.create(this.databaseConfig, sqlConnectorConfig, null);
 		}
 
 	}
@@ -202,7 +202,7 @@ public class HanaSqlIntegrationTests extends IntegrationTests {
 												.databasePassword(PASSWORD)
 												.build();
 			this.sqlConnectorConfig = new TestSqlConnectorConfig(databaseConfig);
-			this.dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConnectorConfig);
+			this.dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConnectorConfig, null);
 		}
 
 	}

--- a/backend/src/test/java/com/bakdata/conquery/integration/sql/dialect/PostgreSqlIntegrationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/sql/dialect/PostgreSqlIntegrationTests.java
@@ -1,6 +1,7 @@
 package com.bakdata.conquery.integration.sql.dialect;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.bakdata.conquery.TestTags;
@@ -20,6 +21,7 @@ import com.bakdata.conquery.sql.conversion.supplier.DateNowSupplier;
 import com.bakdata.conquery.sql.execution.ResultSetProcessor;
 import com.bakdata.conquery.sql.execution.ResultSetProcessorFactory;
 import com.bakdata.conquery.sql.execution.SqlExecutionService;
+import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
@@ -48,29 +50,30 @@ public class PostgreSqlIntegrationTests extends IntegrationTests {
 	private static TestSqlConnectorConfig sqlConfig;
 	private static TestSqlDialect testSqlDialect;
 	private static SqlTestDataImporter testDataImporter;
+	private static boolean useLocalPostgresDb = true;
+
+	static {
+		final String USE_LOCAL_POSTGRES_DB = System.getenv("USE_LOCAL_POSTGRES_DB");
+		if (!Strings.isNullOrEmpty(USE_LOCAL_POSTGRES_DB)) {
+			useLocalPostgresDb = Boolean.parseBoolean(USE_LOCAL_POSTGRES_DB);
+		}
+	}
 
 	public PostgreSqlIntegrationTests() {
 		super(ConqueryIntegrationTests.DEFAULT_SQL_TEST_ROOT, "com.bakdata.conquery.integration");
 	}
 
-	@Container
-	private static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER = new PostgreSQLContainer<>(postgreSqlImageName)
-			.withDatabaseName(DATABASE_NAME)
-			.withUsername(USERNAME)
-			.withPassword(PASSWORD);
 
 
 	@BeforeAll
 	static void before() {
-		POSTGRESQL_CONTAINER.start();
-		databaseConfig = DatabaseConfig.builder()
-									   .dialect(Dialect.POSTGRESQL)
-									   .jdbcConnectionUrl(POSTGRESQL_CONTAINER.getJdbcUrl())
-									   .databaseUsername(USERNAME)
-									   .databasePassword(PASSWORD)
-									   .build();
+		TestContextProvider provider = useLocalPostgresDb
+									   ? new PortgresTestcontainerContextProvider()
+									   : new RemotePostgresContextProvider();
+
+		databaseConfig = provider.getDatabaseConfig();
 		sqlConfig = new TestSqlConnectorConfig(databaseConfig);
-		dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConfig);
+		dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConfig, null);
 		testSqlDialect = new TestPostgreSqlDialect();
 		testDataImporter = new SqlTestDataImporter(new CsvTableImporter(dslContextWrapper.getDslContext(), testSqlDialect, databaseConfig));
 	}
@@ -131,4 +134,59 @@ public class PostgreSqlIntegrationTests extends IntegrationTests {
 		}
 	}
 
+	@Getter
+	private static class PortgresTestcontainerContextProvider implements TestContextProvider {
+
+		private final DSLContextWrapper dslContextWrapper;
+		private final DatabaseConfig databaseConfig;
+		private final TestSqlConnectorConfig sqlConnectorConfig;
+
+		@Container
+		private final PostgreSQLContainer<?> postgreSQLContainer;
+
+		public PortgresTestcontainerContextProvider() {
+			this.postgreSQLContainer = new PostgreSQLContainer<>(postgreSqlImageName)
+					.withDatabaseName(DATABASE_NAME)
+					.withUsername(USERNAME)
+					.withPassword(PASSWORD);
+			this.postgreSQLContainer.start();
+			this.databaseConfig = DatabaseConfig.builder()
+										   .dialect(Dialect.POSTGRESQL)
+										   .jdbcConnectionUrl(postgreSQLContainer.getJdbcUrl())
+										   .databaseUsername(USERNAME)
+										   .databasePassword(PASSWORD)
+										   .build();
+
+			this.sqlConnectorConfig = new TestSqlConnectorConfig(databaseConfig);
+			this.dslContextWrapper = DslContextFactory.create(this.databaseConfig, sqlConnectorConfig, null);
+		}
+
+	}
+
+
+	@Getter
+	private static class RemotePostgresContextProvider implements TestContextProvider {
+
+		private final static String PORT = Objects.requireNonNullElse(System.getenv("CONQUERY_SQL_PORT"), "39041");
+		private final static String HOST = System.getenv("CONQUERY_SQL_HOST");
+		private final static String DATABASE = System.getenv("CONQUERY_SQL_DATABASE");
+		private final static String CONNECTION_URL = "jdbc:postgresql://%s:%s/%s".formatted(HOST, PORT, DATABASE);
+		private final static String USERNAME = System.getenv("CONQUERY_SQL_USER");
+		private final static String PASSWORD = System.getenv("CONQUERY_SQL_PASSWORD");
+		private final DSLContextWrapper dslContextWrapper;
+		private final DatabaseConfig databaseConfig;
+		private final TestSqlConnectorConfig sqlConnectorConfig;
+
+		public RemotePostgresContextProvider() {
+			this.databaseConfig = DatabaseConfig.builder()
+												.dialect(Dialect.POSTGRESQL)
+												.jdbcConnectionUrl(CONNECTION_URL)
+												.databaseUsername(USERNAME)
+												.databasePassword(PASSWORD)
+												.build();
+			this.sqlConnectorConfig = new TestSqlConnectorConfig(databaseConfig);
+			this.dslContextWrapper = DslContextFactory.create(databaseConfig, sqlConnectorConfig, null);
+		}
+
+	}
 }

--- a/backend/src/test/java/com/bakdata/conquery/integration/sql/dialect/TestSqlConnectorConfig.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/sql/dialect/TestSqlConnectorConfig.java
@@ -15,7 +15,7 @@ public class TestSqlConnectorConfig extends SqlConnectorConfig {
 	private static final String TEST_DATASET = "test";
 
 	public TestSqlConnectorConfig(DatabaseConfig databaseConfig) {
-		super(true, true, Map.of(TEST_DATASET, databaseConfig));
+		super(true, true, Map.of(TEST_DATASET, databaseConfig), null);
 	}
 
 	@Override

--- a/backend/src/test/java/com/bakdata/conquery/io/AbstractSerializationTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/AbstractSerializationTest.java
@@ -24,6 +24,7 @@ import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.NonPersistentStoreFactory;
 import com.codahale.metrics.SharedMetricRegistries;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.core.setup.Environment;
 import io.dropwizard.jersey.validation.Validators;
 import lombok.Getter;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,7 +66,7 @@ public abstract class AbstractSerializationTest {
 		datasetRegistry = new DatasetRegistry<>(0, config, creator, clusterNamespaceHandler, indexService);
 		creator.init(datasetRegistry);
 
-		namespace = datasetRegistry.createNamespace(new Dataset("serialization_test"), metaStorage);
+		namespace = datasetRegistry.createNamespace(new Dataset("serialization_test"), metaStorage, new Environment(this.getClass().getSimpleName()));
 
 		// Prepare manager meta internal mapper
 		managerMetaInternalMapper = creator.createInternalObjectMapper(View.Persistence.Manager.class);


### PR DESCRIPTION
HealthCheck-Endpoint, when DB is down:
```json
{
  "HikariPool-1.pool.ConnectivityCheck" : {
    "healthy" : false,
    "message" : "HikariPool-1 - Connection is not available, request timed out after 30015ms.",
    "error" : {
      "type" : "java.sql.SQLTransientConnectionException",
      "message" : "HikariPool-1 - Connection is not available, request timed out after 30015ms.",
      "stack" : [ "com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:696)", "com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:181)", "com.zaxxer.hikari.metrics.dropwizard.CodahaleHealthChecker$ConnectivityHealthCheck.check(CodahaleHealthChecker.java:95)", "com.codahale.metrics.health.HealthCheck.execute(HealthCheck.java:374)", "com.codahale.metrics.health.HealthCheckRegistry.runHealthChecks(HealthCheckRegistry.java:184)", "io.dropwizard.metrics.servlets.HealthCheckServlet.runHealthChecks(HealthCheckServlet.java:177)", "io.dropwizard.metrics.servlets.HealthCheckServlet.doGet(HealthCheckServlet.java:146)", "jakarta.servlet.http.HttpServlet.service(HttpServlet.java:500)", "jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)", "io.dropwizard.metrics.servlets.AdminServlet.service(AdminServlet.java:154)", "jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)", "org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)", "org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1665)", "io.dropwizard.jersey.filter.AllowedMethodsFilter.handle(AllowedMethodsFilter.java:46)", "io.dropwizard.jersey.filter.AllowedMethodsFilter.doFilter(AllowedMethodsFilter.java:40)", "org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:202)", "org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1635)", "org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:527)", "org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)", "org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1381)", "org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)", "org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)", "org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)", "org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1303)", "org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)", "io.dropwizard.jetty.RoutingHandler.handle(RoutingHandler.java:52)", "org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)", "org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:822)", "io.dropwizard.jetty.ZipExceptionHandlingGzipHandler.handle(ZipExceptionHandlingGzipHandler.java:26)", "org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:46)", "org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:173)", "org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)", "org.eclipse.jetty.server.Server.handle(Server.java:563)", "org.eclipse.jetty.server.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1598)", "org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:753)", "org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:501)", "org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:287)", "org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)", "org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)", "org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)", "org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:421)", "org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:390)", "org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:277)", "org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:199)", "org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:411)", "org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:969)", "org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1194)", "org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1149)", "java.base/java.lang.Thread.run(Thread.java:840)" ],
      "cause" : {
        "type" : "org.postgresql.util.PSQLException",
        "message" : "Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.",
        "stack" : [ "org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:342)", "org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)", "org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:253)", "org.postgresql.Driver.makeConnection(Driver.java:434)", "org.postgresql.Driver.connect(Driver.java:291)", "com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:138)", "com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:359)", "com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:201)", "com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:470)", "com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:733)", "com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:712)", "java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)", "java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)", "java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)", "java.base/java.lang.Thread.run(Thread.java:840)" ],
        "cause" : {
          "type" : "java.net.ConnectException",
          "message" : "Connection timed out: getsockopt",
          "stack" : [ "java.base/sun.nio.ch.Net.pollConnect(Native Method)", "java.base/sun.nio.ch.Net.pollConnectNow(Net.java:672)", "java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:554)", "java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:602)", "java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)", "java.base/java.net.Socket.connect(Socket.java:633)", "org.postgresql.core.PGStream.createSocket(PGStream.java:243)", "org.postgresql.core.PGStream.<init>(PGStream.java:98)", "org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:132)", "org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:258)", "org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)", "org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:253)", "org.postgresql.Driver.makeConnection(Driver.java:434)", "org.postgresql.Driver.connect(Driver.java:291)", "com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:138)", "com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:359)", "com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:201)", "com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:470)", "com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:733)", "com.zaxxer.hikari.pool.HikariPool$PoolEntryCreator.call(HikariPool.java:712)", "java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)", "java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)", "java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)", "java.base/java.lang.Thread.run(Thread.java:840)" ]
        }
      }
    },
    "duration" : 30015,
    "timestamp" : "2024-08-09T14:03:12.811+02:00"
  },
  "deadlocks" : {
    "healthy" : true,
    "duration" : 0,
    "timestamp" : "2024-08-09T14:03:12.811+02:00"
  }
}
```
when it is up again 
```json
{
  "HikariPool-1.pool.ConnectivityCheck" : {
    "healthy" : true,
    "duration" : 38,
    "timestamp" : "2024-08-09T14:06:46.497+02:00"
  },
  "deadlocks" : {
    "healthy" : true,
    "duration" : 0,
    "timestamp" : "2024-08-09T14:06:46.497+02:00"
  }
}
```

When the DB is down, the health check request returns after the connection/connectivity timeout is over (default 30 s).

The reconnect only works if the database connection could be established upon server start. 