### PR TITLE
remove cqpp import via file path

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/config/PreprocessingConfig.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/PreprocessingConfig.java
@@ -2,6 +2,7 @@ package com.bakdata.conquery.models.config;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminDatasetResource.java
@@ -3,7 +3,6 @@ package com.bakdata.conquery.resources.admin.rest;
 import static com.bakdata.conquery.resources.ResourceConstants.*;
 
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -25,9 +24,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response.Status;
 
 import com.bakdata.conquery.io.jersey.ExtraMimeTypes;
 import com.bakdata.conquery.models.datasets.Dataset;
@@ -42,7 +39,6 @@ import com.bakdata.conquery.models.identifiable.mapping.EntityIdMap;
 import com.bakdata.conquery.models.index.InternToExternMapper;
 import com.bakdata.conquery.models.index.search.SearchIndex;
 import com.bakdata.conquery.models.worker.Namespace;
-import com.bakdata.conquery.util.io.FileUtil;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -145,17 +141,6 @@ public class AdminDatasetResource {
 		processor.updateImport(namespace, new GZIPInputStream(new BufferedInputStream(importStream)));
 	}
 
-	@PUT
-	@Path("imports")
-	public void updateImport(@NotNull @QueryParam("file") File importFile) throws WebApplicationException {
-		try {
-			processor.updateImport(namespace, new GZIPInputStream(FileUtil.cqppFileToInputstream(importFile)));
-		}
-		catch (IOException err) {
-			throw new WebApplicationException(String.format("Invalid file (`%s`) supplied.", importFile), err, Status.BAD_REQUEST);
-		}
-	}
-
 	@POST
 	@Consumes(MediaType.APPLICATION_OCTET_STREAM)
 	@Path("cqpp")
@@ -164,19 +149,6 @@ public class AdminDatasetResource {
 		log.debug("Importing from file upload");
 		processor.addImport(namespace, new GZIPInputStream(new BufferedInputStream(importStream)));
 	}
-
-	@POST
-	@Path("imports")
-	public void addImport(@QueryParam("file") File importFile) throws WebApplicationException {
-		try {
-			processor.addImport(namespace, new GZIPInputStream(FileUtil.cqppFileToInputstream(importFile)));
-		}
-		catch (IOException err) {
-			log.warn("Unable to process import", err);
-			throw new WebApplicationException(String.format("Invalid file (`%s`) supplied.", importFile), err, Status.BAD_REQUEST);
-		}
-	}
-
 
 	@POST
 	@Path("concepts")

--- a/backend/src/main/java/com/bakdata/conquery/util/io/FileUtil.java
+++ b/backend/src/main/java/com/bakdata/conquery/util/io/FileUtil.java
@@ -1,9 +1,7 @@
 package com.bakdata.conquery.util.io;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.FileVisitResult;
@@ -11,12 +9,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.StringJoiner;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
 
-import com.bakdata.conquery.ConqueryConstants;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
@@ -57,40 +52,6 @@ public class FileUtil {
 	public static boolean isGZipped(@NonNull File file) {
 		return file.getName().endsWith(".csv.gz");
 	}
-
-	/**
-	 * converts the provided cqpp file to an inputstream
-	 * @param file cqpp file to convert
-	 * @return file as inputstream
-	 * @throws IOException if any I/O error occured
-	 */
-    public static InputStream cqppFileToInputstream(@NonNull File file) throws IOException {
-
-		StringJoiner errors = new StringJoiner("\n");
-
-		if (!file.canRead()) {
-			errors.add("Cannot read.");
-		}
-
-		if (!file.exists()) {
-			errors.add("Does not exist.");
-		}
-
-		if (!file.isAbsolute()) {
-			errors.add("Is not absolute.");
-		}
-
-		if (!file.getPath().endsWith(ConqueryConstants.EXTENSION_PREPROCESSED)) {
-			errors.add(String.format("Does not end with `%s`.", ConqueryConstants.EXTENSION_PREPROCESSED));
-		}
-
-		if (errors.length() > 0) {
-			throw new IOException(errors.toString());
-		}
-
-		return new FileInputStream(file);
-	}
-
 
 	/**
 	 * Takes a {@link URI} which acts as base uri and a second uri that is more specific and resolves them.

--- a/backend/src/test/resources/tests/endpoints/adminEndpointInfo.json
+++ b/backend/src/test/resources/tests/endpoints/adminEndpointInfo.json
@@ -61,11 +61,6 @@
   },
   {
     "method": "POST",
-    "path": "/datasets/{dataset}/imports",
-    "clazz": "AdminDatasetResource"
-  },
-  {
-    "method": "POST",
     "path": "/datasets/{dataset}/label",
     "clazz": "AdminDatasetResource"
   },
@@ -153,11 +148,6 @@
     "method": "GET",
     "path": "/datasets/{dataset}/tables/{table}/imports/{importId}",
     "clazz": "AdminTablesResource"
-  },
-  {
-    "method": "PUT",
-    "path": "/datasets/{dataset}/imports",
-    "clazz": "AdminDatasetResource"
   },
   {
     "method": "PUT",


### PR DESCRIPTION
One solution to fix 3 of these warnings: https://github.com/ingef/conquery/security/code-scanning

An alternative would be to define a path (e.g.) in PreprocessingConfig that specifies an absolute path from which local CQPPs are allowed to be imported.