### PR TITLE
Fix search for multi struct node hierarchy

### DIFF
--- a/frontend/src/js/concept-trees/ConceptTreeListItem.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeListItem.tsx
@@ -2,22 +2,10 @@ import { useMemo } from "react";
 import type { ConceptIdT } from "../api/types";
 
 import ConceptTree from "./ConceptTree";
-import ConceptTreeFolder from "./ConceptTreeFolder";
+import ConceptTreeFolder, { getNonFolderChildren } from "./ConceptTreeFolder";
 import { getConceptById } from "./globalTreeStoreHelper";
-import type { LoadedConcept, SearchT, TreesT } from "./reducer";
+import type { SearchT, TreesT } from "./reducer";
 import { isNodeInSearchResult } from "./selectors";
-
-const getNonFolderChildren = (trees: TreesT, node: LoadedConcept): string[] => {
-  if (node.detailsAvailable) return node.children || [];
-
-  if (!node.children) return [];
-
-  // collect all non-folder children, recursively
-  return node.children.reduce<ConceptIdT[]>((acc, childId) => {
-    const child = trees[childId];
-    return acc.concat(getNonFolderChildren(trees, child));
-  }, []);
-};
 
 const ConceptTreeListItem = ({
   trees,
@@ -32,11 +20,11 @@ const ConceptTreeListItem = ({
 }) => {
   const tree = trees[conceptId];
 
-  const nonFolderChildren = useMemo(() => {
-    if (tree.detailsAvailable) return tree.children;
-
-    return getNonFolderChildren(trees, tree);
-  }, [trees, tree]);
+  const nonFolderChildren = useMemo(
+    () =>
+      tree.detailsAvailable ? tree.children : getNonFolderChildren(trees, tree),
+    [trees, tree],
+  );
 
   if (!isNodeInSearchResult(conceptId, search, nonFolderChildren)) return null;
 

--- a/frontend/src/js/concept-trees/ConceptTreeListItem.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeListItem.tsx
@@ -12,11 +12,11 @@ const getNonFolderChildren = (trees: TreesT, node: LoadedConcept): string[] => {
 
   if (!node.children) return [];
 
-  // recursively get children of children
-  return node.children.reduce((acc, childId) => {
+  // collect all non-folder children, recursively
+  return node.children.reduce<ConceptIdT[]>((acc, childId) => {
     const child = trees[childId];
     return acc.concat(getNonFolderChildren(trees, child));
-  }, [] as ConceptIdT[]);
+  }, []);
 };
 
 const ConceptTreeListItem = ({

--- a/frontend/src/js/concept-trees/ConceptTreeNodeTextContainer.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNodeTextContainer.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef } from "react";
+import { useRef } from "react";
 import { useDrag } from "react-dnd";
 
 import type { ConceptIdT, ConceptT } from "../api/types";
@@ -14,19 +14,6 @@ import AdditionalInfoHoverable from "../tooltip/AdditionalInfoHoverable";
 
 import ConceptTreeNodeText from "./ConceptTreeNodeText";
 import type { SearchT } from "./reducer";
-
-interface PropsT {
-  conceptId: ConceptIdT;
-  node: ConceptT;
-  root: ConceptT;
-  open: boolean;
-  depth: number;
-  active?: boolean;
-  onTextClick?: () => void;
-  createQueryElement?: () => ConceptQueryNodeType;
-  search: SearchT;
-  isStructFolder?: boolean;
-}
 
 function getResultCount(
   search: SearchT,
@@ -44,7 +31,7 @@ function getResultCount(
     : null;
 }
 
-const ConceptTreeNodeTextContainer: FC<PropsT> = ({
+const ConceptTreeNodeTextContainer = ({
   conceptId,
   node,
   root,
@@ -55,11 +42,24 @@ const ConceptTreeNodeTextContainer: FC<PropsT> = ({
   onTextClick,
   isStructFolder,
   createQueryElement,
+}: {
+  conceptId: ConceptIdT;
+  node: ConceptT;
+  root: ConceptT;
+  open: boolean;
+  depth: number;
+  active?: boolean;
+  onTextClick?: () => void;
+  createQueryElement?: () => ConceptQueryNodeType;
+  search: SearchT;
+  isStructFolder?: boolean;
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
 
   const red = exists(node.matchingEntries) && node.matchingEntries === 0;
-  const resultCount = getResultCount(search, node, conceptId);
+  const resultCount = isStructFolder
+    ? null
+    : getResultCount(search, node, conceptId);
   const hasChildren = !!node.children && node.children.length > 0;
 
   const item: DragItemConceptTreeNode = {

--- a/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
+++ b/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
@@ -181,9 +181,8 @@ export const globalSearch = async (trees: TreesT, query: string) => {
   // TODO: Refactor the state and keep both root trees as well as concept trees in a single format
   //       Then simply use that here
   const formattedTrees = Object.fromEntries(
-    Object.keys(trees).map((key) => [key, { [key]: trees[key] }]),
+    Object.entries(trees).map(([key, value]) => [key, { [key]: value }]),
   );
-
   const combinedTrees = Object.assign({}, formattedTrees, window.conceptTrees);
 
   const result = Object.keys(combinedTrees)

--- a/frontend/src/js/concept-trees/search.ts
+++ b/frontend/src/js/concept-trees/search.ts
@@ -58,17 +58,17 @@ export const findConcepts = (
   // Count node as 1 already, if it matches
   let sum = isNodeIncluded ? 1 : 0;
 
-  for (const child of node.children) {
+  for (const childId of node.children) {
     const result = findConcepts(
       trees,
       treeId,
-      child,
-      trees[treeId][child],
+      childId,
+      trees[treeId][childId],
       query,
       intermediateResult,
     );
 
-    sum += result[child] || 0;
+    sum += result[childId] || 0;
   }
 
   if (sum !== 0) {

--- a/frontend/src/js/concept-trees/selectors.ts
+++ b/frontend/src/js/concept-trees/selectors.ts
@@ -15,7 +15,7 @@ const isChildWithinResults = (children: ConceptIdT[], search: SearchT) => {
 export const isNodeInSearchResult = (
   id: ConceptIdT,
   search: SearchT,
-  children?: ConceptIdT[],
+  children?: ConceptIdT[], // actual concept tree ids, not folder ids
 ) => {
   if (!search.result) return true;
 


### PR DESCRIPTION
So that all nested levels of struct nodes open, if one of the concept trees contained within them is part of the search result.