### PR TITLE
Feature/sql config doc

### DIFF
--- a/autodoc/pom.xml
+++ b/autodoc/pom.xml
@@ -5,7 +5,7 @@
 
 
 	<properties>
-		<javaparser.version>3.24.4</javaparser.version>
+        <javaparser.version>3.26.1</javaparser.version>
 	</properties>
 
 	<parent>

--- a/autodoc/src/main/java/com/bakdata/conquery/AutoDoc.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/AutoDoc.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import com.bakdata.conquery.handler.GroupHandler;
 import com.bakdata.conquery.handler.SimpleWriter;
 import com.bakdata.conquery.model.Group;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StaticJavaParser;
 import com.github.powerlibraries.io.Out;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
@@ -17,10 +19,17 @@ import lombok.extern.slf4j.Slf4j;
 public class AutoDoc {
 
 	public static void main(String[] args) throws IOException {
+		configureJavaParser();
+
 		new AutoDoc().start(new File(args.length == 0 ? "./docs/" : args[0]));
 	}
 
-	private ScanResult scan;
+	private static void configureJavaParser() {
+		ParserConfiguration parserConfiguration = StaticJavaParser.getParserConfiguration();
+		parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+	}
+
+	private final ScanResult scan;
 
 	public AutoDoc() {
 		scan = new ClassGraph()

--- a/autodoc/src/main/java/com/bakdata/conquery/Constants.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/Constants.java
@@ -4,6 +4,7 @@ import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.time.ZonedDateTime;
 import java.util.Currency;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import jakarta.ws.rs.DELETE;
@@ -41,12 +42,15 @@ import com.bakdata.conquery.models.config.APIConfig;
 import com.bakdata.conquery.models.config.CSVConfig;
 import com.bakdata.conquery.models.config.ClusterConfig;
 import com.bakdata.conquery.models.config.ConqueryConfig;
+import com.bakdata.conquery.models.config.DatabaseConfig;
+import com.bakdata.conquery.models.config.Dialect;
 import com.bakdata.conquery.models.config.FrontendConfig;
 import com.bakdata.conquery.models.config.LocaleConfig;
 import com.bakdata.conquery.models.config.MinaConfig;
 import com.bakdata.conquery.models.config.PluginConfig;
 import com.bakdata.conquery.models.config.PreprocessingConfig;
 import com.bakdata.conquery.models.config.QueryConfig;
+import com.bakdata.conquery.models.config.SqlConnectorConfig;
 import com.bakdata.conquery.models.config.StandaloneConfig;
 import com.bakdata.conquery.models.config.XodusConfig;
 import com.bakdata.conquery.models.config.XodusStoreFactory;
@@ -129,6 +133,7 @@ public class Constants {
 				 .otherClass(MinaConfig.class)
 				 .otherClass(FrontendConfig.CurrencyConfig.class)
 				 .otherClass(XodusConfig.class)
+				 .otherClasses(List.of(SqlConnectorConfig.class, DatabaseConfig.class, Dialect.class))
 				 .hide(Charset.class)
 				 .hide(Currency.class)
 				 .hide(InetAddress.class)

--- a/autodoc/src/main/java/com/bakdata/conquery/handler/GroupHandler.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/handler/GroupHandler.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import jakarta.ws.rs.core.UriBuilder;
 
 import com.bakdata.conquery.introspection.Introspection;
@@ -98,7 +97,7 @@ public class GroupHandler {
 		}
 		if (!endpoints.isEmpty()) {
 			out.heading("REST endpoints");
-			for (Pair<String, MethodInfo> endpoint : endpoints.stream().sorted(Comparator.comparing(Pair::getLeft)).collect(Collectors.toList())) {
+			for (Pair<String, MethodInfo> endpoint : endpoints.stream().sorted(Comparator.comparing(Pair::getLeft)).toList()) {
 				handleEndpoint(endpoint.getLeft(), endpoint.getRight());
 			}
 		}
@@ -108,13 +107,13 @@ public class GroupHandler {
 		}
 
 		out.subHeading("Other Types");
-		for (Class<?> t : group.getOtherClasses().stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toList())) {
+		for (Class<?> t : group.getOtherClasses().stream().sorted(Comparator.comparing(Class::getSimpleName)).toList()) {
 			handleClass(typeTitle(t), scan.getClassInfo(t.getName()));
 		}
 
 		if (!group.getMarkerInterfaces().isEmpty()) {
 			out.subHeading("Marker Interfaces");
-			for (Class<?> t : group.getMarkerInterfaces().stream().sorted(Comparator.comparing(Class::getSimpleName)).collect(Collectors.toList())) {
+			for (Class<?> t : group.getMarkerInterfaces().stream().sorted(Comparator.comparing(Class::getSimpleName)).toList()) {
 				handleMarkerInterface(markerTitle(t), scan.getClassInfo(t.getName()));
 			}
 		}
@@ -135,7 +134,7 @@ public class GroupHandler {
 		}
 	}
 
-	private void collectEndpoints(Class<?> resource) throws IOException {
+	private void collectEndpoints(Class<?> resource) {
 		final ClassInfo info = scan.getClassInfo(resource.getName());
 
 		for (MethodInfo method : info.getMethodInfo()) {
@@ -172,7 +171,7 @@ public class GroupHandler {
 					  + code(typeProperty)
 					  + " to one of the following values:");
 
-		for (Pair<CPSType, ClassInfo> pair : content.get(base).stream().sorted(Comparator.comparing(p -> p.getLeft().id())).collect(Collectors.toList())) {
+		for (Pair<CPSType, ClassInfo> pair : content.get(base).stream().sorted(Comparator.comparing(p -> p.getLeft().id())).toList()) {
 
 			handleClass(pair.getLeft(), pair.getRight());
 		}
@@ -198,7 +197,7 @@ public class GroupHandler {
 				out.line("Supported Fields:");
 
 				out.tableHeader("", "Field", "Type", "Default", "Example", "Description");
-				for (FieldInfo field : c.getFieldInfo().stream().sorted().collect(Collectors.toList())) {
+				for (FieldInfo field : c.getFieldInfo().stream().sorted().toList()) {
 					handleField(c, field);
 				}
 			}
@@ -226,12 +225,7 @@ public class GroupHandler {
 			);
 		}
 
-		return new Closeable() {
-			@Override
-			public void close() throws IOException {
-				out.line("</p></details>");
-			}
-		};
+		return () -> out.line("</p></details>");
 	}
 
 	private void handleMarkerInterface(String name, ClassInfo c) throws IOException {
@@ -487,6 +481,7 @@ public class GroupHandler {
 			}
 		}
 
-		return false;
+		// is record
+		return field.getClassInfo().isRecord();
 	}
 }

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/AbstractJavadocIntrospection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/AbstractJavadocIntrospection.java
@@ -10,53 +10,55 @@ import io.github.classgraph.FieldInfo;
 import io.github.classgraph.MethodInfo;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
-public class AbstractJavadocIntrospection<VALUE extends NodeWithJavadoc<?>&NodeWithRange<?>> implements Introspection {
+public class AbstractJavadocIntrospection<VALUE extends NodeWithJavadoc<?> & NodeWithRange<?>> implements Introspection {
 
 	@Getter
 	protected final File file;
 	@Getter
 	protected final VALUE value;
-	
+
 	@Getter(lazy = true)
 	private final String description = extractDescription();
 	@Getter(lazy = true)
 	private final String example = extractExample();
 
-	private String extractDescription() {
-		if(!value.getJavadoc().isPresent()) {
+	protected String extractDescription() {
+		if (value.getJavadoc().isEmpty()) {
 			return "";
 		}
 		var javadoc = value.getJavadoc().get();
 		return javadoc.getDescription().toText().replaceAll("\\s+", " ");
 	}
-	
+
 	private String extractExample() {
-		if(!value.getJavadoc().isPresent()) {
+		if (value.getJavadoc().isEmpty()) {
 			return "";
 		}
 		var javadoc = value.getJavadoc().get();
 		return javadoc.getBlockTags()
-			.stream()
-			.filter(b->b.getTagName().equals("jsonExample"))
-			.findAny()
-			.map(JavadocBlockTag::getContent)
-			.map(JavadocDescription::toText)
-			.orElse("");
+					  .stream()
+					  .filter(b -> b.getTagName().equals("jsonExample"))
+					  .findAny()
+					  .map(JavadocBlockTag::getContent)
+					  .map(JavadocDescription::toText)
+					  .orElse("");
 	}
-	
+
 	@Override
 	public String getLine() {
-		if(value.getJavadocComment().isPresent()) {
+		if (value.getJavadocComment().isPresent()) {
 			return "L"
-				+ value.getJavadocComment().get().getBegin().get().line
-				+ "-L"
-				+ value.getJavadocComment().get().getEnd().get().line;
+				   + value.getJavadocComment().get().getBegin().get().line
+				   + "-L"
+				   + value.getJavadocComment().get().getEnd().get().line;
 		}
-		return "L"+value.getBegin().get().line;
+		return "L" + value.getBegin().get().line;
 	}
-	
+
 	@Override
 	public Introspection findMethod(MethodInfo method) {
 		return new SimpleIntrospection(file);

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/AbstractNodeWithMemberIntrospection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/AbstractNodeWithMemberIntrospection.java
@@ -1,0 +1,93 @@
+package com.bakdata.conquery.introspection;
+
+import java.io.File;
+import java.util.Arrays;
+
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.RecordDeclaration;
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
+import com.github.javaparser.ast.nodeTypes.NodeWithMembers;
+import com.github.javaparser.ast.nodeTypes.NodeWithRange;
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName;
+import com.google.common.collect.MoreCollectors;
+import io.github.classgraph.ArrayTypeSignature;
+import io.github.classgraph.BaseTypeSignature;
+import io.github.classgraph.ClassRefTypeSignature;
+import io.github.classgraph.FieldInfo;
+import io.github.classgraph.MethodInfo;
+import io.github.classgraph.MethodParameterInfo;
+import io.github.classgraph.TypeSignature;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AbstractNodeWithMemberIntrospection<VALUE extends NodeWithJavadoc<?> & NodeWithRange<?> & NodeWithMembers<?>> extends AbstractJavadocIntrospection<VALUE> {
+
+	public AbstractNodeWithMemberIntrospection(File file, VALUE nodeWithJavadoc) {
+		super(file, nodeWithJavadoc);
+	}
+
+	@Override
+	public Introspection findMethod(MethodInfo method) {
+		var types = Arrays.stream(method.getParameterInfo())
+						  .map(MethodParameterInfo::getTypeSignatureOrTypeDescriptor)
+						  .map(this::toClass)
+						  .toArray(Class[]::new);
+
+		return new AbstractJavadocIntrospection<>(
+				file,
+				value
+						.getMethodsByParameterTypes(types)
+						.stream()
+						.filter(md -> md.getNameAsString().equals(method.getName()))
+						.collect(MoreCollectors.onlyElement())
+		);
+
+	}
+
+	@Override
+	public Introspection findField(FieldInfo field) {
+
+		var f = value.getFieldByName(field.getName());
+		if (f.isPresent()) {
+			FieldDeclaration fieldDeclaration = f.get();
+			return new AbstractJavadocIntrospection<>(file, fieldDeclaration);
+		}
+		log.warn("Could not find field '{}'", field.getName());
+		return new SimpleIntrospection(file);
+	}
+
+	public Introspection findInnerType(String simpleName) {
+		for (var decl : value.getMembers()) {
+			if (decl instanceof NodeWithSimpleName<?> node) {
+				if (!node.getNameAsString().equals(simpleName)) {
+					continue;
+				}
+			}
+			else {
+				continue;
+			}
+			if (decl instanceof ClassOrInterfaceDeclaration cType) {
+				return new ClassIntrospection(file, cType);
+			}
+			if (decl instanceof RecordDeclaration recordDeclaration) {
+				return new RecordIntrospection(file, recordDeclaration);
+			}
+		}
+		throw new IllegalStateException(value.getNameAsString() + " has no inner type " + simpleName);
+	}
+
+	private Class<?> toClass(TypeSignature sig) {
+		if (sig instanceof BaseTypeSignature) {
+			return ((BaseTypeSignature) sig).getType();
+		}
+		else if (sig instanceof ArrayTypeSignature) {
+			return ((ArrayTypeSignature) sig).loadClass();
+		}
+		else if (sig instanceof ClassRefTypeSignature) {
+			return ((ClassRefTypeSignature) sig).loadClass();
+		}
+		throw new IllegalStateException("Can't find class for signature " + sig);
+	}
+
+}

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/ClassIntrospection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/ClassIntrospection.java
@@ -1,71 +1,16 @@
 package com.bakdata.conquery.introspection;
 
 import java.io.File;
-import java.util.Arrays;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import com.google.common.collect.MoreCollectors;
-import io.github.classgraph.ArrayTypeSignature;
-import io.github.classgraph.BaseTypeSignature;
-import io.github.classgraph.ClassRefTypeSignature;
-import io.github.classgraph.FieldInfo;
-import io.github.classgraph.MethodInfo;
-import io.github.classgraph.TypeSignature;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ClassIntrospection extends AbstractJavadocIntrospection<ClassOrInterfaceDeclaration> {
+public class ClassIntrospection extends AbstractNodeWithMemberIntrospection<ClassOrInterfaceDeclaration> {
 
 	public ClassIntrospection(File file, ClassOrInterfaceDeclaration value) {
 		super(file, value);
 	}
 
-	public ClassIntrospection findInnerType(String simpleName) {
-		for(var decl : value.getMembers()) {
-			if(decl.isClassOrInterfaceDeclaration()) {
-				var cType = decl.asClassOrInterfaceDeclaration();
-				if(cType.getNameAsString().equals(simpleName)) {
-					return new ClassIntrospection(file, cType);
-				}
-			}
-		}
-		throw new IllegalStateException(value.getNameAsString()+" has no inner type "+simpleName);
-	}
 
-	public Introspection findMethod(MethodInfo method) {
-		var types = Arrays.stream(method.getParameterInfo())
-			.map(p->p.getTypeSignatureOrTypeDescriptor())
-			.map(this::toClass)
-			.toArray(Class[]::new);
-		
-		return new AbstractJavadocIntrospection<>(file, 
-			value
-				.getMethodsByParameterTypes(types)
-				.stream()
-				.filter(md->md.getNameAsString().equals(method.getName()))
-				.collect(MoreCollectors.onlyElement())
-		);
-	}
-	
-	private Class<?> toClass(TypeSignature sig) {
-		if(sig instanceof BaseTypeSignature) {
-			return ((BaseTypeSignature) sig).getType();
-		}
-		else if(sig instanceof ArrayTypeSignature) {
-			return ((ArrayTypeSignature) sig).loadClass();
-		}
-		else if(sig instanceof ClassRefTypeSignature) {
-			return ((ClassRefTypeSignature) sig).loadClass();
-		}
-		throw new IllegalStateException("Can't find class for signature "+sig);
-	}
-
-	public Introspection findField(FieldInfo field) {
-		var f = value.getFieldByName(field.getName());
-		if(f.isPresent()) {
-			return new AbstractJavadocIntrospection<>(file, f.get());
-		}
-		log.warn("Could not find field "+field.getName());
-		return super.findField(field);
-	}
 }

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/EnumIntrospection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/EnumIntrospection.java
@@ -1,0 +1,26 @@
+package com.bakdata.conquery.introspection;
+
+import java.io.File;
+import java.util.stream.Collectors;
+
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.javadoc.Javadoc;
+
+public class EnumIntrospection extends AbstractNodeWithMemberIntrospection<EnumDeclaration> {
+
+
+	public EnumIntrospection(File file, EnumDeclaration enumDeclaration) {
+		super(file, enumDeclaration);
+	}
+
+	@Override
+	protected String extractDescription() {
+		String description = super.extractDescription();
+
+		String values = value.getEntries().stream()
+							 .map(e -> "`%s`: %s".formatted(e.getNameAsString(), e.getJavadoc().map(Javadoc::toText).orElse("No description available")))
+							 .collect(Collectors.joining("\n- ", "\nValues:\n- ", ""));
+		description += values;
+		return description;
+	}
+}

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/Introspection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/Introspection.java
@@ -13,8 +13,8 @@ public interface Introspection {
 	String getDescription();
 	String getExample();
 	File getFile();
-	
-	public static Introspection from(File root, ClassInfo cl) {
+
+	static Introspection from(File root, ClassInfo cl) {
 		File f = new File(root, "backend/src/main/java/"+cl.getName().replace('.', '/')+".java");
 		try {
 			if(cl.isInnerClass()) {

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/Introspection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/Introspection.java
@@ -4,6 +4,8 @@ import java.io.File;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.FieldInfo;
 import io.github.classgraph.MethodInfo;
@@ -18,17 +20,31 @@ public interface Introspection {
 		File f = new File(root, "backend/src/main/java/"+cl.getName().replace('.', '/')+".java");
 		try {
 			if(cl.isInnerClass()) {
-				ClassIntrospection parent = (ClassIntrospection)from(root, cl.getOuterClasses().get(cl.getOuterClasses().size()-1));
-				return parent.findInnerType(cl.getSimpleName());
+				Introspection from = from(root, cl.getOuterClasses().get(cl.getOuterClasses().size() - 1));
+				if (from instanceof SimpleIntrospection simpleIntrospection) {
+					return simpleIntrospection;
+				}
+
+				if (from instanceof AbstractNodeWithMemberIntrospection<?> nodeWithMemberIntrospection) {
+					return nodeWithMemberIntrospection.findInnerType(cl.getSimpleName());
+				}
+				else {
+					return new SimpleIntrospection(f);
+				}
 			}
 			
 			
 			CompilationUnit cu = StaticJavaParser.parse(f);
-			
-			var type = cu.getPrimaryType().get().asClassOrInterfaceDeclaration();
-			return new ClassIntrospection(f, type);
+
+			TypeDeclaration<?> typeDeclaration = cu.getPrimaryType().get();
+
+			if (typeDeclaration instanceof EnumDeclaration enumDeclaration) {
+				return new EnumIntrospection(f, enumDeclaration);
+			}
+			return new AbstractNodeWithMemberIntrospection<>(f, typeDeclaration);
+			//			return new ClassIntrospection(f, typeDeclaration);
 		} catch(Exception e) {
-			LoggerFactory.getLogger(Introspection.class).warn("Could not create compilation unit for "+cl.getName(), e);
+			LoggerFactory.getLogger(Introspection.class).warn("Could not create compilation unit for {}", cl.getName(), e);
 			return new SimpleIntrospection(f);
 		}
 	}

--- a/autodoc/src/main/java/com/bakdata/conquery/introspection/RecordIntrospection.java
+++ b/autodoc/src/main/java/com/bakdata/conquery/introspection/RecordIntrospection.java
@@ -1,0 +1,13 @@
+package com.bakdata.conquery.introspection;
+
+import java.io.File;
+
+import com.github.javaparser.ast.body.RecordDeclaration;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RecordIntrospection extends AbstractNodeWithMemberIntrospection<RecordDeclaration> {
+	public RecordIntrospection(File file, RecordDeclaration recordDeclaration) {
+		super(file, recordDeclaration);
+	}
+}

--- a/backend/src/main/java/com/bakdata/conquery/models/config/DatabaseConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/DatabaseConfig.java
@@ -6,6 +6,11 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
 
+/**
+ * Connection properties for a SQL database.
+ * <p/>
+ * Currently supported are HANA and Prostgres databases, see {@link DatabaseConfig#dialect}.
+ */
 @Data
 @Builder
 @Jacksonized
@@ -15,14 +20,30 @@ public class DatabaseConfig {
 
 	private static final String DEFAULT_PRIMARY_COLUMN = "pid";
 
+	/**
+	 * SQL vendor specific dialect used to transform queries to SQL
+	 */
 	private Dialect dialect;
 
+	/**
+	 * Username used to connect to the database.
+	 */
 	private String databaseUsername;
 
+
+	/**
+	 * Password used to connect to the database.
+	 */
 	private String databasePassword;
 
+	/**
+	 * Connections url in JDBC notation.
+	 */
 	private String jdbcConnectionUrl;
 
+	/**
+	 * Name of the column which is shared among the table and all aggregations are grouped by.
+	 */
 	@Builder.Default
 	private String primaryColumn = DEFAULT_PRIMARY_COLUMN;
 

--- a/backend/src/main/java/com/bakdata/conquery/models/config/Dialect.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/Dialect.java
@@ -3,6 +3,11 @@ package com.bakdata.conquery.models.config;
 import lombok.Getter;
 import org.jooq.SQLDialect;
 
+/**
+ * The dialect sets SQL vendor specific query transformation rules.
+ * <p/>
+ * There is no fallback dialect, so the dialect must fit the targeted database.
+ */
 @Getter
 public enum Dialect {
 

--- a/backend/src/main/java/com/bakdata/conquery/models/config/Dialect.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/Dialect.java
@@ -11,7 +11,13 @@ import org.jooq.SQLDialect;
 @Getter
 public enum Dialect {
 
+	/**
+	 * Dialect for PostgreSQL database
+	 */
 	POSTGRESQL(SQLDialect.POSTGRES, 63),
+	/**
+	 * Dialect for SAP HANA database
+	 */
 	HANA(SQLDialect.DEFAULT, 127);
 
 	private final SQLDialect jooqDialect;

--- a/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/SqlConnectorConfig.java
@@ -13,6 +13,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
 
+/**
+ * Configuration for SQL databases to send dataset queries to.
+ * <p/>
+ * Multiple databases can be configured for different datasets.
+ *
+ * @implNote At the moment, dataset names are statically mapped to a database by the {@link SqlConnectorConfig#databaseConfigs}-map.
+ */
 @Data
 @Builder
 @Jacksonized


### PR DESCRIPTION
Adds AutoDoc support for:
- Records, e.g.:
  ### Type ResolvedConceptsResult<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java#L330)</sup></sub></sup>
  
  
  <details><summary>Details</summary><p>
  
  Java Type: `com.bakdata.conquery.resources.api.ConceptsProcessor$ResolvedConceptsResult`
  
  Supported Fields:
  
  |  | Field | Type | Default | Example | Description |
  | --- | --- | --- | --- | --- | --- |
  | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java) | resolvedConcepts | `Set<ConceptElementId<?>>` | ? |  |  | 
  | [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/resources/api/ConceptsProcessor.java) | unknownCodes | `Collection<String>` | ? |  |  | 
  </p></details>
- Enums, e.g.:
    ### Type Dialect<sup><sub><sup> [✎](https://github.com/bakdata/conquery/edit/develop/backend/src/main/java/com/bakdata/conquery/models/config/Dialect.java#L6-L10)</sup></sub></sup>
  The dialect sets SQL vendor specific query transformation rules. <p/> There is no fallback dialect, so the dialect must fit the targeted database.
  Values:
  - `POSTGRESQL`: Dialect for PostgreSQL database
  
  - `HANA`: Dialect for SAP HANA database
  
  
  <details><summary>Details</summary><p>
  
  Java Type: `com.bakdata.conquery.models.config.Dialect`
  
  No fields can be set for this type.
  
  </p></details>

And adds documentation for SQL Connector configuration