### PR TITLE
minor dependency update to mina 2.2.4

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>org.apache.mina</groupId>
             <artifactId>mina-core</artifactId>
-            <version>2.1.5</version>
+            <version>2.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>

--- a/backend/src/test/java/com/bakdata/conquery/io/mina/MinaStackTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/io/mina/MinaStackTest.java
@@ -184,8 +184,9 @@ public class MinaStackTest {
 			// Wait until all clients completed writing
 			CompletableFuture.allOf(clientThreads.toArray(new CompletableFuture[0])).join();
 
+			log.info("Waiting to receive all send messages");
 			// Wait until all messages are received
-			await().atMost(10,TimeUnit.SECONDS).until(() -> SERVER_RECEIVED_MESSAGES.size() == messagesWritten.size());
+			await().atMost(10,TimeUnit.SECONDS).alias("Send and received same amount of messages").until(() -> SERVER_RECEIVED_MESSAGES.size() == messagesWritten.size());
 
 			// Check that the messages are correct
 			assertThat(SERVER_RECEIVED_MESSAGES).containsExactlyInAnyOrderElementsOf(messagesWritten);


### PR DESCRIPTION
To upgrade to a version that does not contain CVE-2024-52046 (which we are not affected by).

Closes https://github.com/ingef/conquery/pull/3646