### PR TITLE
Fix search for multi struct node hierarchy

### DIFF
--- a/frontend/src/js/concept-trees/ConceptTreeListItem.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeListItem.tsx
@@ -1,11 +1,11 @@
-import { FC } from "react";
+import { FC, useMemo } from "react";
 
 import type { ConceptIdT } from "../api/types";
 
 import ConceptTree from "./ConceptTree";
 import ConceptTreeFolder from "./ConceptTreeFolder";
 import { getConceptById } from "./globalTreeStoreHelper";
-import type { SearchT, TreesT } from "./reducer";
+import type { LoadedConcept, SearchT, TreesT } from "./reducer";
 import { isNodeInSearchResult } from "./selectors";
 
 interface PropsT {
@@ -15,6 +15,18 @@ interface PropsT {
   onLoadTree: (id: string) => void;
 }
 
+const getNonFolderChildren = (trees: TreesT, node: LoadedConcept): string[] => {
+  if (node.detailsAvailable) return node.children || [];
+
+  if (!node.children) return [];
+
+  // recursively get children of children
+  return node.children.reduce((acc, childId) => {
+    const child = trees[childId];
+    return acc.concat(getNonFolderChildren(trees, child));
+  }, [] as ConceptIdT[]);
+};
+
 const ConceptTreeListItem: FC<PropsT> = ({
   trees,
   conceptId,
@@ -23,7 +35,13 @@ const ConceptTreeListItem: FC<PropsT> = ({
 }) => {
   const tree = trees[conceptId];
 
-  if (!isNodeInSearchResult(conceptId, search, tree.children)) return null;
+  const nonFolderChildren = useMemo(() => {
+    if (tree.detailsAvailable) return tree.children;
+
+    return getNonFolderChildren(trees, tree);
+  }, [trees, tree]);
+
+  if (!isNodeInSearchResult(conceptId, search, nonFolderChildren)) return null;
 
   const rootConcept = getConceptById(conceptId);
 

--- a/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
+++ b/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
@@ -180,13 +180,9 @@ export const globalSearch = async (trees: TreesT, query: string) => {
   //
   // TODO: Refactor the state and keep both root trees as well as concept trees in a single format
   //       Then simply use that here
-  const formattedTrees = Object.keys(trees).reduce<
-    Record<string, Record<string, ConceptT>>
-  >((all, key) => {
-    all[key] = { [key]: trees[key] };
-
-    return all;
-  }, {});
+  const formattedTrees = Object.fromEntries(
+    Object.entries(trees).map(([key, value]) => [key, { [key]: value }]),
+  );
   const combinedTrees = Object.assign({}, formattedTrees, window.conceptTrees);
 
   const result = Object.keys(combinedTrees)

--- a/frontend/src/js/concept-trees/search.ts
+++ b/frontend/src/js/concept-trees/search.ts
@@ -58,17 +58,17 @@ export const findConcepts = (
   // Count node as 1 already, if it matches
   let sum = isNodeIncluded ? 1 : 0;
 
-  for (const child of node.children) {
+  for (const childId of node.children) {
     const result = findConcepts(
       trees,
       treeId,
-      child,
-      trees[treeId][child],
+      childId,
+      trees[treeId][childId],
       query,
       intermediateResult,
     );
 
-    sum += result[child] || 0;
+    sum += result[childId] || 0;
   }
 
   if (sum !== 0) {

--- a/frontend/src/js/concept-trees/selectors.ts
+++ b/frontend/src/js/concept-trees/selectors.ts
@@ -15,7 +15,7 @@ const isChildWithinResults = (children: ConceptIdT[], search: SearchT) => {
 export const isNodeInSearchResult = (
   id: ConceptIdT,
   search: SearchT,
-  children?: ConceptIdT[],
+  children?: ConceptIdT[], // actual concept tree ids, not folder ids
 ) => {
   if (!search.result) return true;
 


### PR DESCRIPTION
So that all nested levels of struct nodes open, if one of the concept trees contained within them is part of the search result.