### PR TITLE
ci: document the dependabot / pnpm release-age interplay for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,16 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
+    # Must match minimumReleaseAge (7 days) in frontend/pnpm-workspace.yaml,
+    # otherwise dependabot proposes versions that pnpm refuses to install.
+    cooldown:
+      default-days: 7
+    groups:
+      frontend-minor-and-patch:
+        update-types:
+          - minor
+          - patch
     assignees:
       - Kadrian
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
     # otherwise dependabot proposes versions that pnpm refuses to install.
     cooldown:
       default-days: 7
+    # Majors are migrations and are done by hand, dependabot only proposes minor/patch
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       frontend-minor-and-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,20 +16,11 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
-    # Must match minimumReleaseAge (7 days) in frontend/pnpm-workspace.yaml,
-    # otherwise dependabot proposes versions that pnpm refuses to install.
-    cooldown:
-      default-days: 7
-    # Majors are migrations and are done by hand, dependabot only proposes minor/patch
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      frontend-minor-and-patch:
-        update-types:
-          - minor
-          - patch
+    # Version updates are done by hand (upgrades are cheap now, majors are migrations);
+    # dependabot only opens security PRs here, which ignore this limit. Note that a
+    # security fix younger than minimumReleaseAge (frontend/pnpm-workspace.yaml) needs a
+    # minimumReleaseAgeExclude before it installs.
+    open-pull-requests-limit: 0
     assignees:
       - Kadrian
     labels:


### PR DESCRIPTION
Follow-up from the review of #3957. Decision: no automated npm version updates - upgrades are done by hand (majors are migrations), dependabot keeps opening security PRs only (those ignore `open-pull-requests-limit`).

The comment in `dependabot.yml` records the one interaction to know about: a security fix younger than `minimumReleaseAge` (7 days, `frontend/pnpm-workspace.yaml`) needs a `minimumReleaseAgeExclude` before `pnpm install --frozen-lockfile` accepts it.

The ~40 open npm security PRs all target the deleted `package-lock.json`; dependabot closes them on re-evaluation against `pnpm-lock.yaml`.