### PR TITLE
Fix/update import

### DIFF
--- a/backend/src/main/java/com/bakdata/conquery/models/events/BucketManager.java
+++ b/backend/src/main/java/com/bakdata/conquery/models/events/BucketManager.java
@@ -344,7 +344,14 @@ public class BucketManager {
 	}
 
 	public void removeConceptTreeCacheByImport(ConceptId concept, ImportId imp) {
-		treeCaches.get(concept).remove(imp);
+		Map<ImportId, ConceptTreeCache> treeCache = treeCaches.get(concept);
+
+		if(treeCache == null) {
+			// Not all concepts have a cache: only concepts with column-based connectors
+			return;
+		}
+
+		treeCache.remove(imp);
 	}
 
 	public void removeConceptTreeCacheByConcept(ConceptId concept) {

--- a/backend/src/test/resources/tests/query/UPDATE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.json
+++ b/backend/src/test/resources/tests/query/UPDATE_IMPORT_TESTS/SIMPLE_TREECONCEPT_Query.json
@@ -53,6 +53,23 @@
 					"children": []
 				}
 			]
+		},
+		{
+			"label": "test_tree_table",
+			"type": "TREE",
+			"connectors": [
+				{
+					"label": "tree_label",
+					"name": "test_column",
+					"table": "table1",
+					"validityDates": {
+						"label": "datum",
+						"column": "table1.datum"
+					}
+				}
+			],
+			"children": [
+			]
 		}
 	],
 	"content": {


### PR DESCRIPTION
Adds null check to prevent NPE when updateing an import on a datasets, that uses concepts whose connectors only reference tables