### PR TITLE
check against connectorId instead of table id

### DIFF
--- a/frontend/src/js/model/table.ts
+++ b/frontend/src/js/model/table.ts
@@ -58,7 +58,7 @@ export function tableIsIncludedInIds(
   tableIds: string[],
 ) {
   return tableIds.some(
-    (id) => table.id.toLowerCase().indexOf(id.toLowerCase()) !== -1,
+    (id) => table.connectorId.toLowerCase().indexOf(id.toLowerCase()) !== -1,
   );
 }
 


### PR DESCRIPTION
The table id does not necessarily correspond to the connector id. The latter is the right choice to block connectors in concepts.