### PR TITLE
All-Queries-Endpoint fails on uninitialied queries

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/QueryProcessor.java
@@ -1,7 +1,5 @@
 package com.bakdata.conquery.apiv1;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -21,12 +19,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import jakarta.inject.Inject;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Validator;
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
 
 import com.bakdata.conquery.apiv1.execution.ExecutionStatus;
 import com.bakdata.conquery.apiv1.execution.FullExecutionStatus;
@@ -89,6 +81,12 @@ import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdentifiableCollector;
 import com.bakdata.conquery.util.io.IdColumnUtil;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -174,12 +172,12 @@ public class QueryProcessor {
 	public static List<ResultAsset> getResultAssets(List<ResultRendererProvider> renderer, ManagedExecution exec, UriBuilder uriBuilder, boolean allProviders) {
 
 		return renderer.stream()
-					   .map(r -> {
+					   .map(rendererProvider -> {
 						   try {
-							   return r.generateResultURLs(exec, uriBuilder.clone(), allProviders);
+							   return rendererProvider.generateResultURLs(exec, uriBuilder.clone(), allProviders);
 						   }
-						   catch (MalformedURLException | URISyntaxException e) {
-							   log.error("Cannot generate result urls for execution '{}' with provider '{}'", exec.getId(), r.getClass().getName());
+						   catch (Exception e) {
+							   log.error("Cannot generate result urls for execution '{}' with provider {}", exec.getId(), rendererProvider, e);
 							   return null;
 						   }
 					   })

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/execution/ExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/execution/ExecutionStatus.java
@@ -10,12 +10,14 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.SecondaryIdDescriptionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.UserId;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
+@AllArgsConstructor
 @ToString
 @Data
 @FieldNameConstants

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/execution/OverviewExecutionStatus.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/execution/OverviewExecutionStatus.java
@@ -1,11 +1,13 @@
 package com.bakdata.conquery.apiv1.execution;
 
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 /**
  * Light weight description of an execution. Rendering the overview should not cause heavy computations.
  */
 @NoArgsConstructor
+@Builder
 public class OverviewExecutionStatus extends ExecutionStatus {
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/ExternalForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/ExternalForm.java
@@ -26,6 +26,7 @@ import com.bakdata.conquery.models.i18n.I18n;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonParser;
@@ -132,8 +133,8 @@ public class ExternalForm extends Form implements SubTyped {
 	}
 
 	@Override
-	public ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage) {
-		return new ExternalExecution(this, user, submittedDataset, storage);
+	public ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		return new ExternalExecution(this, user, submittedDataset, storage, datasetRegistry);
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/Form.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/Form.java
@@ -10,9 +10,9 @@ import com.bakdata.conquery.models.auth.entities.Subject;
 import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.error.ConqueryError;
+import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.frontendconfiguration.FormScanner;
 import com.bakdata.conquery.models.forms.frontendconfiguration.FormType;
-import com.bakdata.conquery.models.forms.managed.ManagedForm;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,7 +28,7 @@ public abstract class Form implements QueryDescription {
 
 	/**
 	 * Raw form config (basically the raw format of this form), that is used by the backend at the moment to
-	 * create a {@link com.bakdata.conquery.models.forms.configs.FormConfig} upon start of this form (see {@link ManagedForm#start()}).
+	 * create a {@link com.bakdata.conquery.models.forms.configs.FormConfig} upon start of this form (see {@link ManagedExecution#start(com.bakdata.conquery.models.query.ExecutionManager)}).
 	 */
 	@Nullable
 	public abstract JsonNode getValues();

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/Form.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/Form.java
@@ -28,7 +28,7 @@ public abstract class Form implements QueryDescription {
 
 	/**
 	 * Raw form config (basically the raw format of this form), that is used by the backend at the moment to
-	 * create a {@link com.bakdata.conquery.models.forms.configs.FormConfig} upon start of this form (see {@link ManagedExecution#start(com.bakdata.conquery.models.query.ExecutionManager)}).
+	 * create a {@link com.bakdata.conquery.models.forms.configs.FormConfig} upon start of this form (see {@link ManagedExecution#start()}).
 	 */
 	@Nullable
 	public abstract JsonNode getValues();

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/ExportForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/ExportForm.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.ValidationException;
@@ -37,6 +36,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
@@ -215,7 +215,7 @@ public class ExportForm extends Form implements InternalForm {
 
 
 	@Override
-	public ManagedForm toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage) {
-		return new ManagedInternalForm(this, user, submittedDataset, storage);
+	public ManagedForm<?> toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		return new ManagedInternalForm<>(this, user, submittedDataset, storage, datasetRegistry);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/FullExportForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/forms/export_form/FullExportForm.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-
 import javax.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -33,6 +32,7 @@ import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -126,7 +126,7 @@ public class FullExportForm extends Form implements InternalForm {
 
 
 	@Override
-	public ManagedInternalForm<FullExportForm> toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage) {
-		return new ManagedInternalForm<>(this, user, submittedDataset, storage);
+	public ManagedInternalForm<FullExportForm> toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		return new ManagedInternalForm<>(this, user, submittedDataset, storage, datasetRegistry);
 	}
 }

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/query/Query.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/query/Query.java
@@ -18,6 +18,7 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.queryplan.QueryPlan;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfo;
 import com.bakdata.conquery.models.query.results.EntityResult;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 
@@ -41,8 +42,8 @@ public abstract class Query implements QueryDescription {
 	public abstract List<ResultInfo> getResultInfos(PrintSettings printSettings);
 
 	@Override
-	public ManagedQuery toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage) {
-		return new ManagedQuery(this, user, submittedDataset, storage);
+	public ManagedQuery toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		return new ManagedQuery(this, user, submittedDataset, storage, datasetRegistry);
 	}
 
 	/**

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/query/QueryDescription.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/query/QueryDescription.java
@@ -22,6 +22,7 @@ import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.RequiredEntities;
 import com.bakdata.conquery.models.query.Visitable;
 import com.bakdata.conquery.models.query.visitor.QueryVisitor;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.util.QueryUtils;
 import com.bakdata.conquery.util.QueryUtils.ExternalIdChecker;
 import com.bakdata.conquery.util.QueryUtils.NamespacedIdentifiableCollector;
@@ -44,7 +45,7 @@ public interface QueryDescription extends Visitable {
 	 * @param storage
 	 * @return
 	 */
-	ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage);
+	ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry);
 
 
 	Set<ManagedExecutionId> collectRequiredQueries();

--- a/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/cluster/ClusterNamespaceHandler.java
@@ -25,7 +25,7 @@ public class ClusterNamespaceHandler implements NamespaceHandler<DistributedName
 	@Override
 	public DistributedNamespace createNamespace(NamespaceStorage namespaceStorage, MetaStorage metaStorage, DatasetRegistry<DistributedNamespace> datasetRegistry, Environment environment) {
 		NamespaceSetupData namespaceData = NamespaceHandler.createNamespaceSetup(namespaceStorage, config, internalMapperFactory, datasetRegistry);
-		DistributedExecutionManager executionManager = new DistributedExecutionManager(metaStorage, clusterState);
+		DistributedExecutionManager executionManager = new DistributedExecutionManager(metaStorage, datasetRegistry, clusterState);
 		WorkerHandler workerHandler = new WorkerHandler(namespaceData.getCommunicationMapper(), namespaceStorage);
 		clusterState.getWorkerHandlers().put(namespaceStorage.getDataset().getId(), workerHandler);
 

--- a/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
+++ b/backend/src/main/java/com/bakdata/conquery/mode/local/LocalNamespaceHandler.java
@@ -53,7 +53,7 @@ public class LocalNamespaceHandler implements NamespaceHandler<LocalNamespace> {
 		SqlExecutionService sqlExecutionService = new SqlExecutionService(dslContext, resultSetProcessor);
 		NodeConversions nodeConversions = new NodeConversions(idColumns, sqlDialect, dslContext, databaseConfig, sqlExecutionService);
 		SqlConverter sqlConverter = new SqlConverter(nodeConversions, config);
-		ExecutionManager executionManager = new SqlExecutionManager(sqlConverter, sqlExecutionService, metaStorage);
+		ExecutionManager executionManager = new SqlExecutionManager(sqlConverter, sqlExecutionService, metaStorage, datasetRegistry);
 		SqlStorageHandler sqlStorageHandler = new SqlStorageHandler(sqlExecutionService);
 		SqlEntityResolver sqlEntityResolver = new SqlEntityResolver(idColumns, dslContext, sqlDialect, sqlExecutionService);
 

--- a/backend/src/main/java/com/bakdata/conquery/models/config/CsvResultProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/CsvResultProvider.java
@@ -16,14 +16,12 @@ import com.bakdata.conquery.models.query.SingleTableResult;
 import com.bakdata.conquery.resources.api.ResultCsvResource;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import jakarta.ws.rs.core.UriBuilder;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 
 @Slf4j
-@NoArgsConstructor
-@AllArgsConstructor
+@Data
 @CPSType(base = ResultRendererProvider.class, id = "CSV")
 public class CsvResultProvider implements ResultRendererProvider {
 	private boolean hidden = false;

--- a/backend/src/main/java/com/bakdata/conquery/models/config/ExternalResultProvider.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/config/ExternalResultProvider.java
@@ -2,7 +2,6 @@ package com.bakdata.conquery.models.config;
 
 import java.util.Collection;
 import java.util.Collections;
-import jakarta.ws.rs.core.UriBuilder;
 
 import com.bakdata.conquery.apiv1.execution.ResultAsset;
 import com.bakdata.conquery.commands.ManagerNode;
@@ -13,11 +12,14 @@ import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.managed.ExternalExecution;
 import com.bakdata.conquery.resources.api.ResultExternalResource;
 import io.dropwizard.jersey.DropwizardResourceConfig;
+import jakarta.ws.rs.core.UriBuilder;
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 @Getter
+@Data
 @CPSType(base = ResultRendererProvider.class, id = "EXTERNAL")
 public class ExternalResultProvider implements ResultRendererProvider {
 

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ExternalExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ExternalExecution.java
@@ -97,13 +97,12 @@ public class ExternalExecution extends ManagedForm<ExternalForm> {
 			User serviceUser = formBackendConfig.createServiceUser(originalUser, dataset);
 			ExternalFormBackendApi api = formBackendConfig.createApi();
 
-			final ExternalTaskState externalTaskState = api.postForm(getSubmitted(), originalUser, serviceUser, dataset);
-
-			externalTaskId = externalTaskState.getId();
-
 			super.start(executionManager);
 
 			this.executionManager.addState(this.getId(), new ExternalStateImpl(ExecutionState.RUNNING, new CountDownLatch(0), api, serviceUser));
+
+			final ExternalTaskState externalTaskState = api.postForm(getSubmitted(), originalUser, serviceUser, dataset);
+			externalTaskId = externalTaskState.getId();
 		}
 	}
 
@@ -155,7 +154,9 @@ public class ExternalExecution extends ManagedForm<ExternalForm> {
 
 	@Override
 	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status, ExecutionManager executionManager) {
-		syncExternalState(executionManager);
+		if (externalTaskId != null) {
+			syncExternalState(executionManager);
+		}
 
 		super.setStatusBase(subject, status, executionManager);
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -10,9 +10,9 @@ import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.configs.FormConfig;
-import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.Visitable;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.DatabindContext;
 import lombok.AccessLevel;
@@ -46,16 +46,16 @@ public abstract class ManagedForm<F extends Form> extends ManagedExecution {
 	@Getter
 	private Form submittedForm;
 
-	protected ManagedForm(F submittedForm, User owner, Dataset submittedDataset, MetaStorage storage) {
-		super(owner, submittedDataset, storage);
+	protected ManagedForm(F submittedForm, User owner, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		super(owner, submittedDataset, storage, datasetRegistry);
 		this.submittedForm = submittedForm;
 	}
 
 
 	@Override
-	public void start(ExecutionManager executionManager) {
+	public void start() {
 		synchronized (this) {
-			super.start(executionManager);
+			super.start();
 
 			if (getSubmittedForm().getValues() != null) {
 				// save as formConfig

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedForm.java
@@ -10,6 +10,7 @@ import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.configs.FormConfig;
+import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.Visitable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -52,9 +53,9 @@ public abstract class ManagedForm<F extends Form> extends ManagedExecution {
 
 
 	@Override
-	public void start() {
+	public void start(ExecutionManager executionManager) {
 		synchronized (this) {
-			super.start();
+			super.start(executionManager);
 
 			if (getSubmittedForm().getValues() != null) {
 				// save as formConfig

--- a/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedInternalForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/forms/managed/ManagedInternalForm.java
@@ -21,6 +21,7 @@ import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.IdMap;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.ColumnDescriptor;
+import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.QueryResolveContext;
@@ -95,12 +96,12 @@ public class ManagedInternalForm<F extends Form & InternalForm> extends ManagedF
 
 
 	@Override
-	public void start() {
+	public void start(ExecutionManager executionManager) {
 		synchronized (this) {
 			subQueries.values().forEach(flatSubQueries::add);
 		}
-		flatSubQueries.values().forEach(ManagedQuery::start);
-		super.start();
+		flatSubQueries.values().forEach(query -> query.start(executionManager));
+		super.start(executionManager);
 	}
 
 	@Override
@@ -159,9 +160,9 @@ public class ManagedInternalForm<F extends Form & InternalForm> extends ManagedF
 		return subQueries.values().iterator().next().resultRowCount();
 	}
 
-	public boolean allSubQueriesDone() {
+	public boolean allSubQueriesDone(ExecutionManager executionManager) {
 		synchronized (this) {
-			return flatSubQueries.values().stream().allMatch(q -> q.getState().equals(ExecutionState.DONE));
+			return flatSubQueries.values().stream().allMatch(q -> q.getState(executionManager).equals(ExecutionState.DONE));
 		}
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/DistributedExecutionManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/DistributedExecutionManager.java
@@ -19,6 +19,7 @@ import com.bakdata.conquery.models.execution.InternalExecution;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.forms.managed.ManagedInternalForm;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
+import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.identifiable.ids.specific.WorkerId;
 import com.bakdata.conquery.models.messages.namespaces.WorkerMessage;
 import com.bakdata.conquery.models.messages.namespaces.specific.CancelQuery;
@@ -27,17 +28,36 @@ import com.bakdata.conquery.models.messages.namespaces.specific.ExecuteQuery;
 import com.bakdata.conquery.models.query.results.EntityResult;
 import com.bakdata.conquery.models.query.results.ShardResult;
 import com.bakdata.conquery.models.worker.WorkerHandler;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
+import org.jetbrains.annotations.NotNull;
 
 @Slf4j
 public class DistributedExecutionManager extends ExecutionManager {
 
-	public record DistributedState(Map<WorkerId, List<EntityResult>> results, CountDownLatch executingLock) implements InternalState {
+	@Data
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class DistributedState implements InternalState {
+		@Setter
+		@NonNull
+		private ExecutionState state;
+		private Map<WorkerId, List<EntityResult>> results;
+		private CountDownLatch executingLock;
 
 		public DistributedState() {
-			this(new ConcurrentHashMap<>(), new CountDownLatch(1));
+			this(ExecutionState.RUNNING, new ConcurrentHashMap<>(), new CountDownLatch(1));
+		}
+
+		@NotNull
+		@Override
+		public ExecutionState getState() {
+			return state;
 		}
 
 		@Override
@@ -111,8 +131,11 @@ public class DistributedExecutionManager extends ExecutionManager {
 		log.debug("Received Result[size={}] for Query[{}]", result.getResults().size(), result.getQueryId());
 		log.trace("Received Result\n{}", result.getResults());
 
-		if (execution.getState() != ExecutionState.RUNNING) {
-			log.warn("Received result for Query[{}] that is not RUNNING but {}", execution.getId(), execution.getState());
+		ManagedExecutionId id = execution.getId();
+		State state = getResult(id);
+		ExecutionState execState = state.getState();
+		if (execState != ExecutionState.RUNNING) {
+			log.warn("Received result for Query[{}] that is not RUNNING but {}", id, execState);
 			return;
 		}
 
@@ -122,7 +145,6 @@ public class DistributedExecutionManager extends ExecutionManager {
 		else {
 
 			// We don't collect all results together into a fat list as that would cause lots of huge re-allocations for little gain.
-			State state = getResult(execution.getId());
 			if (!(state instanceof DistributedState distributedState)) {
 				throw new IllegalStateException("Expected execution '%s' to be of type %s, but was %s".formatted(execution.getId(), DistributedState.class, state.getClass()));
 			}
@@ -130,17 +152,21 @@ public class DistributedExecutionManager extends ExecutionManager {
 
 			// If all known workers have returned a result, the query is DONE.
 			if (distributedState.allResultsArrived(getWorkerHandler(execution.getDataset().getId()).getAllWorkerIds())) {
+
+				DistributedExecutionManager.DistributedState previousState = getResult(id);
+				((DistributedState) state).setState(ExecutionState.DONE);
 				execution.finish(ExecutionState.DONE, this);
 
 			}
 		}
 
 		// State changed to DONE or FAILED
-		if (execution.getState() != ExecutionState.RUNNING) {
+		ExecutionState execStateAfterResultCollect = getResult(id).getState();
+		if (execStateAfterResultCollect != ExecutionState.RUNNING) {
 			final String primaryGroupName = AuthorizationHelper.getPrimaryGroup(execution.getOwner(), getStorage()).map(Group::getName).orElse("none");
 
 			ExecutionMetrics.getRunningQueriesCounter(primaryGroupName).dec();
-			ExecutionMetrics.getQueryStateCounter(execution.getState(), primaryGroupName).inc();
+			ExecutionMetrics.getQueryStateCounter(execStateAfterResultCollect, primaryGroupName).inc();
 			ExecutionMetrics.getQueriesTimeHistogram(primaryGroupName).update(execution.getExecutionTime().toMillis());
 
 			/* This log is here to prevent an NPE which could occur when no strong reference to result.getResults()

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ExternalStateImpl.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ExternalStateImpl.java
@@ -10,14 +10,22 @@ import com.bakdata.conquery.apiv1.execution.ResultAsset;
 import com.bakdata.conquery.io.external.form.ExternalFormBackendApi;
 import com.bakdata.conquery.io.result.ExternalState;
 import com.bakdata.conquery.models.auth.entities.User;
+import com.bakdata.conquery.models.execution.ExecutionState;
 import com.google.common.collect.MoreCollectors;
 import it.unimi.dsi.fastutil.Pair;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @RequiredArgsConstructor
 public class ExternalStateImpl implements ExternalState {
+
+	@Getter
+	@Setter
+	@NonNull
+	private ExecutionState state;
+
 	private final CountDownLatch latch;
 
 	@Getter

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -96,9 +96,9 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 	}
 
 	@Override
-	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status, Namespace namespace) {
+	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status, ExecutionManager executionManager) {
 
-		super.setStatusBase(subject, status, namespace);
+		super.setStatusBase(subject, status, executionManager);
 		status.setNumberOfResults(getLastResultCount());
 
 		Query query = getQuery();
@@ -120,12 +120,6 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 	@JsonIgnore
 	public List<ResultInfo> getResultInfos(PrintSettings printSettings) {
 		return query.getResultInfos(printSettings);
-	}
-
-	@Override
-	public void reset(ExecutionManager executionManager) {
-		super.reset(executionManager);
-		getNamespace().getExecutionManager().clearQueryResults(this);
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -24,6 +24,7 @@ import com.bakdata.conquery.models.execution.InternalExecution;
 import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfo;
 import com.bakdata.conquery.models.query.results.EntityResult;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.QueryUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -54,23 +55,23 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 	private transient List<ColumnDescriptor> columnDescriptions;
 
 
-	public ManagedQuery(Query query, User owner, Dataset submittedDataset, MetaStorage storage) {
-		super(owner, submittedDataset, storage);
+	public ManagedQuery(Query query, User owner, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		super(owner, submittedDataset, storage, datasetRegistry);
 		this.query = query;
 	}
 
 	@Override
-	protected void doInitExecutable(Namespace namespace) {
+	protected void doInitExecutable() {
 		query.resolve(new QueryResolveContext(getNamespace(), getConfig(), getMetaStorage(), null));
 	}
 
 
 	@Override
-	public void finish(ExecutionState executionState, ExecutionManager executionManager) {
+	public void finish(ExecutionState executionState) {
 		//TODO this is not optimal with SQLExecutionService as this might fully evaluate the query.
 		lastResultCount = query.countResults(streamResults(OptionalLong.empty()));
 
-		super.finish(executionState, executionManager);
+		super.finish(executionState);
 	}
 
 
@@ -96,9 +97,9 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 	}
 
 	@Override
-	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status, ExecutionManager executionManager) {
+	public void setStatusBase(@NonNull Subject subject, @NonNull ExecutionStatus status) {
 
-		super.setStatusBase(subject, status, executionManager);
+		super.setStatusBase(subject, status);
 		status.setNumberOfResults(getLastResultCount());
 
 		Query query = getQuery();

--- a/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java
@@ -67,7 +67,7 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 
 
 	@Override
-	public void finish(ExecutionState executionState) {
+	public synchronized void finish(ExecutionState executionState) {
 		//TODO this is not optimal with SQLExecutionService as this might fully evaluate the query.
 		lastResultCount = query.countResults(streamResults(OptionalLong.empty()));
 
@@ -89,7 +89,7 @@ public class ManagedQuery extends ManagedExecution implements SingleTableResult,
 	}
 
 	@Override
-	public long resultRowCount() {
+	public synchronized long resultRowCount() {
 		if (lastResultCount == null) {
 			throw new IllegalStateException("Result row count is unknown, because the query has not yet finished.");
 		}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/preview/EntityPreviewExecution.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/preview/EntityPreviewExecution.java
@@ -40,6 +40,7 @@ import com.bakdata.conquery.models.query.results.EntityResult;
 import com.bakdata.conquery.models.query.results.MultilineEntityResult;
 import com.bakdata.conquery.models.types.ResultType;
 import com.bakdata.conquery.models.types.SemanticType;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -64,8 +65,8 @@ public class EntityPreviewExecution extends ManagedInternalForm<EntityPreviewFor
 	@ToString.Exclude
 	private PreviewConfig previewConfig;
 
-	public EntityPreviewExecution(EntityPreviewForm entityPreviewQuery, User user, Dataset submittedDataset, MetaStorage storage) {
-		super(entityPreviewQuery, user, submittedDataset, storage);
+	public EntityPreviewExecution(EntityPreviewForm entityPreviewQuery, User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		super(entityPreviewQuery, user, submittedDataset, storage, datasetRegistry);
 	}
 
 	/**
@@ -215,8 +216,8 @@ public class EntityPreviewExecution extends ManagedInternalForm<EntityPreviewFor
 	}
 
 	@Override
-	public void doInitExecutable(Namespace namespace) {
-		super.doInitExecutable(namespace);
+	public void doInitExecutable() {
+		super.doInitExecutable();
 		previewConfig = getNamespace().getPreviewConfig();
 	}
 
@@ -228,7 +229,7 @@ public class EntityPreviewExecution extends ManagedInternalForm<EntityPreviewFor
 	@Override
 	public FullExecutionStatus buildStatusFull(Subject subject, Namespace namespace) {
 
-		initExecutable(getNamespace(), getConfig());
+		initExecutable(getConfig());
 
 		final EntityPreviewStatus status = new EntityPreviewStatus();
 		setStatusFull(status, subject, namespace);

--- a/backend/src/main/java/com/bakdata/conquery/models/query/preview/EntityPreviewForm.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/preview/EntityPreviewForm.java
@@ -82,7 +82,7 @@ public class EntityPreviewForm extends Form implements InternalForm {
 		return null; // will not be implemented.
 	}
 
-	public static EntityPreviewForm create(String entity, String idKind, Range<LocalDate> dateRange, List<Connector> sources, List<Select> infos, List<PreviewConfig.TimeStratifiedSelects> timeStratifiedSelects, DatasetRegistry datasetRegistry) {
+	public static EntityPreviewForm create(String entity, String idKind, Range<LocalDate> dateRange, List<Connector> sources, List<Select> infos, List<PreviewConfig.TimeStratifiedSelects> timeStratifiedSelects, DatasetRegistry<?> datasetRegistry) {
 
 		// We use this query to filter for the single selected query.
 		final Query entitySelectQuery = new ConceptQuery(new CQExternal(List.of(idKind), new String[][]{{"HEAD"}, {entity}}, true));
@@ -97,7 +97,7 @@ public class EntityPreviewForm extends Form implements InternalForm {
 	}
 
 	@NotNull
-	private static Map<String, AbsoluteFormQuery> createTimeStratifiedQueries(Range<LocalDate> dateRange, List<PreviewConfig.TimeStratifiedSelects> timeStratifiedSelects, DatasetRegistry datasetRegistry, Query entitySelectQuery) {
+	private static Map<String, AbsoluteFormQuery> createTimeStratifiedQueries(Range<LocalDate> dateRange, List<PreviewConfig.TimeStratifiedSelects> timeStratifiedSelects, DatasetRegistry<?> datasetRegistry, Query entitySelectQuery) {
 		final Map<String, AbsoluteFormQuery> timeQueries = new HashMap<>();
 
 		// per group create an AbsoluteFormQuery on years and quarters.
@@ -171,8 +171,8 @@ public class EntityPreviewForm extends Form implements InternalForm {
 	}
 
 	@Override
-	public ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage) {
-		return new EntityPreviewExecution(this, user, submittedDataset, storage);
+	public ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		return new EntityPreviewExecution(this, user, submittedDataset, storage, datasetRegistry);
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/query/results/FormShardResult.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/results/FormShardResult.java
@@ -39,19 +39,18 @@ public class FormShardResult extends ShardResult {
 		executionManager.handleQueryResult(this, subQuery);
 
 		// Fail the whole execution if a subquery fails
-		if (ExecutionState.FAILED.equals(subQuery.getState(executionManager))) {
+		if (ExecutionState.FAILED.equals(subQuery.getState())) {
 			managedInternalForm.fail(
 					getError().orElseThrow(
 							() -> new IllegalStateException(String.format("Query[%s] failed but no error was set.", subQuery.getId()))
-					),
-					executionManager
+					)
 			);
 		}
 
 		if (managedInternalForm.allSubQueriesDone(executionManager)) {
 
 			ManagedExecutionId id = managedInternalForm.getId();
-			managedInternalForm.finish(ExecutionState.DONE, executionManager);
+			managedInternalForm.finish(ExecutionState.DONE);
 		}
 
 	}

--- a/backend/src/main/java/com/bakdata/conquery/models/query/results/FormShardResult.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/results/FormShardResult.java
@@ -39,7 +39,7 @@ public class FormShardResult extends ShardResult {
 		executionManager.handleQueryResult(this, subQuery);
 
 		// Fail the whole execution if a subquery fails
-		if (ExecutionState.FAILED.equals(subQuery.getState())) {
+		if (ExecutionState.FAILED.equals(subQuery.getState(executionManager))) {
 			managedInternalForm.fail(
 					getError().orElseThrow(
 							() -> new IllegalStateException(String.format("Query[%s] failed but no error was set.", subQuery.getId()))
@@ -48,7 +48,9 @@ public class FormShardResult extends ShardResult {
 			);
 		}
 
-		if (managedInternalForm.allSubQueriesDone()) {
+		if (managedInternalForm.allSubQueriesDone(executionManager)) {
+
+			ManagedExecutionId id = managedInternalForm.getId();
 			managedInternalForm.finish(ExecutionState.DONE, executionManager);
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/models/query/results/FormShardResult.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/results/FormShardResult.java
@@ -48,8 +48,6 @@ public class FormShardResult extends ShardResult {
 		}
 
 		if (managedInternalForm.allSubQueriesDone(executionManager)) {
-
-			ManagedExecutionId id = managedInternalForm.getId();
 			managedInternalForm.finish(ExecutionState.DONE);
 		}
 

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
@@ -116,7 +116,7 @@ public class AdminResource {
 						  catch (ConqueryError e) {
 							  // Initialization of execution probably failed, so we construct a status based on the overview status
 							  final FullExecutionStatus fullExecutionStatus = new FullExecutionStatus();
-							  t.setStatusBase(currentUser, fullExecutionStatus, namespace);
+							  t.setStatusBase(currentUser, fullExecutionStatus, namespace.getExecutionManager());
 							  fullExecutionStatus.setStatus(ExecutionState.FAILED);
 							  fullExecutionStatus.setError(e);
 							  return fullExecutionStatus;

--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminResource.java
@@ -116,7 +116,7 @@ public class AdminResource {
 						  catch (ConqueryError e) {
 							  // Initialization of execution probably failed, so we construct a status based on the overview status
 							  final FullExecutionStatus fullExecutionStatus = new FullExecutionStatus();
-							  t.setStatusBase(currentUser, fullExecutionStatus, namespace.getExecutionManager());
+							  t.setStatusBase(currentUser, fullExecutionStatus);
 							  fullExecutionStatus.setStatus(ExecutionState.FAILED);
 							  fullExecutionStatus.setError(e);
 							  return fullExecutionStatus;

--- a/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlExecutionManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlExecutionManager.java
@@ -86,7 +86,7 @@ public class SqlExecutionManager extends ExecutionManager {
 									SqlExecutionState startResult = getResult(id);
 									SqlExecutionState
 											finishResult =
-											new SqlExecutionState(result.getColumnNames(), result.getTable(), startResult.getExecutingLock());
+											new SqlExecutionState(ExecutionState.DONE, result.getColumnNames(), result.getTable(), startResult.getExecutingLock());
 									addState(id, finishResult);
 
 									managedQuery.setLastResultCount(((long) result.getRowCount()));

--- a/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlExecutionManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conquery/SqlExecutionManager.java
@@ -48,32 +48,16 @@ public class SqlExecutionManager extends ExecutionManager {
 
 		if (execution instanceof ManagedInternalForm<?> managedForm) {
 			CompletableFuture.allOf(managedForm.getSubQueries().values().stream().map(managedQuery -> {
-								 addState(managedQuery.getId(), new SqlExecutionState());
-								 return executeAsync(managedQuery, this);
+												   addState(managedQuery.getId(), new SqlExecutionState());
+												   return executeAsync(managedQuery, this);
 
-							 }).toArray(CompletableFuture[]::new))
+											   })
+											   .toArray(CompletableFuture[]::new))
 							 .thenRun(() -> managedForm.finish(ExecutionState.DONE));
 			return;
 		}
 
 		throw new IllegalStateException("Unexpected type of execution: %s".formatted(execution.getClass()));
-	}
-
-	@Override
-	public void doCancelQuery(ManagedExecution execution) {
-
-		CompletableFuture<Void> sqlQueryExecution = runningExecutions.remove(execution.getId());
-
-		// already finished/canceled
-		if (sqlQueryExecution == null) {
-			return;
-		}
-
-		if (!sqlQueryExecution.isCancelled()) {
-			sqlQueryExecution.cancel(true);
-		}
-
-		execution.cancel();
 	}
 
 	private CompletableFuture<Void> executeAsync(ManagedQuery managedQuery, SqlExecutionManager executionManager) {
@@ -99,6 +83,23 @@ public class SqlExecutionManager extends ExecutionManager {
 									runningExecutions.remove(managedQuery.getId());
 									return null;
 								});
+	}
+
+	@Override
+	public void doCancelQuery(ManagedExecution execution) {
+
+		CompletableFuture<Void> sqlQueryExecution = runningExecutions.remove(execution.getId());
+
+		// already finished/canceled
+		if (sqlQueryExecution == null) {
+			return;
+		}
+
+		if (!sqlQueryExecution.isCancelled()) {
+			sqlQueryExecution.cancel(true);
+		}
+
+		execution.cancel();
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/sql/execution/SqlExecutionService.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/execution/SqlExecutionService.java
@@ -13,6 +13,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.bakdata.conquery.models.error.ConqueryError;
+import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.query.resultinfo.ResultInfo;
 import com.bakdata.conquery.models.query.results.EntityResult;
 import com.bakdata.conquery.models.types.ResultType;
@@ -59,7 +60,7 @@ public class SqlExecutionService {
 			final List<String> columnNames = getColumnNames(resultSet, columnCount);
 			final List<EntityResult> resultTable = createResultTable(resultSet, resultTypes, columnCount);
 
-			return new SqlExecutionState(columnNames, resultTable, new CountDownLatch(1));
+			return new SqlExecutionState(ExecutionState.RUNNING, columnNames, resultTable, new CountDownLatch(1));
 		}
 		// not all DB vendors throw SQLExceptions
 		catch (SQLException | RuntimeException e) {

--- a/backend/src/main/java/com/bakdata/conquery/sql/execution/SqlExecutionState.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/execution/SqlExecutionState.java
@@ -4,26 +4,32 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
 
+import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.query.results.EntityResult;
-import lombok.Value;
+import lombok.Data;
+import lombok.Setter;
 
-@Value
+@Data
 public class SqlExecutionState implements ExecutionManager.InternalState {
 
+	@Setter
+	ExecutionState state;
 	List<String> columnNames;
 	List<EntityResult> table;
 	int rowCount;
 	CountDownLatch executingLock;
 
 	public SqlExecutionState() {
+		this.state = ExecutionState.RUNNING;
 		this.columnNames = null;
 		this.table = null;
 		this.executingLock = new CountDownLatch(1);
 		rowCount = 0;
 	}
 
-	public SqlExecutionState(List<String> columnNames, List<EntityResult> table, CountDownLatch executingLock) {
+	public SqlExecutionState(ExecutionState state, List<String> columnNames, List<EntityResult> table, CountDownLatch executingLock) {
+		this.state = state;
 		this.columnNames = columnNames;
 		this.table = table;
 		this.executingLock = executingLock;

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/FormConfigTest.java
@@ -130,7 +130,7 @@ public class FormConfigTest {
 		user = new User("test", "test", storage);
 		storage.addUser(user);
 
-		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), user, dataset, null);
+		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), user, dataset, null, null);
 		managedQuery.setQueryId(UUID.randomUUID());
 
 		form = new ExportForm();

--- a/backend/src/test/java/com/bakdata/conquery/api/form/config/TestForm.java
+++ b/backend/src/test/java/com/bakdata/conquery/api/form/config/TestForm.java
@@ -18,14 +18,15 @@ import com.bakdata.conquery.models.forms.managed.ManagedInternalForm;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
 import com.bakdata.conquery.models.query.QueryResolveContext;
 import com.bakdata.conquery.models.query.Visitable;
+import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class TestForm extends Form implements InternalForm {
 
 	@Override
-	public ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage) {
-		return new ManagedInternalForm<>(this, user, submittedDataset, storage);
+	public ManagedExecution toManagedExecution(User user, Dataset submittedDataset, MetaStorage storage, DatasetRegistry<?> datasetRegistry) {
+		return new ManagedInternalForm<>(this, user, submittedDataset, storage, datasetRegistry);
 	}
 
 	@Override

--- a/backend/src/test/java/com/bakdata/conquery/integration/DownloadLinkGeneration.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/DownloadLinkGeneration.java
@@ -42,7 +42,7 @@ public class DownloadLinkGeneration extends IntegrationTest.Simple implements Pr
 		test.importRequiredData(conquery);
 
 		// Create execution for download
-		ManagedQuery exec = new ManagedQuery(test.getQuery(), user, conquery.getDataset(), storage);
+		ManagedQuery exec = new ManagedQuery(test.getQuery(), user, conquery.getDataset(), storage, conquery.getDatasetRegistry());
 		exec.setLastResultCount(100L);
 
 		storage.addExecution(exec);

--- a/backend/src/test/java/com/bakdata/conquery/integration/DownloadLinkGeneration.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/DownloadLinkGeneration.java
@@ -17,6 +17,7 @@ import com.bakdata.conquery.models.auth.permissions.Ability;
 import com.bakdata.conquery.models.auth.permissions.DatasetPermission;
 import com.bakdata.conquery.models.exceptions.ValidatorHelper;
 import com.bakdata.conquery.models.execution.ExecutionState;
+import com.bakdata.conquery.models.query.DistributedExecutionManager;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.github.powerlibraries.io.In;
@@ -56,7 +57,10 @@ public class DownloadLinkGeneration extends IntegrationTest.Simple implements Pr
 
 		{
 			// Tinker the state of the execution and try again: still not possible because of missing permissions
-			exec.setState(ExecutionState.DONE);
+			DistributedExecutionManager.DistributedState distributedState = new DistributedExecutionManager.DistributedState();
+			distributedState.setState(ExecutionState.DONE);
+			distributedState.getExecutingLock().countDown();
+			conquery.getNamespace().getExecutionManager().addState(exec.getId(), distributedState);
 
 			FullExecutionStatus status = IntegrationUtils.getExecutionStatus(conquery, exec.getId(), user, 200);
 			assertThat(status.getResultUrls()).isEmpty();

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/IntegrationUtils.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/IntegrationUtils.java
@@ -4,14 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
-
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import com.bakdata.conquery.apiv1.execution.ExecutionStatus;
 import com.bakdata.conquery.apiv1.execution.FullExecutionStatus;
+import com.bakdata.conquery.apiv1.execution.OverviewExecutionStatus;
 import com.bakdata.conquery.apiv1.query.Query;
 import com.bakdata.conquery.integration.json.ConqueryTestSpec;
 import com.bakdata.conquery.io.storage.MetaStorage;
@@ -109,8 +111,32 @@ public class IntegrationUtils {
 		return ManagedExecutionId.Parser.INSTANCE.parse(id);
 	}
 
+	public static List<OverviewExecutionStatus> getAllQueries(StandaloneSupport conquery, int expectedResponseCode) {
+
+		URI allQueriesURI = getAllQueriesURI(conquery);
+		final Response response = conquery.getClient()
+										  .target(allQueriesURI)
+										  .queryParam("all-providers", true)
+										  .request(MediaType.APPLICATION_JSON_TYPE)
+										  .get();
+
+
+		assertThat(response.getStatusInfo().getStatusCode()).as("Result of %s", allQueriesURI)
+															.isEqualTo(expectedResponseCode);
+
+		return response.readEntity(new GenericType<>() {
+		});
+	}
+
 	private static URI getPostQueryURI(StandaloneSupport conquery) {
 		return HierarchyHelper.hierarchicalPath(conquery.defaultApiURIBuilder(), DatasetQueryResource.class, "postQuery")
+							  .buildFromMap(Map.of(
+									  "dataset", conquery.getDataset().getId()
+							  ));
+	}
+
+	private static URI getAllQueriesURI(StandaloneSupport conquery) {
+		return HierarchyHelper.hierarchicalPath(conquery.defaultApiURIBuilder(), DatasetQueryResource.class, "getAllQueries")
 							  .buildFromMap(Map.of(
 									  "dataset", conquery.getDataset().getId()
 							  ));

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
@@ -80,7 +80,7 @@ public class LoadingUtil {
 
 			user.addPermission(managed.createPermission(AbilitySets.QUERY_CREATOR));
 
-			if (managed.getState(executionManager) == ExecutionState.FAILED) {
+			if (managed.getState() == ExecutionState.FAILED) {
 				fail("Query failed");
 			}
 		}
@@ -95,7 +95,7 @@ public class LoadingUtil {
 
 			user.addPermission(ExecutionPermission.onInstance(AbilitySets.QUERY_CREATOR, managed.getId()));
 
-			if (managed.getState(executionManager) == ExecutionState.FAILED) {
+			if (managed.getState() == ExecutionState.FAILED) {
 				fail("Query failed");
 			}
 		}

--- a/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/common/LoadingUtil.java
@@ -80,7 +80,7 @@ public class LoadingUtil {
 
 			user.addPermission(managed.createPermission(AbilitySets.QUERY_CREATOR));
 
-			if (managed.getState() == ExecutionState.FAILED) {
+			if (managed.getState(executionManager) == ExecutionState.FAILED) {
 				fail("Query failed");
 			}
 		}
@@ -95,7 +95,7 @@ public class LoadingUtil {
 
 			user.addPermission(ExecutionPermission.onInstance(AbilitySets.QUERY_CREATOR, managed.getId()));
 
-			if (managed.getState() == ExecutionState.FAILED) {
+			if (managed.getState(executionManager) == ExecutionState.FAILED) {
 				fail("Query failed");
 			}
 		}

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -101,7 +101,7 @@ public class FormTest extends ConqueryTestSpec {
 
 		ExecutionState executionState = namespace.getExecutionManager().awaitDone(managedForm, 10, TimeUnit.MINUTES);
 		if (executionState != ExecutionState.DONE) {
-			if (managedForm.getState(executionManager) == ExecutionState.FAILED) {
+			if (managedForm.getState() == ExecutionState.FAILED) {
 				fail(getLabel() + " Query failed");
 			}
 			else {

--- a/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/json/FormTest.java
@@ -11,6 +11,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
 import com.bakdata.conquery.apiv1.forms.Form;
 import com.bakdata.conquery.integration.common.RequiredData;
 import com.bakdata.conquery.integration.common.ResourceFile;
@@ -23,6 +27,7 @@ import com.bakdata.conquery.models.execution.ExecutionState;
 import com.bakdata.conquery.models.forms.managed.ManagedForm;
 import com.bakdata.conquery.models.forms.managed.ManagedInternalForm;
 import com.bakdata.conquery.models.identifiable.mapping.IdPrinter;
+import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.query.ManagedQuery;
 import com.bakdata.conquery.models.query.PrintSettings;
 import com.bakdata.conquery.models.query.SingleTableResult;
@@ -37,9 +42,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.github.powerlibraries.io.In;
 import com.univocity.parsers.csv.CsvWriter;
 import io.dropwizard.validation.ValidationMethod;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -93,14 +95,13 @@ public class FormTest extends ConqueryTestSpec {
 				.isEmpty();
 
 
-		ManagedInternalForm<?> managedForm = (ManagedInternalForm<?>) support
-				.getNamespace()
-				.getExecutionManager()
+		ExecutionManager executionManager = support.getNamespace().getExecutionManager();
+		ManagedInternalForm<?> managedForm = (ManagedInternalForm<?>) executionManager
 				.runQuery(namespace, form, support.getTestUser(), support.getConfig(), false);
 
 		ExecutionState executionState = namespace.getExecutionManager().awaitDone(managedForm, 10, TimeUnit.MINUTES);
 		if (executionState != ExecutionState.DONE) {
-			if (managedForm.getState() == ExecutionState.FAILED) {
+			if (managedForm.getState(executionManager) == ExecutionState.FAILED) {
 				fail(getLabel() + " Query failed");
 			}
 			else {

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/ExternalFormBackendTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/ExternalFormBackendTest.java
@@ -93,6 +93,7 @@ public class ExternalFormBackendTest implements ProgrammaticIntegrationTest {
 		assert managedExecutionId != null;
 		final FullExecutionStatus executionStatus = IntegrationUtils.getExecutionStatus(support, managedExecutionId, testUser, 200);
 
+		assertThat(executionStatus.getStatus()).isEqualTo(ExecutionState.DONE);
 
 		// Generate asset urls and check them in the status
 		final ManagedExecution storedExecution = testConquery.getSupport(name).getMetaStorage().getExecution(managedExecutionId);
@@ -108,7 +109,6 @@ public class ExternalFormBackendTest implements ProgrammaticIntegrationTest {
 																																				 .getAssetId());
 
 
-		assertThat(executionStatus.getStatus()).isEqualTo(ExecutionState.DONE);
 		assertThat(executionStatus.getResultUrls()).containsExactly(new ResultAsset("Result", downloadUrlAsset1), new ResultAsset("Another Result", downloadUrlAsset2));
 
 		log.info("Download Result");

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/RestartTest.java
@@ -2,7 +2,12 @@ package com.bakdata.conquery.integration.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import jakarta.validation.Validator;
+
+import com.bakdata.conquery.apiv1.execution.OverviewExecutionStatus;
 import com.bakdata.conquery.commands.ManagerNode;
+import com.bakdata.conquery.integration.common.IntegrationUtils;
 import com.bakdata.conquery.integration.json.ConqueryTestSpec;
 import com.bakdata.conquery.integration.json.JsonIntegrationTest;
 import com.bakdata.conquery.io.storage.MetaStorage;
@@ -23,7 +28,6 @@ import com.bakdata.conquery.util.support.StandaloneSupport;
 import com.bakdata.conquery.util.support.TestConquery;
 import com.github.powerlibraries.io.In;
 import io.dropwizard.jersey.validation.Validators;
-import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -40,7 +44,7 @@ public class RestartTest implements ProgrammaticIntegrationTest {
 	public void execute(String name, TestConquery testConquery) throws Exception {
 
 		//read test specification
-		String testJson = In.resource("/tests/query/RESTART_TEST_DATA/SIMPLE_TREECONCEPT_Query.json").withUTF8().readAll();
+		String testJson = In.resource("/tests/query/RESTART_TEST_DATA/SIMPLE_FRONTEND_Query.json").withUTF8().readAll();
 
 		Validator validator = Validators.newValidator();
 		EntityIdMap entityIdMap = IdMapSerialisationTest.createTestPersistentMap();
@@ -61,6 +65,7 @@ public class RestartTest implements ProgrammaticIntegrationTest {
 		test.executeTest(conquery);
 
 		final int numberOfExecutions = conquery.getMetaStorage().getAllExecutions().size();
+		assertThat(numberOfExecutions).isEqualTo(1);
 
 		// IDMapping Testing
 		NamespaceStorage namespaceStorage = conquery.getNamespaceStorage();
@@ -141,10 +146,13 @@ public class RestartTest implements ProgrammaticIntegrationTest {
 
 
 		log.info("Restart complete");
-		
-		DatasetRegistry datasetRegistry = support.getDatasetsProcessor().getDatasetRegistry();
+
+		DatasetRegistry<?> datasetRegistry = support.getDatasetsProcessor().getDatasetRegistry();
 
 		assertThat(support.getMetaStorage().getAllExecutions().size()).as("Executions after restart").isEqualTo(numberOfExecutions);
+
+		List<OverviewExecutionStatus> allQueries = IntegrationUtils.getAllQueries(support, 200);
+		assertThat(allQueries).size().isEqualTo(1);
 
 		test.executeTest(support);
 

--- a/backend/src/test/java/com/bakdata/conquery/io/result/ResultTestUtil.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/result/ResultTestUtil.java
@@ -62,7 +62,7 @@ public class ResultTestUtil {
 
 	@NotNull
 	public static ManagedQuery getTestQuery() {
-		return new ManagedQuery(mock(Query.class), mock(User.class), new Dataset(ResultTestUtil.class.getSimpleName()), null) {
+		return new ManagedQuery(mock(Query.class), mock(User.class), new Dataset(ResultTestUtil.class.getSimpleName()), null, null) {
 			@Override
 			public List<ResultInfo> getResultInfos(PrintSettings printSettings) {
 				return getResultTypes().stream()

--- a/backend/src/test/java/com/bakdata/conquery/io/result/excel/ExcelResultRenderTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/result/excel/ExcelResultRenderTest.java
@@ -70,7 +70,7 @@ public class ExcelResultRenderTest {
 		// The Shard nodes send Object[] but since Jackson is used for deserialization, nested collections are always a list because they are not further specialized
 		List<EntityResult> results = getTestEntityResults();
 
-		ManagedQuery mquery = new ManagedQuery(mock(Query.class), mock(User.class), new Dataset(ExcelResultRenderTest.class.getSimpleName()), null) {
+		ManagedQuery mquery = new ManagedQuery(mock(Query.class), mock(User.class), new Dataset(ExcelResultRenderTest.class.getSimpleName()), null, null) {
 			public List<ResultInfo> getResultInfos(PrintSettings printSettings) {
 				return getResultTypes().stream()
 									   .map(ResultTestUtil.TypedSelectDummy::new)

--- a/backend/src/test/java/com/bakdata/conquery/io/storage/xodus/stores/SerializingStoreDumpTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/storage/xodus/stores/SerializingStoreDumpTest.java
@@ -44,7 +44,7 @@ public class SerializingStoreDumpTest {
 	private ObjectMapper objectMapper;
 
 	// Test data
-	private final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), new Dataset("dataset"), STORAGE);
+	private final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), new Dataset("dataset"), STORAGE, null);
 	private final ConceptQuery cQuery = new ConceptQuery(
 			new CQReusedQuery(managedQuery.getId()));
 	private final User user = new User("username", "userlabel", STORAGE);

--- a/backend/src/test/java/com/bakdata/conquery/models/SerializationTests.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/SerializationTests.java
@@ -346,7 +346,7 @@ public class SerializationTests extends AbstractSerializationTest {
 
 		getMetaStorage().updateUser(user);
 
-		ManagedQuery execution = new ManagedQuery(null, user, dataset, getMetaStorage());
+		ManagedQuery execution = new ManagedQuery(null, user, dataset, getMetaStorage(), getDatasetRegistry());
 		execution.setTags(new String[]{"test-tag"});
 
 		SerializationTestUtil.forType(ManagedExecution.class)
@@ -385,7 +385,7 @@ public class SerializationTests extends AbstractSerializationTest {
 
 		final ExportForm exportForm = createExportForm(registry, dataset);
 
-		ManagedInternalForm<ExportForm> execution = new ManagedInternalForm<>(exportForm, user, dataset, getMetaStorage());
+		ManagedInternalForm<ExportForm> execution = new ManagedInternalForm<>(exportForm, user, dataset, getMetaStorage(), getDatasetRegistry());
 		execution.setTags(new String[]{"test-tag"});
 
 		SerializationTestUtil.forType(ManagedExecution.class)
@@ -410,7 +410,7 @@ public class SerializationTests extends AbstractSerializationTest {
 		final Dataset dataset = SerialisationObjectsUtil.createDataset(centralRegistry);
 		final User user = SerialisationObjectsUtil.createUser(centralRegistry, getMetaStorage());
 
-		final ExternalExecution execution = new ExternalExecution(form, user, dataset, getMetaStorage());
+		final ExternalExecution execution = new ExternalExecution(form, user, dataset, getMetaStorage(), getDatasetRegistry());
 
 		SerializationTestUtil.forType(ManagedExecution.class)
 							 .objectMappers(getManagerInternalMapper())

--- a/backend/src/test/java/com/bakdata/conquery/models/execution/DefaultLabelTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/models/execution/DefaultLabelTest.java
@@ -58,11 +58,8 @@ public class DefaultLabelTest {
 
 		I18n.init();
 
-		doAnswer((invocation -> {
-			return CONCEPT;
-
-		})).when(NAMESPACE)
-		   .resolve(CONCEPT.getId());
+		doAnswer((invocation -> CONCEPT)).when(NAMESPACE)
+										 .resolve(CONCEPT.getId());
 	}
 
 	@ParameterizedTest
@@ -75,7 +72,7 @@ public class DefaultLabelTest {
 
 		CQConcept concept = makeCQConcept("Concept");
 		ConceptQuery cq = new ConceptQuery(concept);
-		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE);
+		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE, null);
 
 		mQuery.setLabel(mQuery.makeAutoLabel(getPrintSettings(locale)));
 
@@ -108,7 +105,7 @@ public class DefaultLabelTest {
 		concept.setLabel(null);
 		concept.setElements(List.of(CONCEPT));
 		ConceptQuery cq = new ConceptQuery(concept);
-		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE);
+		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE, null);
 		UUID uuid = UUID.randomUUID();
 		mQuery.setQueryId(uuid);
 
@@ -127,12 +124,12 @@ public class DefaultLabelTest {
 	void autoLabelReusedQuery(Locale locale, String autoLabel) {
 		I18n.LOCALE.set(locale);
 
-		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), DATASET, STORAGE);
+		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), DATASET, STORAGE, null);
 		managedQuery.setQueryId(UUID.randomUUID());
 
 		CQReusedQuery reused = new CQReusedQuery(managedQuery.getId());
 		ConceptQuery cq = new ConceptQuery(reused);
-		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE);
+		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE, null);
 
 		mQuery.setLabel(mQuery.makeAutoLabel(getPrintSettings(locale)));
 
@@ -151,7 +148,7 @@ public class DefaultLabelTest {
 
 		CQExternal external = new CQExternal(List.of(), new String[0][0], false);
 		ConceptQuery cq = new ConceptQuery(external);
-		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE);
+		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE, null);
 
 		mQuery.setLabel(mQuery.makeAutoLabel(getPrintSettings(locale)));
 
@@ -167,7 +164,7 @@ public class DefaultLabelTest {
 	void autoLabelComplexQuery(Locale locale, String autoLabel) {
 		I18n.LOCALE.set(locale);
 
-		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), DATASET, STORAGE);
+		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), DATASET, STORAGE, null);
 		managedQuery.setQueryId(UUID.randomUUID());
 
 		CQAnd and = new CQAnd();
@@ -183,7 +180,7 @@ public class DefaultLabelTest {
 				concept3
 		));
 		ConceptQuery cq = new ConceptQuery(and);
-		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE);
+		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE, null);
 
 		mQuery.setLabel(mQuery.makeAutoLabel(getPrintSettings(locale)));
 
@@ -200,7 +197,7 @@ public class DefaultLabelTest {
 	void autoLabelComplexQueryNullLabels(Locale locale, String autoLabel) {
 		I18n.LOCALE.set(locale);
 
-		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), DATASET, STORAGE);
+		final ManagedQuery managedQuery = new ManagedQuery(mock(Query.class), mock(User.class), DATASET, STORAGE, null);
 		managedQuery.setQueryId(UUID.randomUUID());
 
 		CQAnd and = new CQAnd();
@@ -217,7 +214,7 @@ public class DefaultLabelTest {
 				concept3
 		));
 		ConceptQuery cq = new ConceptQuery(and);
-		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE);
+		ManagedQuery mQuery = cq.toManagedExecution(user, DATASET, STORAGE, null);
 
 		mQuery.setLabel(mQuery.makeAutoLabel(getPrintSettings(locale)));
 
@@ -234,7 +231,7 @@ public class DefaultLabelTest {
 		I18n.LOCALE.set(locale);
 
 		ExportForm form = new ExportForm();
-		ManagedForm<?> mForm = form.toManagedExecution(user, DATASET, STORAGE);
+		ManagedForm<?> mForm = form.toManagedExecution(user, DATASET, STORAGE, null);
 		mForm.setCreationTime(LocalDateTime.of(2020, 10, 30, 12, 37));
 
 		mForm.setLabel(mForm.makeAutoLabel(getPrintSettings(locale)));

--- a/backend/src/test/java/com/bakdata/conquery/tasks/PermissionCleanupTaskTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/tasks/PermissionCleanupTaskTest.java
@@ -42,7 +42,7 @@ class PermissionCleanupTaskTest {
 
         ConceptQuery query = new ConceptQuery(root);
 
-		final ManagedQuery managedQuery = new ManagedQuery(query, mock(User.class), new Dataset("test"), STORAGE);
+		final ManagedQuery managedQuery = new ManagedQuery(query, mock(User.class), new Dataset("test"), STORAGE, null);
 
         managedQuery.setCreationTime(LocalDateTime.now().minusDays(1));
 

--- a/backend/src/test/java/com/bakdata/conquery/tasks/QueryCleanupTaskTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/tasks/QueryCleanupTaskTest.java
@@ -36,7 +36,7 @@ class QueryCleanupTaskTest {
 
 		ConceptQuery query = new ConceptQuery(root);
 
-		final ManagedQuery managedQuery = new ManagedQuery(query, mock(User.class), new Dataset("test"), STORAGE);
+		final ManagedQuery managedQuery = new ManagedQuery(query, mock(User.class), new Dataset("test"), STORAGE, null);
 
 		managedQuery.setCreationTime(LocalDateTime.now().minus(queryExpiration).minusDays(1));
 

--- a/backend/src/test/java/com/bakdata/conquery/util/support/TestConquery.java
+++ b/backend/src/test/java/com/bakdata/conquery/util/support/TestConquery.java
@@ -27,8 +27,8 @@ import com.bakdata.conquery.models.auth.entities.User;
 import com.bakdata.conquery.models.config.ConqueryConfig;
 import com.bakdata.conquery.models.datasets.Dataset;
 import com.bakdata.conquery.models.execution.ExecutionState;
-import com.bakdata.conquery.models.execution.ManagedExecution;
 import com.bakdata.conquery.models.identifiable.ids.specific.DatasetId;
+import com.bakdata.conquery.models.query.ExecutionManager;
 import com.bakdata.conquery.models.worker.DatasetRegistry;
 import com.bakdata.conquery.models.worker.Namespace;
 import com.bakdata.conquery.util.io.Cloner;
@@ -252,11 +252,10 @@ public class TestConquery {
 	private boolean isBusy() {
 		boolean busy;
 		busy = standaloneCommand.getManagerNode().getJobManager().isSlowWorkerBusy();
-		busy |= standaloneCommand.getManagerNode()
-				.getMetaStorage()
-								 .getAllExecutions()
-								 .stream()
-								 .map(ManagedExecution::getState)
+		busy |= standaloneCommand.getManager().getDatasetRegistry().getDatasets().stream()
+								 .map(Namespace::getExecutionManager)
+								 .flatMap(e -> e.getExecutionStates().asMap().values().stream())
+								 .map(ExecutionManager.State::getState)
 								 .anyMatch(ExecutionState.RUNNING::equals);
 
 		for (Namespace namespace : standaloneCommand.getManagerNode().getDatasetRegistry().getDatasets()) {

--- a/backend/src/test/resources/tests/query/RESTART_TEST_DATA/SIMPLE_FRONTEND_Query.json
+++ b/backend/src/test/resources/tests/query/RESTART_TEST_DATA/SIMPLE_FRONTEND_Query.json
@@ -5,14 +5,24 @@
   "query": {
     "type": "CONCEPT_QUERY",
     "root": {
-      "type": "CONCEPT",
-      "ids": [
-        "test_tree.test_child1"
-      ],
-      "tables": [
+      "type": "AND",
+      "children": [
         {
-          "id": "test_tree.connector",
-          "filters": []
+          "type": "OR",
+          "children": [
+            {
+              "type": "CONCEPT",
+              "ids": [
+                "test_tree.test_child1"
+              ],
+              "tables": [
+                {
+                  "id": "test_tree.connector",
+                  "filters": []
+                }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
```
ERROR [2024-09-19 22:01:54]	i.d.j.e.LoggingExceptionMapper	user.81ac8d69-f2a6-4cf8-bf61-292453a3f44b	Error handling a request: ac5e6b1e3510bfab
java.lang.NullPointerException: Cannot invoke "com.bakdata.conquery.models.config.ConqueryConfig.getPreprocessor()" because "config" is null
	at com.bakdata.conquery.models.query.PrintSettings.<init>(PrintSettings.java:69)
	at com.bakdata.conquery.models.query.PrintSettings.<init>(PrintSettings.java:62)
	at com.bakdata.conquery.models.config.ExcelResultProvider.generateResultURLs(ExcelResultProvider.java:77)
	at com.bakdata.conquery.apiv1.QueryProcessor.lambda$getResultAssets$4(QueryProcessor.java:175)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at com.bakdata.conquery.apiv1.QueryProcessor.getResultAssets(QueryProcessor.java:184)
	at com.bakdata.conquery.apiv1.QueryProcessor.lambda$getQueriesFiltered$3(QueryProcessor.java:132)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
	at java.base/java.util.concurrent.ConcurrentHashMap$ValueSpliterator.forEachRemaining(ConcurrentHashMap.java:3612)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at com.bakdata.conquery.resources.api.DatasetQueryResource.getAllQueries(DatasetQueryResource.java:95)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

```