### PR TITLE
Fixes faulty calculation of width in TableExportQueryConverter by usi…

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/apiv1/query/TableExportQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/query/TableExportQuery.java
@@ -8,10 +8,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -23,6 +23,7 @@ import com.bakdata.conquery.apiv1.query.concept.filter.CQTable;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQConcept;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.View;
+import com.bakdata.conquery.io.jackson.serializer.NsIdRefKeys;
 import com.bakdata.conquery.models.common.CDateSet;
 import com.bakdata.conquery.models.common.Range;
 import com.bakdata.conquery.models.common.daterange.CDateRange;
@@ -31,10 +32,7 @@ import com.bakdata.conquery.models.datasets.SecondaryIdDescription;
 import com.bakdata.conquery.models.datasets.concepts.Concept;
 import com.bakdata.conquery.models.datasets.concepts.Connector;
 import com.bakdata.conquery.models.datasets.concepts.ValidityDate;
-import com.bakdata.conquery.models.identifiable.ids.specific.ColumnId;
-import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
-import com.bakdata.conquery.models.identifiable.ids.specific.SecondaryIdDescriptionId;
 import com.bakdata.conquery.models.query.DateAggregationMode;
 import com.bakdata.conquery.models.query.QueryExecutionContext;
 import com.bakdata.conquery.models.query.QueryPlanContext;
@@ -51,6 +49,8 @@ import com.bakdata.conquery.models.types.SemanticType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -99,13 +99,14 @@ public class TableExportQuery extends Query {
 	 * - SecondaryIds are collected into a Column per SecondaryId
 	 * - The remaining columns are arbitrarily ordered, but usually grouped by their source table.
 	 */
+	@NsIdRefKeys
 	@JsonView(View.InternalCommunication.class)
-	private Map<ColumnId, Integer> positions;
+	private Map<Column, Integer> positions;
 
 	@JsonIgnore
-	private Set<ColumnId> conceptColumns;
+	private Set<Column> conceptColumns;
 	@JsonIgnore
-	private Map<SecondaryIdDescriptionId, Integer> secondaryIdPositions;
+	private Object2IntMap<SecondaryIdDescription> secondaryIdPositions;
 
 
 	@Override
@@ -143,7 +144,16 @@ public class TableExportQuery extends Query {
 		// First is dates, second is source id
 		final AtomicInteger currentPosition = new AtomicInteger(2);
 
-		secondaryIdPositions = calculateSecondaryIdPositions(currentPosition);
+		// We need to know if a column is a concept column so we can prioritize it if it is also a SecondaryId
+		conceptColumns = tables.stream()
+							   .map(CQConcept::getTables)
+							   .flatMap(Collection::stream)
+							   .map(CQTable::getConnector)
+							   .map(Connector::getColumn)
+							   .filter(Objects::nonNull)
+							   .collect(Collectors.toSet());
+
+		secondaryIdPositions = calculateSecondaryIdPositions(currentPosition, tables, conceptColumns);
 
 		final Set<ValidityDate> validityDates = tables.stream()
 													  .map(CQConcept::getTables)
@@ -152,72 +162,65 @@ public class TableExportQuery extends Query {
 													  .filter(Objects::nonNull)
 													  .collect(Collectors.toSet());
 
-		// We need to know if a column is a concept column, so we can prioritize it, if it is also a SecondaryId
-		conceptColumns = tables.stream()
-							   .map(CQConcept::getTables)
-							   .flatMap(Collection::stream)
-							   .map(CQTable::getConnector)
-							   .map(ConnectorId::resolve)
-							   .map(Connector::getColumn)
-							   .filter(Objects::nonNull)
-							   .collect(Collectors.toSet());
 
 		positions = calculateColumnPositions(currentPosition, tables, secondaryIdPositions, conceptColumns, validityDates);
-
-
 	}
 
-	private Map<SecondaryIdDescriptionId, Integer> calculateSecondaryIdPositions(AtomicInteger currentPosition) {
-		final Map<SecondaryIdDescriptionId, Integer> secondaryIdPositions = new HashMap<>();
+	public static int calculateWidth(Map<?, Integer> positions) {
+		return positions.values().stream().max(Integer::compareTo).orElse(0) + 1;
+	}
+
+	private static Object2IntMap<SecondaryIdDescription> calculateSecondaryIdPositions(AtomicInteger currentPosition, List<CQConcept> tables, Set<Column> conceptColumns) {
+		final Object2IntMap<SecondaryIdDescription> secondaryIdPositions = new Object2IntOpenHashMap<>();
 
 		// SecondaryIds are pulled to the front and grouped over all tables
 		tables.stream()
 			  .flatMap(con -> con.getTables().stream())
-			  .flatMap(table -> Arrays.stream(table.getConnector().resolve().getResolvedTable().getColumns()))
+			  .flatMap(table -> Arrays.stream(table.getConnector().getTable().getColumns()))
+			  // Concept Columns are placed separately so they won't provide a secondaryId
+			  .filter(Predicate.not(conceptColumns::contains))
 			  .map(Column::getSecondaryId)
 			  .filter(Objects::nonNull)
-			  .map(SecondaryIdDescriptionId::resolve)
 			  .distinct()
 			  .sorted(Comparator.comparing(SecondaryIdDescription::getLabel))
 			  // Using for each and not a collector allows us to guarantee sorted insertion.
-			  .forEach(secondaryId -> secondaryIdPositions.put(secondaryId.getId(), currentPosition.getAndIncrement()));
+			  .forEach(secondaryId -> secondaryIdPositions.put(secondaryId, currentPosition.getAndIncrement()));
 
 		return secondaryIdPositions;
 	}
 
-	private static Map<ColumnId, Integer> calculateColumnPositions(
+	private static Map<Column, Integer> calculateColumnPositions(
 			AtomicInteger currentPosition,
 			List<CQConcept> tables,
-			Map<SecondaryIdDescriptionId, Integer> secondaryIdPositions,
-			Collection<ColumnId> conceptColumns,
-			Collection<ValidityDate> validityDates
-	) {
-		final Map<ColumnId, Integer> positions = new HashMap<>();
+			Map<SecondaryIdDescription, Integer> secondaryIdPositions,
+			Set<Column> conceptColumns,
+			Set<ValidityDate> validityDates) {
+
+		final Map<Column, Integer> positions = new Object2IntOpenHashMap<>();
 
 
 		for (CQConcept concept : tables) {
 			for (CQTable table : concept.getTables()) {
 
 				// Set column positions, set SecondaryId positions to precomputed ones.
-				for (Column column : table.getConnector().resolve().getResolvedTable().getColumns()) {
+				for (Column column : table.getConnector().getTable().getColumns()) {
 
 					// ValidityDates are handled separately in column=0
 					if (validityDates.stream().anyMatch(vd -> vd.containsColumn(column))) {
 						continue;
 					}
 
-					final ColumnId columnId = column.getId();
-					if (positions.containsKey(columnId)) {
+					if (positions.containsKey(column)) {
 						continue;
 					}
 
 					// We want to have ConceptColumns separate here.
-					if (column.getSecondaryId() != null && !conceptColumns.contains(column.getId())) {
-						positions.putIfAbsent(columnId, secondaryIdPositions.get(column.getSecondaryId()));
+					if (column.getSecondaryId() != null && !conceptColumns.contains(column)) {
+						positions.putIfAbsent(column, secondaryIdPositions.get(column.getSecondaryId()));
 						continue;
 					}
 
-					positions.put(columnId, currentPosition.getAndIncrement());
+					positions.put(column, currentPosition.getAndIncrement());
 				}
 			}
 		}
@@ -230,13 +233,9 @@ public class TableExportQuery extends Query {
 		return createResultInfos(conceptColumns);
 	}
 
-	private List<ResultInfo> createResultInfos(Set<ColumnId> conceptColumns) {
+	private List<ResultInfo> createResultInfos(Set<Column> conceptColumns) {
 
-		OptionalInt max = positions.values().stream().mapToInt(i -> i).max();
-		if (max.isEmpty()) {
-			throw new IllegalStateException("Unable to determine maximum position");
-		}
-		final int size = max.getAsInt() + 1;
+		final int size = calculateWidth(positions);
 
 		final ResultInfo[] infos = new ResultInfo[size];
 
@@ -244,37 +243,33 @@ public class TableExportQuery extends Query {
 		infos[1] = ResultHeaders.sourceInfo();
 
 
-		for (Map.Entry<SecondaryIdDescriptionId, Integer> e : secondaryIdPositions.entrySet()) {
-			final SecondaryIdDescriptionId desc = e.getKey();
+		for (Map.Entry<SecondaryIdDescription, Integer> e : secondaryIdPositions.entrySet()) {
+			final SecondaryIdDescription desc = e.getKey();
 			final Integer pos = e.getValue();
 
-			infos[pos] = new SecondaryIdResultInfo(desc.resolve());
+			infos[pos] = new SecondaryIdResultInfo(desc);
 		}
 
 
 		final Map<Column, Concept<?>> connectorColumns =
 				tables.stream()
 					  .flatMap(con -> con.getTables().stream())
-					  .map(CQTable::getConnector)
-					  .map(ConnectorId::resolve)
-					  .filter(con -> con.getColumn() != null)
-					  .collect(Collectors.toMap(con -> con.getColumn().resolve(), Connector::getConcept));
+					  .filter(tbl -> tbl.getConnector().getColumn() != null)
+					  .collect(Collectors.toMap(tbl -> tbl.getConnector().getColumn(), tbl -> tbl.getConnector().getConcept()));
 
 
-		for (Map.Entry<ColumnId, Integer> entry : positions.entrySet()) {
+		for (Map.Entry<Column, Integer> entry : positions.entrySet()) {
 
 			final int position = entry.getValue();
-
-			ColumnId columnId = entry.getKey();
-			final Column column = columnId.resolve();
+			final Column column = entry.getKey();
 
 			if (position == 0) {
 				continue;
 			}
 
 			// SecondaryIds and date columns are pulled to the front, thus already covered.
-			if (column.getSecondaryId() != null && !conceptColumns.contains(columnId)) {
-				infos[secondaryIdPositions.get(column.getSecondaryId())].addSemantics(new SemanticType.ColumnT(columnId));
+			if (column.getSecondaryId() != null && !conceptColumns.contains(column)) {
+				infos[secondaryIdPositions.getInt(column.getSecondaryId())].addSemantics(new SemanticType.ColumnT(column));
 				continue;
 			}
 
@@ -286,14 +281,14 @@ public class TableExportQuery extends Query {
 				columnResultInfo = new ColumnResultInfo(column, ResultType.Primitive.STRING, column.getDescription(), isRawConceptValues() ? null : concept);
 
 				// Columns that are used to build concepts are marked as ConceptColumn.
-				columnResultInfo.addSemantics(new SemanticType.ConceptColumnT(concept.getId()));
+				columnResultInfo.addSemantics(new SemanticType.ConceptColumnT(concept));
 
 				infos[position] = columnResultInfo;
 			}
 			else {
 				// If it's not a connector column, we just link to the source column.
 				columnResultInfo = new ColumnResultInfo(column, ResultType.resolveResultType(column.getType()), column.getDescription(), null);
-				columnResultInfo.addSemantics(new SemanticType.ColumnT(column.getId()));
+				columnResultInfo.addSemantics(new SemanticType.ColumnT(column));
 			}
 
 			infos[position] = columnResultInfo;

--- a/backend/src/main/java/com/bakdata/conquery/apiv1/query/TableExportQuery.java
+++ b/backend/src/main/java/com/bakdata/conquery/apiv1/query/TableExportQuery.java
@@ -23,7 +23,6 @@ import com.bakdata.conquery.apiv1.query.concept.filter.CQTable;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQConcept;
 import com.bakdata.conquery.io.cps.CPSType;
 import com.bakdata.conquery.io.jackson.View;
-import com.bakdata.conquery.io.jackson.serializer.NsIdRefKeys;
 import com.bakdata.conquery.models.common.CDateSet;
 import com.bakdata.conquery.models.common.Range;
 import com.bakdata.conquery.models.common.daterange.CDateRange;
@@ -32,7 +31,10 @@ import com.bakdata.conquery.models.datasets.SecondaryIdDescription;
 import com.bakdata.conquery.models.datasets.concepts.Concept;
 import com.bakdata.conquery.models.datasets.concepts.Connector;
 import com.bakdata.conquery.models.datasets.concepts.ValidityDate;
+import com.bakdata.conquery.models.identifiable.ids.specific.ColumnId;
+import com.bakdata.conquery.models.identifiable.ids.specific.ConnectorId;
 import com.bakdata.conquery.models.identifiable.ids.specific.ManagedExecutionId;
+import com.bakdata.conquery.models.identifiable.ids.specific.SecondaryIdDescriptionId;
 import com.bakdata.conquery.models.query.DateAggregationMode;
 import com.bakdata.conquery.models.query.QueryExecutionContext;
 import com.bakdata.conquery.models.query.QueryPlanContext;
@@ -49,12 +51,11 @@ import com.bakdata.conquery.models.types.SemanticType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
-import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -72,6 +73,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 @Setter
+@ToString(onlyExplicitlyIncluded = false)
 @CPSType(id = "TABLE_EXPORT", base = QueryDescription.class)
 @RequiredArgsConstructor(onConstructor_ = {@JsonCreator})
 public class TableExportQuery extends Query {
@@ -79,17 +81,22 @@ public class TableExportQuery extends Query {
 	@Valid
 	@NotNull
 	@NonNull
+	@ToString.Include
 	protected final Query query;
+
 	@NotNull
+	@ToString.Include
 	private Range<LocalDate> dateRange = Range.all();
 
 	@NotEmpty
 	@Valid
+	@ToString.Include
 	private List<CQConcept> tables;
 
 	/**
 	 * @see TableExportQueryPlan#isRawConceptValues()
 	 */
+	@ToString.Include
 	private boolean rawConceptValues = true;
 
 	/**
@@ -99,14 +106,13 @@ public class TableExportQuery extends Query {
 	 * - SecondaryIds are collected into a Column per SecondaryId
 	 * - The remaining columns are arbitrarily ordered, but usually grouped by their source table.
 	 */
-	@NsIdRefKeys
 	@JsonView(View.InternalCommunication.class)
-	private Map<Column, Integer> positions;
+	private Map<ColumnId, Integer> positions;
 
 	@JsonIgnore
-	private Set<Column> conceptColumns;
+	private Set<ColumnId> conceptColumns;
 	@JsonIgnore
-	private Object2IntMap<SecondaryIdDescription> secondaryIdPositions;
+	private Map<SecondaryIdDescriptionId, Integer> secondaryIdPositions;
 
 
 	@Override
@@ -122,13 +128,7 @@ public class TableExportQuery extends Query {
 			}
 		}
 
-		return new TableExportQueryPlan(
-				query.createQueryPlan(context),
-				CDateSet.create(CDateRange.of(dateRange)),
-				filterQueryNodes,
-				positions,
-				rawConceptValues
-		);
+		return new TableExportQueryPlan(query.createQueryPlan(context), CDateSet.create(CDateRange.of(dateRange)), filterQueryNodes, positions, rawConceptValues);
 	}
 
 	@Override
@@ -144,83 +144,78 @@ public class TableExportQuery extends Query {
 		// First is dates, second is source id
 		final AtomicInteger currentPosition = new AtomicInteger(2);
 
-		// We need to know if a column is a concept column so we can prioritize it if it is also a SecondaryId
+		// We need to know if a column is a concept column, so we can prioritize it, if it is also a SecondaryId
 		conceptColumns = tables.stream()
 							   .map(CQConcept::getTables)
 							   .flatMap(Collection::stream)
 							   .map(CQTable::getConnector)
+							   .map(ConnectorId::resolve)
 							   .map(Connector::getColumn)
 							   .filter(Objects::nonNull)
 							   .collect(Collectors.toSet());
 
-		secondaryIdPositions = calculateSecondaryIdPositions(currentPosition, tables, conceptColumns);
+		secondaryIdPositions = calculateSecondaryIdPositions(currentPosition, conceptColumns, tables);
 
-		final Set<ValidityDate> validityDates = tables.stream()
-													  .map(CQConcept::getTables)
-													  .flatMap(Collection::stream)
-													  .map(CQTable::findValidityDate)
-													  .filter(Objects::nonNull)
-													  .collect(Collectors.toSet());
+		final Set<ValidityDate> validityDates =
+				tables.stream().map(CQConcept::getTables).flatMap(Collection::stream).map(CQTable::findValidityDate).filter(Objects::nonNull).collect(Collectors.toSet());
 
 
 		positions = calculateColumnPositions(currentPosition, tables, secondaryIdPositions, conceptColumns, validityDates);
 	}
 
-	public static int calculateWidth(Map<?, Integer> positions) {
-		return positions.values().stream().max(Integer::compareTo).orElse(0) + 1;
-	}
-
-	private static Object2IntMap<SecondaryIdDescription> calculateSecondaryIdPositions(AtomicInteger currentPosition, List<CQConcept> tables, Set<Column> conceptColumns) {
-		final Object2IntMap<SecondaryIdDescription> secondaryIdPositions = new Object2IntOpenHashMap<>();
+	private static Map<SecondaryIdDescriptionId, Integer> calculateSecondaryIdPositions(
+			AtomicInteger currentPosition, Set<ColumnId> conceptColumns, List<CQConcept> tables) {
+		final Map<SecondaryIdDescriptionId, Integer> secondaryIdPositions = new HashMap<>();
 
 		// SecondaryIds are pulled to the front and grouped over all tables
 		tables.stream()
 			  .flatMap(con -> con.getTables().stream())
-			  .flatMap(table -> Arrays.stream(table.getConnector().getTable().getColumns()))
+			  .flatMap(table -> Arrays.stream(table.getConnector().resolve().getResolvedTable().getColumns()))
 			  // Concept Columns are placed separately so they won't provide a secondaryId
 			  .filter(Predicate.not(conceptColumns::contains))
 			  .map(Column::getSecondaryId)
 			  .filter(Objects::nonNull)
+			  .map(SecondaryIdDescriptionId::resolve)
 			  .distinct()
 			  .sorted(Comparator.comparing(SecondaryIdDescription::getLabel))
 			  // Using for each and not a collector allows us to guarantee sorted insertion.
-			  .forEach(secondaryId -> secondaryIdPositions.put(secondaryId, currentPosition.getAndIncrement()));
+			  .forEach(secondaryId -> secondaryIdPositions.put(secondaryId.getId(), currentPosition.getAndIncrement()));
 
 		return secondaryIdPositions;
 	}
 
-	private static Map<Column, Integer> calculateColumnPositions(
+	private static Map<ColumnId, Integer> calculateColumnPositions(
 			AtomicInteger currentPosition,
 			List<CQConcept> tables,
-			Map<SecondaryIdDescription, Integer> secondaryIdPositions,
-			Set<Column> conceptColumns,
-			Set<ValidityDate> validityDates) {
-
-		final Map<Column, Integer> positions = new Object2IntOpenHashMap<>();
+			Map<SecondaryIdDescriptionId, Integer> secondaryIdPositions,
+			Collection<ColumnId> conceptColumns,
+			Collection<ValidityDate> validityDates) {
+		final Map<ColumnId, Integer> positions = new HashMap<>();
 
 
 		for (CQConcept concept : tables) {
 			for (CQTable table : concept.getTables()) {
 
 				// Set column positions, set SecondaryId positions to precomputed ones.
-				for (Column column : table.getConnector().getTable().getColumns()) {
+				for (Column column : table.getConnector().resolve().getResolvedTable().getColumns()) {
 
 					// ValidityDates are handled separately in column=0
 					if (validityDates.stream().anyMatch(vd -> vd.containsColumn(column))) {
 						continue;
 					}
 
-					if (positions.containsKey(column)) {
+					final ColumnId columnId = column.getId();
+					if (positions.containsKey(columnId)) {
 						continue;
 					}
 
 					// We want to have ConceptColumns separate here.
-					if (column.getSecondaryId() != null && !conceptColumns.contains(column)) {
-						positions.putIfAbsent(column, secondaryIdPositions.get(column.getSecondaryId()));
+					if (column.getSecondaryId() != null && !conceptColumns.contains(column.getId())) {
+						positions.putIfAbsent(columnId, secondaryIdPositions.get(column.getSecondaryId()));
 						continue;
 					}
 
-					positions.put(column, currentPosition.getAndIncrement());
+					positions.put(columnId, currentPosition.getAndIncrement());
 				}
 			}
 		}
@@ -233,9 +228,10 @@ public class TableExportQuery extends Query {
 		return createResultInfos(conceptColumns);
 	}
 
-	private List<ResultInfo> createResultInfos(Set<Column> conceptColumns) {
+	private List<ResultInfo> createResultInfos(Set<ColumnId> conceptColumns) {
 
 		final int size = calculateWidth(positions);
+		;
 
 		final ResultInfo[] infos = new ResultInfo[size];
 
@@ -243,33 +239,36 @@ public class TableExportQuery extends Query {
 		infos[1] = ResultHeaders.sourceInfo();
 
 
-		for (Map.Entry<SecondaryIdDescription, Integer> e : secondaryIdPositions.entrySet()) {
-			final SecondaryIdDescription desc = e.getKey();
+		for (Map.Entry<SecondaryIdDescriptionId, Integer> e : secondaryIdPositions.entrySet()) {
+			final SecondaryIdDescriptionId desc = e.getKey();
 			final Integer pos = e.getValue();
 
-			infos[pos] = new SecondaryIdResultInfo(desc);
+			infos[pos] = new SecondaryIdResultInfo(desc.resolve());
 		}
 
 
-		final Map<Column, Concept<?>> connectorColumns =
-				tables.stream()
-					  .flatMap(con -> con.getTables().stream())
-					  .filter(tbl -> tbl.getConnector().getColumn() != null)
-					  .collect(Collectors.toMap(tbl -> tbl.getConnector().getColumn(), tbl -> tbl.getConnector().getConcept()));
+		final Map<Column, Concept<?>> connectorColumns = tables.stream()
+															   .flatMap(con -> con.getTables().stream())
+															   .map(CQTable::getConnector)
+															   .map(ConnectorId::resolve)
+															   .filter(con -> con.getColumn() != null)
+															   .collect(Collectors.toMap(con -> con.getColumn().resolve(), Connector::getConcept));
 
 
-		for (Map.Entry<Column, Integer> entry : positions.entrySet()) {
+		for (Map.Entry<ColumnId, Integer> entry : positions.entrySet()) {
 
 			final int position = entry.getValue();
-			final Column column = entry.getKey();
+
+			ColumnId columnId = entry.getKey();
+			final Column column = columnId.resolve();
 
 			if (position == 0) {
 				continue;
 			}
 
 			// SecondaryIds and date columns are pulled to the front, thus already covered.
-			if (column.getSecondaryId() != null && !conceptColumns.contains(column)) {
-				infos[secondaryIdPositions.getInt(column.getSecondaryId())].addSemantics(new SemanticType.ColumnT(column));
+			if (column.getSecondaryId() != null && !conceptColumns.contains(columnId)) {
+				infos[secondaryIdPositions.get(column.getSecondaryId())].addSemantics(new SemanticType.ColumnT(columnId));
 				continue;
 			}
 
@@ -281,14 +280,14 @@ public class TableExportQuery extends Query {
 				columnResultInfo = new ColumnResultInfo(column, ResultType.Primitive.STRING, column.getDescription(), isRawConceptValues() ? null : concept);
 
 				// Columns that are used to build concepts are marked as ConceptColumn.
-				columnResultInfo.addSemantics(new SemanticType.ConceptColumnT(concept));
+				columnResultInfo.addSemantics(new SemanticType.ConceptColumnT(concept.getId()));
 
 				infos[position] = columnResultInfo;
 			}
 			else {
 				// If it's not a connector column, we just link to the source column.
 				columnResultInfo = new ColumnResultInfo(column, ResultType.resolveResultType(column.getType()), column.getDescription(), null);
-				columnResultInfo.addSemantics(new SemanticType.ColumnT(column));
+				columnResultInfo.addSemantics(new SemanticType.ColumnT(column.getId()));
 			}
 
 			infos[position] = columnResultInfo;
@@ -297,6 +296,10 @@ public class TableExportQuery extends Query {
 		}
 
 		return List.of(infos);
+	}
+
+	public static int calculateWidth(Map<?, Integer> positions) {
+		return positions.values().stream().max(Integer::compareTo).orElse(0) + 1;
 	}
 
 	@Override

--- a/backend/src/main/java/com/bakdata/conquery/models/query/queryplan/TableExportQueryPlan.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/queryplan/TableExportQueryPlan.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.bakdata.conquery.apiv1.query.TableExportQuery;
 import com.bakdata.conquery.apiv1.query.concept.filter.CQTable;
 import com.bakdata.conquery.models.common.CDateSet;
 import com.bakdata.conquery.models.common.daterange.CDateRange;
@@ -60,8 +61,8 @@ public class TableExportQueryPlan implements QueryPlan<MultilineEntityResult> {
 
 	@Override
 	public Optional<MultilineEntityResult> execute(QueryExecutionContext ctx, Entity entity) {
-		Optional<? extends EntityResult> result = subPlan.execute(ctx, entity);
 
+		final Optional<? extends EntityResult> result = subPlan.execute(ctx, entity);
 
 		if (result.isEmpty() || tables.isEmpty()) {
 			return Optional.empty();
@@ -69,7 +70,7 @@ public class TableExportQueryPlan implements QueryPlan<MultilineEntityResult> {
 
 		final List<Object[]> results = new ArrayList<>();
 
-		final int totalColumns = positions.values().stream().mapToInt(i -> i).max().getAsInt() + 1;
+		final int totalColumns = TableExportQuery.calculateWidth(positions);
 		final String entityId = entity.getId();
 
 		for (Map.Entry<CQTable, QPNode> entry : tables.entrySet()) {

--- a/backend/src/main/java/com/bakdata/conquery/models/query/queryplan/TableExportQueryPlan.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/query/queryplan/TableExportQueryPlan.java
@@ -61,8 +61,8 @@ public class TableExportQueryPlan implements QueryPlan<MultilineEntityResult> {
 
 	@Override
 	public Optional<MultilineEntityResult> execute(QueryExecutionContext ctx, Entity entity) {
+		Optional<? extends EntityResult> result = subPlan.execute(ctx, entity);
 
-		final Optional<? extends EntityResult> result = subPlan.execute(ctx, entity);
 
 		if (result.isEmpty() || tables.isEmpty()) {
 			return Optional.empty();

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
@@ -167,15 +167,14 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	private static Field<?>[] createPlaceholders(Map<ColumnId, Integer> positions, CQTable cqTable) {
 
 		final int size = TableExportQuery.calculateWidth(positions);
-		Field<?>[] exportColumns = new Field[size];
+		final Field<?>[] exportColumns = new Field[size];
 		exportColumns[0] = createSourceInfoSelect(cqTable);
 
 		// if columns have the same computed position, they can share a common name because they will be unioned over multiple tables anyway
-		positions.forEach((column, position) -> {
-			int shifted = position - 1;
-			Field<?> columnSelect = DSL.inline(null, Object.class).as("%s-%d".formatted(column.getColumn(), shifted));
-			exportColumns[shifted] = columnSelect;
-		});
+		for (int index = 0; index < size; index++) {
+			final Field<?> columnSelect = DSL.inline(null, Object.class).as("null-%d".formatted(index));
+			exportColumns[index] = columnSelect;
+		}
 
 		return exportColumns;
 	}

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
@@ -13,6 +13,7 @@ import com.bakdata.conquery.apiv1.query.concept.filter.CQTable;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQConcept;
 import com.bakdata.conquery.models.common.daterange.CDateRange;
 import com.bakdata.conquery.models.datasets.Column;
+import com.bakdata.conquery.models.datasets.concepts.ValidityDate;
 import com.bakdata.conquery.models.identifiable.ids.specific.ColumnId;
 import com.bakdata.conquery.sql.conversion.NodeConverter;
 import com.bakdata.conquery.sql.conversion.SharedAliases;
@@ -49,27 +50,25 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	@Override
 	public ConversionContext convert(TableExportQuery tableExportQuery, ConversionContext context) {
 
-		QueryStep convertedPrerequisite = convertPrerequisite(tableExportQuery, context);
-		Map<ColumnId, Integer> positions = tableExportQuery.getPositions();
-		CDateRange dateRestriction = CDateRange.of(tableExportQuery.getDateRange());
+		final QueryStep convertedPrerequisite = convertPrerequisite(tableExportQuery, context);
+		final CDateRange dateRestriction = CDateRange.of(tableExportQuery.getDateRange());
 
-		List<QueryStep> convertedTables = tableExportQuery.getTables().stream()
-														  .flatMap(concept -> concept.getTables().stream().map(table -> convertTable(
-																  table,
-																  concept,
-																  dateRestriction,
-																  convertedPrerequisite,
-																  positions,
-																  context
-														  )))
-														  .toList();
+		final List<QueryStep> convertedTables = tableExportQuery.getTables()
+																.stream()
+																.flatMap(concept -> concept.getTables()
+																						   .stream()
+																						   .map(table -> convertTable(table,
+																													  concept,
+																													  dateRestriction,
+																													  convertedPrerequisite,
+																													  tableExportQuery.getPositions(),
+																													  context
+																						   )))
+																.toList();
 
-		QueryStep unionedTables = QueryStep.createUnionAllStep(
-				convertedTables,
-				null, // no CTE name required as this step will be the final select
-				List.of(convertedPrerequisite)
-		);
-		Select<Record> selectQuery = queryStepTransformer.toSelectQuery(unionedTables);
+		// no CTE name required as this step will be the final select
+		final QueryStep unionedTables = QueryStep.createUnionAllStep(convertedTables, null, List.of(convertedPrerequisite));
+		final Select<Record> selectQuery = queryStepTransformer.toSelectQuery(unionedTables);
 
 		return context.withFinalQuery(new SqlQuery(selectQuery, tableExportQuery.getResultInfos()));
 	}
@@ -79,14 +78,13 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	 */
 	private static QueryStep convertPrerequisite(TableExportQuery exportQuery, ConversionContext context) {
 
-		ConversionContext withConvertedPrerequisite = context.getNodeConversions().convert(exportQuery.getQuery(), context);
-		Preconditions.checkArgument(withConvertedPrerequisite.getQuerySteps().size() == 1, "Base query conversion should produce exactly 1 QueryStep");
-		QueryStep convertedPrerequisite = withConvertedPrerequisite.getLastConvertedStep();
+		final ConversionContext withConvertedPrerequisite = context.getNodeConversions().convert(exportQuery.getQuery(), context);
 
-		Selects prerequisiteSelects = convertedPrerequisite.getQualifiedSelects();
-		Selects selects = Selects.builder()
-								 .ids(new SqlIdColumns(prerequisiteSelects.getIds().getPrimaryColumn()))
-								 .build();
+		Preconditions.checkState(withConvertedPrerequisite.getQuerySteps().size() == 1, "Base query conversion should produce exactly 1 QueryStep");
+
+		final QueryStep convertedPrerequisite = withConvertedPrerequisite.getLastConvertedStep();
+		final Selects prerequisiteSelects = convertedPrerequisite.getQualifiedSelects();
+		final Selects selects = Selects.builder().ids(new SqlIdColumns(prerequisiteSelects.getIds().getPrimaryColumn())).build();
 
 		return QueryStep.builder()
 						.cteName(FormCteStep.EXTRACT_IDS.getSuffix())
@@ -102,79 +100,92 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	 * linked to the given table, we just do a null select.
 	 */
 	private static QueryStep convertTable(
-			CQTable cqTable,
-			CQConcept concept,
-			CDateRange dateRestriction,
-			QueryStep convertedPrerequisite,
-			Map<ColumnId, Integer> positions,
-			ConversionContext context
-	) {
-		Field<Object> primaryColumn = TablePrimaryColumnUtil.findPrimaryColumn(cqTable.getConnector().resolve().getResolvedTable(), context.getConfig());
-		SqlIdColumns ids = new SqlIdColumns(primaryColumn);
-    String conceptConnectorName = context.getNameGenerator().conceptConnectorName(concept, cqTable.getConnector().resolve(), context.getSqlPrintSettings().getLocale());
-		Optional<ColumnDateRange> validityDate = convertTablesValidityDate(cqTable, conceptConnectorName, context);
+			CQTable cqTable, CQConcept concept, CDateRange dateRestriction, QueryStep convertedPrerequisite, Map<ColumnId, Integer> positions, ConversionContext context) {
 
-		List<FieldWrapper<?>> exportColumns = initializeFields(cqTable, positions);
-		Selects selects = Selects.builder()
-								 .ids(ids)
-								 .validityDate(validityDate)
-								 .sqlSelects(exportColumns)
-								 .build();
+		final Field<Object> primaryColumn = TablePrimaryColumnUtil.findPrimaryColumn(cqTable.getConnector().getTable(), context.getConfig());
+		final SqlIdColumns ids = new SqlIdColumns(primaryColumn);
+		final String conceptConnectorName = context.getNameGenerator().conceptConnectorName(concept, cqTable.getConnector(), context.getSqlPrintSettings().getLocale());
+		final Optional<ColumnDateRange> validityDate = convertTablesValidityDate(cqTable, conceptConnectorName, context);
 
-		List<Condition> filters = cqTable.getFilters().stream().map(filterValue -> filterValue.convertForTableExport(ids, context)).toList();
-		Table<Record> joinedTable = joinConnectorTableWithPrerequisite(cqTable, ids, convertedPrerequisite, dateRestriction, context);
+		final List<FieldWrapper<?>> exportColumns = initializeFields(cqTable, positions);
+		final Selects selects = Selects.builder().ids(ids).validityDate(validityDate).sqlSelects(exportColumns).build();
 
-		return QueryStep.builder()
-						.cteName(conceptConnectorName)
-						.selects(selects)
-						.fromTable(joinedTable)
-						.conditions(filters)
-						.build();
+		final List<Condition> filters = cqTable.getFilters().stream().map(filterValue -> filterValue.convertForTableExport(ids, context)).toList();
+		final Table<Record> joinedTable = joinConnectorTableWithPrerequisite(cqTable, ids, convertedPrerequisite, dateRestriction, context);
+
+		return QueryStep.builder().cteName(conceptConnectorName).selects(selects).fromTable(joinedTable).conditions(filters).build();
 	}
 
 	private static Optional<ColumnDateRange> convertTablesValidityDate(CQTable table, String alias, ConversionContext context) {
-		if (table.findValidityDate() == null) {
+		final ValidityDate validityDate = table.findValidityDate();
+		if (validityDate == null) {
 			return Optional.of(ColumnDateRange.empty());
 		}
-		SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
-		ColumnDateRange validityDate = functionProvider.forValidityDate(table.findValidityDate());
+		final SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
+		final ColumnDateRange validityDateRange = functionProvider.forValidityDate(validityDate);
 		// when exporting tables, we want the validity date as a single-column daterange string expression straightaway
-		Field<String> asStringExpression = functionProvider.encloseInCurlyBraces(functionProvider.daterangeStringExpression(validityDate));
+		final Field<String> asStringExpression = functionProvider.encloseInCurlyBraces(functionProvider.daterangeStringExpression(validityDateRange));
 		return Optional.of(ColumnDateRange.of(asStringExpression).asValidityDateRange(alias));
 	}
 
 	private static List<FieldWrapper<?>> initializeFields(CQTable cqTable, Map<ColumnId, Integer> positions) {
 
-		Field<?>[] exportColumns = createPlaceholders(positions, cqTable);
+		final Field<?>[] exportColumns = createPlaceholders(positions, cqTable);
 		for (Column column : cqTable.getConnector().resolve().getResolvedTable().getColumns()) {
 			// e.g. date column(s) are handled separately and not part of positions
 			if (!positions.containsKey(column.getId())) {
 				continue;
 			}
-			int position = positions.get(column.getId()) - 1;
+			final int position = positions.get(column.getId()) - 1;
 			exportColumns[position] = createColumnSelect(column, position);
 		}
 
 		return Arrays.stream(exportColumns).map(FieldWrapper::new).collect(Collectors.toList());
 	}
 
+	private static Table<Record> joinConnectorTableWithPrerequisite(
+			CQTable cqTable, SqlIdColumns ids, QueryStep convertedPrerequisite, CDateRange dateRestriction, ConversionContext context) {
+
+		final SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
+		final Table<Record> connectorTable = DSL.table(DSL.name(cqTable.getConnector().getTable().getName()));
+		final Table<Record> convertedPrerequisiteTable = DSL.table(DSL.name(convertedPrerequisite.getCteName()));
+
+		final ColumnDateRange validityDate = functionProvider.forValidityDate(cqTable.findValidityDate());
+		final List<Condition> joinConditions =
+				Stream.concat(
+						ids.join(convertedPrerequisite.getQualifiedSelects().getIds()).stream(),
+						Stream.of(functionProvider.dateRestriction(functionProvider.forCDateRange(dateRestriction), validityDate))
+				).toList();
+
+		return functionProvider.innerJoin(connectorTable, convertedPrerequisiteTable, joinConditions);
+	}
+
 	private static Field<?>[] createPlaceholders(Map<ColumnId, Integer> positions, CQTable cqTable) {
 
-		Field<?>[] exportColumns = new Field[positions.size() + 1];
+		final Field<?>[] exportColumns = new Field[TableExportQuery.calculateWidth(positions)];
 		exportColumns[0] = createSourceInfoSelect(cqTable);
 
 		// if columns have the same computed position, they can share a common name because they will be unioned over multiple tables anyway
-		positions.forEach((column, position) -> {
-			int shifted = position - 1;
-			Field<?> columnSelect = DSL.inline(null, Object.class).as("%s-%d".formatted(column.getColumn(), shifted));
+		for (Map.Entry<ColumnId, Integer> entry : positions.entrySet()) {
+			final ColumnId column = entry.getKey();
+			final int position = entry.getValue();
+
+			final int shifted = position - 1;
+			final Field<?> columnSelect = DSL.inline(null, Object.class).as("%s-%d".formatted(column.getColumn(), shifted));
+
 			exportColumns[shifted] = columnSelect;
-		});
+		}
 
 		return exportColumns;
 	}
 
+	private static Field<?> createColumnSelect(Column column, int position) {
+		final String columnName = "%s-%s".formatted(column.getName(), position);
+		return DSL.field(DSL.name(column.getTable().getName(), column.getName())).as(columnName);
+	}
+
 	private static Field<String> createSourceInfoSelect(CQTable cqTable) {
-		String tableName = cqTable.getConnector().resolve().getResolvedTableId().getTable();
+		final String tableName = cqTable.getConnector().resolve().getResolvedTableId().getTable();
 		return DSL.val(tableName).as(SharedAliases.SOURCE.getAlias());
 	}
 

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
@@ -55,12 +55,12 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	@Override
 	public ConversionContext convert(TableExportQuery tableExportQuery, ConversionContext context) {
 
-		QueryStep convertedPrerequisite = convertPrerequisite(tableExportQuery, context);
-		Map<ColumnId, Integer> positions = tableExportQuery.getPositions();
-		CDateRange dateRestriction = CDateRange.of(tableExportQuery.getDateRange());
+		final QueryStep convertedPrerequisite = convertPrerequisite(tableExportQuery, context);
+		final Map<ColumnId, Integer> positions = tableExportQuery.getPositions();
+		final CDateRange dateRestriction = CDateRange.of(tableExportQuery.getDateRange());
 
-		List<QueryStep> convertedTables = tableExportQuery.getTables().stream()
-														  .flatMap(concept -> concept.getTables().stream().map(table -> convertTable(
+		final List<QueryStep> convertedTables = tableExportQuery.getTables().stream()
+																.flatMap(concept -> concept.getTables().stream().map(table -> convertTable(
 																  table,
 																  concept,
 																  dateRestriction,
@@ -68,14 +68,14 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 																  positions,
 																  context
 														  )))
-														  .toList();
+																.toList();
 
-		QueryStep unionedTables = QueryStep.createUnionAllStep(
+		final QueryStep unionedTables = QueryStep.createUnionAllStep(
 				convertedTables,
 				null, // no CTE name required as this step will be the final select
 				List.of(convertedPrerequisite)
 		);
-		Select<Record> selectQuery = queryStepTransformer.toSelectQuery(unionedTables);
+		final Select<Record> selectQuery = queryStepTransformer.toSelectQuery(unionedTables);
 
 		return context.withFinalQuery(new SqlQuery(selectQuery, tableExportQuery.getResultInfos()));
 	}
@@ -85,14 +85,14 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	 */
 	private static QueryStep convertPrerequisite(TableExportQuery exportQuery, ConversionContext context) {
 
-		ConversionContext withConvertedPrerequisite = context.getNodeConversions().convert(exportQuery.getQuery(), context);
+		final ConversionContext withConvertedPrerequisite = context.getNodeConversions().convert(exportQuery.getQuery(), context);
 		Preconditions.checkArgument(withConvertedPrerequisite.getQuerySteps().size() == 1, "Base query conversion should produce exactly 1 QueryStep");
-		QueryStep convertedPrerequisite = withConvertedPrerequisite.getLastConvertedStep();
+		final QueryStep convertedPrerequisite = withConvertedPrerequisite.getLastConvertedStep();
 
-		Selects prerequisiteSelects = convertedPrerequisite.getQualifiedSelects();
-		Selects selects = Selects.builder()
-								 .ids(new SqlIdColumns(prerequisiteSelects.getIds().getPrimaryColumn()))
-								 .build();
+		final Selects prerequisiteSelects = convertedPrerequisite.getQualifiedSelects();
+		final Selects selects = Selects.builder()
+									   .ids(new SqlIdColumns(prerequisiteSelects.getIds().getPrimaryColumn()))
+									   .build();
 
 		return QueryStep.builder()
 						.cteName(FormCteStep.EXTRACT_IDS.getSuffix())
@@ -115,20 +115,21 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 			Map<ColumnId, Integer> positions,
 			ConversionContext context
 	) {
-		Field<Object> primaryColumn = TablePrimaryColumnUtil.findPrimaryColumn(cqTable.getConnector().resolve().getResolvedTable(), context.getConfig());
-		SqlIdColumns ids = new SqlIdColumns(primaryColumn);
-    	String conceptConnectorName = context.getNameGenerator().conceptConnectorName(concept, cqTable.getConnector().resolve(), context.getSqlPrintSettings().getLocale());
-		Optional<ColumnDateRange> validityDate = convertTablesValidityDate(cqTable, conceptConnectorName, context);
+		final Field<Object> primaryColumn = TablePrimaryColumnUtil.findPrimaryColumn(cqTable.getConnector().resolve().getResolvedTable(), context.getConfig());
+		final SqlIdColumns ids = new SqlIdColumns(primaryColumn);
+		final String conceptConnectorName =
+				context.getNameGenerator().conceptConnectorName(concept, cqTable.getConnector().resolve(), context.getSqlPrintSettings().getLocale());
+		final Optional<ColumnDateRange> validityDate = convertTablesValidityDate(cqTable, conceptConnectorName, context);
 
-		List<FieldWrapper<?>> exportColumns = initializeFields(cqTable, positions);
-		Selects selects = Selects.builder()
-								 .ids(ids)
-								 .validityDate(validityDate)
-								 .sqlSelects(exportColumns)
-								 .build();
+		final List<FieldWrapper<?>> exportColumns = initializeFields(cqTable, positions);
+		final Selects selects = Selects.builder()
+									   .ids(ids)
+									   .validityDate(validityDate)
+									   .sqlSelects(exportColumns)
+									   .build();
 
-		List<Condition> filters = cqTable.getFilters().stream().map(filterValue -> filterValue.convertForTableExport(ids, context)).toList();
-		Table<Record> joinedTable = joinConnectorTableWithPrerequisite(cqTable, ids, convertedPrerequisite, dateRestriction, context);
+		final List<Condition> filters = cqTable.getFilters().stream().map(filterValue -> filterValue.convertForTableExport(ids, context)).toList();
+		final Table<Record> joinedTable = joinConnectorTableWithPrerequisite(cqTable, ids, convertedPrerequisite, dateRestriction, context);
 
 		return QueryStep.builder()
 						.cteName(conceptConnectorName)
@@ -142,52 +143,27 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 		if (table.findValidityDate() == null) {
 			return Optional.of(ColumnDateRange.empty());
 		}
-		SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
-		ColumnDateRange validityDate = functionProvider.forValidityDate(table.findValidityDate());
+		final SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
+		final ColumnDateRange validityDate = functionProvider.forValidityDate(table.findValidityDate());
 		// when exporting tables, we want the validity date as a single-column daterange string expression straightaway
-		Field<String> asStringExpression = functionProvider.encloseInCurlyBraces(functionProvider.daterangeStringExpression(validityDate));
+		final Field<String> asStringExpression = functionProvider.encloseInCurlyBraces(functionProvider.daterangeStringExpression(validityDate));
 		return Optional.of(ColumnDateRange.of(asStringExpression).asValidityDateRange(alias));
 	}
 
 	private static List<FieldWrapper<?>> initializeFields(CQTable cqTable, Map<ColumnId, Integer> positions) {
 
-		Field<?>[] exportColumns = createPlaceholders(positions, cqTable);
+		final Field<?>[] exportColumns = createPlaceholders(positions, cqTable);
+
 		for (Column column : cqTable.getConnector().resolve().getResolvedTable().getColumns()) {
 			// e.g. date column(s) are handled separately and not part of positions
 			if (!positions.containsKey(column.getId())) {
 				continue;
 			}
-			int position = positions.get(column.getId()) - POSITION_OFFSET;
+			final int position = positions.get(column.getId()) - POSITION_OFFSET;
 			exportColumns[position] = createColumnSelect(column, position);
 		}
 
 		return Arrays.stream(exportColumns).map(FieldWrapper::new).collect(Collectors.toList());
-	}
-
-	private static Field<?>[] createPlaceholders(Map<ColumnId, Integer> positions, CQTable cqTable) {
-
-		final int size = TableExportQuery.calculateWidth(positions);
-		final Field<?>[] exportColumns = new Field[size];
-		exportColumns[0] = createSourceInfoSelect(cqTable);
-
-		// if columns have the same computed position, they can share a common name because they will be unioned over multiple tables anyway
-		for (int index = 0; index < size; index++) {
-			final Field<?> columnSelect = DSL.inline(null, Object.class).as("null-%d".formatted(index));
-			exportColumns[index] = columnSelect;
-		}
-
-		return exportColumns;
-	}
-
-	private static Field<String> createSourceInfoSelect(CQTable cqTable) {
-		String tableName = cqTable.getConnector().resolve().getResolvedTableId().getTable();
-		return DSL.val(tableName).as(SharedAliases.SOURCE.getAlias());
-	}
-
-	private static Field<?> createColumnSelect(Column column, int position) {
-		String columnName = "%s-%s".formatted(column.getName(), position);
-		return DSL.field(DSL.name(column.getTable().getName(), column.getName()))
-				  .as(columnName);
 	}
 
 	private static Table<Record> joinConnectorTableWithPrerequisite(
@@ -197,17 +173,43 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 			CDateRange dateRestriction,
 			ConversionContext context
 	) {
-		SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
-		Table<Record> connectorTable = DSL.table(DSL.name(cqTable.getConnector().resolve().getResolvedTableId().getTable()));
-		Table<Record> convertedPrerequisiteTable = DSL.table(DSL.name(convertedPrerequisite.getCteName()));
+		final SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
+		final Table<Record> connectorTable = DSL.table(DSL.name(cqTable.getConnector().resolve().getResolvedTableId().getTable()));
+		final Table<Record> convertedPrerequisiteTable = DSL.table(DSL.name(convertedPrerequisite.getCteName()));
 
-		ColumnDateRange validityDate = functionProvider.forValidityDate(cqTable.findValidityDate());
-		List<Condition> joinConditions = Stream.concat(
+		final ColumnDateRange validityDate = functionProvider.forValidityDate(cqTable.findValidityDate());
+		final List<Condition> joinConditions = Stream.concat(
 				ids.join(convertedPrerequisite.getQualifiedSelects().getIds()).stream(),
 				Stream.of(functionProvider.dateRestriction(functionProvider.forCDateRange(dateRestriction), validityDate))
 		).toList();
 
 		return functionProvider.innerJoin(connectorTable, convertedPrerequisiteTable, joinConditions);
+	}
+
+	private static Field<?>[] createPlaceholders(Map<ColumnId, Integer> positions, CQTable cqTable) {
+
+		final int size = TableExportQuery.calculateWidth(positions) - POSITION_OFFSET;
+		final Field<?>[] exportColumns = new Field[size];
+		exportColumns[0] = createSourceInfoSelect(cqTable);
+
+		// if columns have the same computed position, they can share a common name because they will be unioned over multiple tables anyway
+		for (int index = 0; index < exportColumns.length; index++) {
+			final Field<?> columnSelect = DSL.inline(null, Object.class).as("null-%d".formatted(index));
+			exportColumns[index] = columnSelect;
+		}
+
+		return exportColumns;
+	}
+
+	private static Field<?> createColumnSelect(Column column, int position) {
+		final String columnName = "%s-%s".formatted(column.getName(), position);
+		return DSL.field(DSL.name(column.getTable().getName(), column.getName()))
+				  .as(columnName);
+	}
+
+	private static Field<String> createSourceInfoSelect(CQTable cqTable) {
+		final String tableName = cqTable.getConnector().resolve().getResolvedTableId().getTable();
+		return DSL.val(tableName).as(SharedAliases.SOURCE.getAlias());
 	}
 
 }

--- a/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
+++ b/backend/src/main/java/com/bakdata/conquery/sql/conversion/query/TableExportQueryConverter.java
@@ -13,7 +13,6 @@ import com.bakdata.conquery.apiv1.query.concept.filter.CQTable;
 import com.bakdata.conquery.apiv1.query.concept.specific.CQConcept;
 import com.bakdata.conquery.models.common.daterange.CDateRange;
 import com.bakdata.conquery.models.datasets.Column;
-import com.bakdata.conquery.models.datasets.concepts.ValidityDate;
 import com.bakdata.conquery.models.identifiable.ids.specific.ColumnId;
 import com.bakdata.conquery.sql.conversion.NodeConverter;
 import com.bakdata.conquery.sql.conversion.SharedAliases;
@@ -56,26 +55,27 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	@Override
 	public ConversionContext convert(TableExportQuery tableExportQuery, ConversionContext context) {
 
-		final QueryStep convertedPrerequisite = convertPrerequisite(tableExportQuery, context);
-		final CDateRange dateRestriction = CDateRange.of(tableExportQuery.getDateRange());
+		QueryStep convertedPrerequisite = convertPrerequisite(tableExportQuery, context);
+		Map<ColumnId, Integer> positions = tableExportQuery.getPositions();
+		CDateRange dateRestriction = CDateRange.of(tableExportQuery.getDateRange());
 
-		final List<QueryStep> convertedTables = tableExportQuery.getTables()
-																.stream()
-																.flatMap(concept -> concept.getTables()
-																						   .stream()
-																						   .map(table -> convertTable(
-																								   table,
-																								   concept,
-																								   dateRestriction,
-																								   convertedPrerequisite,
-																								   tableExportQuery.getPositions(),
-																								   context
-																						   )))
-																.toList();
+		List<QueryStep> convertedTables = tableExportQuery.getTables().stream()
+														  .flatMap(concept -> concept.getTables().stream().map(table -> convertTable(
+																  table,
+																  concept,
+																  dateRestriction,
+																  convertedPrerequisite,
+																  positions,
+																  context
+														  )))
+														  .toList();
 
-		// no CTE name required as this step will be the final select
-		final QueryStep unionedTables = QueryStep.createUnionAllStep(convertedTables, null, List.of(convertedPrerequisite));
-		final Select<Record> selectQuery = queryStepTransformer.toSelectQuery(unionedTables);
+		QueryStep unionedTables = QueryStep.createUnionAllStep(
+				convertedTables,
+				null, // no CTE name required as this step will be the final select
+				List.of(convertedPrerequisite)
+		);
+		Select<Record> selectQuery = queryStepTransformer.toSelectQuery(unionedTables);
 
 		return context.withFinalQuery(new SqlQuery(selectQuery, tableExportQuery.getResultInfos()));
 	}
@@ -85,13 +85,14 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	 */
 	private static QueryStep convertPrerequisite(TableExportQuery exportQuery, ConversionContext context) {
 
-		final ConversionContext withConvertedPrerequisite = context.getNodeConversions().convert(exportQuery.getQuery(), context);
+		ConversionContext withConvertedPrerequisite = context.getNodeConversions().convert(exportQuery.getQuery(), context);
+		Preconditions.checkArgument(withConvertedPrerequisite.getQuerySteps().size() == 1, "Base query conversion should produce exactly 1 QueryStep");
+		QueryStep convertedPrerequisite = withConvertedPrerequisite.getLastConvertedStep();
 
-		Preconditions.checkState(withConvertedPrerequisite.getQuerySteps().size() == 1, "Base query conversion should produce exactly 1 QueryStep");
-
-		final QueryStep convertedPrerequisite = withConvertedPrerequisite.getLastConvertedStep();
-		final Selects prerequisiteSelects = convertedPrerequisite.getQualifiedSelects();
-		final Selects selects = Selects.builder().ids(new SqlIdColumns(prerequisiteSelects.getIds().getPrimaryColumn())).build();
+		Selects prerequisiteSelects = convertedPrerequisite.getQualifiedSelects();
+		Selects selects = Selects.builder()
+								 .ids(new SqlIdColumns(prerequisiteSelects.getIds().getPrimaryColumn()))
+								 .build();
 
 		return QueryStep.builder()
 						.cteName(FormCteStep.EXTRACT_IDS.getSuffix())
@@ -107,98 +108,80 @@ public class TableExportQueryConverter implements NodeConverter<TableExportQuery
 	 * linked to the given table, we just do a null select.
 	 */
 	private static QueryStep convertTable(
-			CQTable cqTable, CQConcept concept, CDateRange dateRestriction, QueryStep convertedPrerequisite, Map<ColumnId, Integer> positions, ConversionContext context) {
+			CQTable cqTable,
+			CQConcept concept,
+			CDateRange dateRestriction,
+			QueryStep convertedPrerequisite,
+			Map<ColumnId, Integer> positions,
+			ConversionContext context
+	) {
+		Field<Object> primaryColumn = TablePrimaryColumnUtil.findPrimaryColumn(cqTable.getConnector().resolve().getResolvedTable(), context.getConfig());
+		SqlIdColumns ids = new SqlIdColumns(primaryColumn);
+    	String conceptConnectorName = context.getNameGenerator().conceptConnectorName(concept, cqTable.getConnector().resolve(), context.getSqlPrintSettings().getLocale());
+		Optional<ColumnDateRange> validityDate = convertTablesValidityDate(cqTable, conceptConnectorName, context);
 
-		final Field<Object> primaryColumn = TablePrimaryColumnUtil.findPrimaryColumn(cqTable.getConnector().getTable(), context.getConfig());
-		final SqlIdColumns ids = new SqlIdColumns(primaryColumn);
-		final String
-				conceptConnectorName =
-				context.getNameGenerator().conceptConnectorName(concept, cqTable.getConnector(), context.getSqlPrintSettings().getLocale());
-		final Optional<ColumnDateRange> validityDate = convertTablesValidityDate(cqTable, conceptConnectorName, context);
+		List<FieldWrapper<?>> exportColumns = initializeFields(cqTable, positions);
+		Selects selects = Selects.builder()
+								 .ids(ids)
+								 .validityDate(validityDate)
+								 .sqlSelects(exportColumns)
+								 .build();
 
-		final List<FieldWrapper<?>> exportColumns = initializeFields(cqTable, positions);
-		final Selects selects = Selects.builder().ids(ids).validityDate(validityDate).sqlSelects(exportColumns).build();
+		List<Condition> filters = cqTable.getFilters().stream().map(filterValue -> filterValue.convertForTableExport(ids, context)).toList();
+		Table<Record> joinedTable = joinConnectorTableWithPrerequisite(cqTable, ids, convertedPrerequisite, dateRestriction, context);
 
-		final List<Condition> filters = cqTable.getFilters().stream().map(filterValue -> filterValue.convertForTableExport(ids, context)).toList();
-		final Table<Record> joinedTable = joinConnectorTableWithPrerequisite(cqTable, ids, convertedPrerequisite, dateRestriction, context);
-
-		return QueryStep.builder().cteName(conceptConnectorName).selects(selects).fromTable(joinedTable).conditions(filters).build();
+		return QueryStep.builder()
+						.cteName(conceptConnectorName)
+						.selects(selects)
+						.fromTable(joinedTable)
+						.conditions(filters)
+						.build();
 	}
 
 	private static Optional<ColumnDateRange> convertTablesValidityDate(CQTable table, String alias, ConversionContext context) {
-		final ValidityDate validityDate = table.findValidityDate();
-		if (validityDate == null) {
+		if (table.findValidityDate() == null) {
 			return Optional.of(ColumnDateRange.empty());
 		}
-		final SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
-		final ColumnDateRange validityDateRange = functionProvider.forValidityDate(validityDate);
+		SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
+		ColumnDateRange validityDate = functionProvider.forValidityDate(table.findValidityDate());
 		// when exporting tables, we want the validity date as a single-column daterange string expression straightaway
-		final Field<String> asStringExpression = functionProvider.encloseInCurlyBraces(functionProvider.daterangeStringExpression(validityDateRange));
+		Field<String> asStringExpression = functionProvider.encloseInCurlyBraces(functionProvider.daterangeStringExpression(validityDate));
 		return Optional.of(ColumnDateRange.of(asStringExpression).asValidityDateRange(alias));
 	}
 
 	private static List<FieldWrapper<?>> initializeFields(CQTable cqTable, Map<ColumnId, Integer> positions) {
 
-		final Field<?>[] exportColumns = createPlaceholders(positions, cqTable);
+		Field<?>[] exportColumns = createPlaceholders(positions, cqTable);
 		for (Column column : cqTable.getConnector().resolve().getResolvedTable().getColumns()) {
 			// e.g. date column(s) are handled separately and not part of positions
 			if (!positions.containsKey(column.getId())) {
 				continue;
 			}
-			final int position = positions.get(column.getId()) - POSITION_OFFSET;
+			int position = positions.get(column.getId()) - POSITION_OFFSET;
 			exportColumns[position] = createColumnSelect(column, position);
 		}
 
 		return Arrays.stream(exportColumns).map(FieldWrapper::new).collect(Collectors.toList());
 	}
 
-	private static Table<Record> joinConnectorTableWithPrerequisite(
-			CQTable cqTable,
-			SqlIdColumns ids,
-			QueryStep convertedPrerequisite,
-			CDateRange dateRestriction,
-			ConversionContext context
-	) {
-		final SqlFunctionProvider functionProvider = context.getSqlDialect().getFunctionProvider();
-		final Table<Record> connectorTable = DSL.table(DSL.name(cqTable.getConnector().getTable().getName()));
-		final Table<Record> convertedPrerequisiteTable = DSL.table(DSL.name(convertedPrerequisite.getCteName()));
-
-		final ColumnDateRange validityDate = functionProvider.forValidityDate(cqTable.findValidityDate());
-		final List<Condition> joinConditions =
-				Stream.concat(
-						ids.join(convertedPrerequisite.getQualifiedSelects().getIds()).stream(),
-						Stream.of(functionProvider.dateRestriction(functionProvider.forCDateRange(dateRestriction), validityDate))
-				).toList();
-
-		return functionProvider.innerJoin(connectorTable, convertedPrerequisiteTable, joinConditions);
-	}
-
 	private static Field<?>[] createPlaceholders(Map<ColumnId, Integer> positions, CQTable cqTable) {
 
-		final Field<?>[] exportColumns = new Field[TableExportQuery.calculateWidth(positions) - POSITION_OFFSET];
+		final int size = TableExportQuery.calculateWidth(positions);
+		Field<?>[] exportColumns = new Field[size];
 		exportColumns[0] = createSourceInfoSelect(cqTable);
 
 		// if columns have the same computed position, they can share a common name because they will be unioned over multiple tables anyway
-		for (Map.Entry<ColumnId, Integer> entry : positions.entrySet()) {
-			final ColumnId column = entry.getKey();
-			final int position = entry.getValue();
-
-			final int shifted = position - POSITION_OFFSET;
-			final Field<?> columnSelect = DSL.inline(null, Object.class).as("%s-%d".formatted(column.getColumn(), shifted));
-
+		positions.forEach((column, position) -> {
+			int shifted = position - 1;
+			Field<?> columnSelect = DSL.inline(null, Object.class).as("%s-%d".formatted(column.getColumn(), shifted));
 			exportColumns[shifted] = columnSelect;
-		}
+		});
 
 		return exportColumns;
 	}
 
-	private static Field<?> createColumnSelect(Column column, int position) {
-		final String columnName = "%s-%s".formatted(column.getName(), position);
-		return DSL.field(DSL.name(column.getTable().getName(), column.getName())).as(columnName);
-	}
-
 	private static Field<String> createSourceInfoSelect(CQTable cqTable) {
-		final String tableName = cqTable.getConnector().resolve().getResolvedTableId().getTable();
+		String tableName = cqTable.getConnector().resolve().getResolvedTableId().getTable();
 		return DSL.val(tableName).as(SharedAliases.SOURCE.getAlias());
 	}
 


### PR DESCRIPTION
…ng unified method from TableExportQuery#calculateWidth


Es kann sein, dass `createPlaceholders` etwas anders implementiert werden muss eben wegen den möglichen leeren Spalten, die versuche ich jetzt aber abzufangen bevor sie entstehen.