### PR TITLE
ScriptEnd: rename config property to avoid Exception

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
+++ b/backend/src/main/java/com/bakdata/conquery/resources/admin/rest/AdminProcessor.java
@@ -66,18 +66,6 @@ public class AdminProcessor {
 	private final ObjectWriter jsonWriter = Jackson.MAPPER.writer();
 	private final Supplier<Collection<ShardNodeInformation>> nodeProvider;
 
-	public void addRoles(List<Role> roles) {
-
-		for (Role role : roles) {
-			try {
-				addRole(role);
-			}
-			catch (Exception e) {
-				log.error(String.format("Failed to add Role: %s", role), e);
-			}
-		}
-	}
-
 	public synchronized void addRole(Role role) throws JSONException {
 		ValidatorHelper.failOnError(log, validator.validate(role));
 		log.trace("New role:\tLabel: {}\tName: {}\tId: {} ", role.getLabel(), role.getName(), role.getId());
@@ -296,7 +284,7 @@ public class AdminProcessor {
 		groovy.setProperty("managerNode", getManagerNode());
 		groovy.setProperty("datasetRegistry", getDatasetRegistry());
 		groovy.setProperty("jobManager", getJobManager());
-		groovy.setProperty("config", getConfig());
+		groovy.setProperty("conqueryConfig", getConfig());
 		groovy.setProperty("storage", getStorage());
 
 		try {

--- a/backend/src/test/java/com/bakdata/conquery/integration/tests/ScriptEndTest.java
+++ b/backend/src/test/java/com/bakdata/conquery/integration/tests/ScriptEndTest.java
@@ -1,0 +1,30 @@
+package com.bakdata.conquery.integration.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import com.bakdata.conquery.integration.IntegrationTest;
+import com.bakdata.conquery.io.storage.MetaStorage;
+import com.bakdata.conquery.resources.admin.rest.AdminResource;
+import com.bakdata.conquery.resources.hierarchies.HierarchyHelper;
+import com.bakdata.conquery.util.support.StandaloneSupport;
+
+public class ScriptEndTest extends IntegrationTest.Simple implements ProgrammaticIntegrationTest {
+	@Override
+	public void execute(StandaloneSupport conquery) throws Exception {
+		final URI scriptUri = HierarchyHelper.hierarchicalPath(conquery.defaultAdminURIBuilder()
+															, AdminResource.class, "executeScript")
+													.build();
+
+		try(Response resp = conquery.getClient().target(scriptUri).request(MediaType.TEXT_PLAIN_TYPE).post(Entity.entity("storage", MediaType.TEXT_PLAIN_TYPE))){
+			assertThat(resp.getStatusInfo().getFamily()).isEqualTo(Response.Status.Family.SUCCESSFUL);
+
+			assertThat(resp.readEntity(String.class))
+					.contains(MetaStorage.class.getSimpleName());
+		}
+	}
+}


### PR DESCRIPTION
Fixes:
```
[backend]  | ERROR [2025-01-23 15:39:46]        i.d.j.e.LoggingExceptionMapper  user.81ac8d69-f2a6-4cf8-bf61-292453a3f44b       Error handling a request: 43828b2dc27cf90b
[backend]  | groovy.lang.ReadOnlyPropertyException: Cannot set readonly property: config for class: groovy.lang.GroovyShell
[backend]  |    at groovy.lang.MetaClassImpl.setProperty(MetaClassImpl.java:2855)
[backend]  |    at groovy.lang.MetaClassImpl.setProperty(MetaClassImpl.java:3912)
[backend]  |    at groovy.lang.GroovyObject.setProperty(GroovyObject.java:61)
[backend]  |    at groovy.lang.GroovyShell.setProperty(GroovyShell.java:172)
[backend]  |    at com.bakdata.conquery.resources.admin.rest.AdminProcessor.executeScript(AdminProcessor.java:301)
[backend]  |    at com.bakdata.conquery.resources.admin.rest.AdminResource.executeScript(AdminResource.java:57)
[backend]  |    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
[backend]  |    at java.base/java.lang.reflect.Method.invoke(Unknown Source)
[backend]  |    at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
[backend]  |    at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
[backend]  |    at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189)

```