### PR TITLE
Fix streamQueryResults in case of a failed SQL query

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/sql/execution/SqlExecutionState.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/execution/SqlExecutionState.java
@@ -38,6 +38,10 @@ public class SqlExecutionState implements ExecutionManager.InternalState {
 
 	@Override
 	public Stream<EntityResult> streamQueryResults() {
+		// when the SQL execution fails, table is null
+		if (table == null) {
+			return Stream.empty();
+		}
 		return table.stream();
 	}
 }


### PR DESCRIPTION
Das behebt Issue 43. Der Fehler tauchte nicht direkt in den Logs oder im Stacktrace auf, hat aber dazu geführt, dass [`super.finish()`](https://github.com/ingef/conquery/blob/develop/backend/src/main/java/com/bakdata/conquery/models/query/ManagedQuery.java#L72) nie aufgerufen wurde, wodurch dann die Query für immer im `RUNNING` state verblieb.

