### PR TITLE
chore(frontend): lint cleanup, biome warnings to zero

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider } from "@emotion/react";
-import type { Preview } from "@storybook/react";
+import type { Decorator, Preview } from "@storybook/react";
 
 import { theme } from "../src/app-theme";
 import DndProvider from "../src/js/app/DndProvider";
@@ -10,7 +10,7 @@ import translationsDe from "../src/localization/de.json";
 i18next.addResourceBundle("de", "translation", translationsDe, true, true);
 i18next.changeLanguage("de");
 
-const Decorator = (Story: any) => (
+const withProviders: Decorator = (Story) => (
   <ThemeProvider theme={theme}>
     <DndProvider>
       <GlobalStyles />
@@ -20,7 +20,7 @@ const Decorator = (Story: any) => (
 );
 
 const preview: Preview = {
-  decorators: [Decorator],
+  decorators: [withProviders],
   parameters: {
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {

--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -9,7 +9,8 @@
       "!!dist",
       "!!storybook-static",
       "!!public",
-      "!mock-api/**/*.json"
+      "!mock-api/**/*.json",
+      "!src/fixtures"
     ],
     "ignoreUnknown": true
   },
@@ -47,8 +48,7 @@
         "noSwitchDeclarations": "off",
         "useExhaustiveDependencies": "warn",
         "useHookAtTopLevel": "error",
-        // TODO: 7 lists render without keys, fix and raise to error
-        "useJsxKeyInIterable": "warn"
+        "useJsxKeyInIterable": "error"
       },
       "security": {
         // Markdown/HTML rendering from trusted backend content is intentional
@@ -59,7 +59,7 @@
         "noNonNullAssertion": "off"
       },
       "suspicious": {
-        // TODO: ~30 index keys, revisit
+        // Index keys are fine for the static, non-reorderable lists this app renders
         "noArrayIndexKey": "off",
         "noDoubleEquals": "error",
         "noDebugger": "warn",

--- a/frontend/mock-api/mockApi.ts
+++ b/frontend/mock-api/mockApi.ts
@@ -1,7 +1,7 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import Chance from "chance";
 import type { Application } from "express";
-import path from "path";
-import { fileURLToPath } from "url";
 import packagejson from "../package.json" with { type: "json" };
 
 import config from "./config.json" with { type: "json" };

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -1,13 +1,14 @@
 // ----------------------------------
 // PRODUCTION SERVER (see Dockerfile)
 // ----------------------------------
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import compression from "compression";
 import cors from "cors";
 import express from "express";
 import rateLimit from "express-rate-limit";
 import helmet from "helmet";
-import path from "path";
-import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/frontend/src/js/api/api.ts
+++ b/frontend/src/js/api/api.ts
@@ -275,7 +275,7 @@ export const useGetMe = () => {
 
 export const usePostLogin = () => {
   const api = useApiUnauthorized<PostLoginResponseT>({
-    url: apiUrl + "/auth",
+    url: `${apiUrl}/auth`,
     method: "POST",
   });
 
@@ -411,20 +411,17 @@ export const useGetResult = () => {
     },
     [authToken],
   );
-  return useCallback(
-    (queryId: string, limit: number) => {
-      const url =
-        `/result/arrow/${queryId}.arrs?` +
-        new URLSearchParams({ limit: limit.toString() });
-      const res = fetch(getProtectedUrl(url), {
-        headers: {
-          Authorization: `Bearer ${authTokenRef.current}`,
-        },
-      });
-      return res;
-    },
-    [authTokenRef],
-  );
+  return useCallback((queryId: string, limit: number) => {
+    const url =
+      `/result/arrow/${queryId}.arrs?` +
+      new URLSearchParams({ limit: limit.toString() });
+    const res = fetch(getProtectedUrl(url), {
+      headers: {
+        Authorization: `Bearer ${authTokenRef.current}`,
+      },
+    });
+    return res;
+  }, []);
 };
 
 export const usePreviewStatistics = () => {

--- a/frontend/src/js/button/IconButton.tsx
+++ b/frontend/src/js/button/IconButton.tsx
@@ -63,7 +63,7 @@ const SxBasicButton = styled(BasicButton)<{
 
   border-radius: ${({ theme }) => theme.borderRadius};
   border: ${({ theme, frame }) =>
-    frame ? "1px solid " + theme.col.gray : "none"};
+    frame ? `1px solid ${theme.col.gray}` : "none"};
   display: inline-flex;
   align-items: center;
   gap: ${({ tight }) => (tight ? "5px" : "10px")};

--- a/frontend/src/js/common/helpers/commonHelper.ts
+++ b/frontend/src/js/common/helpers/commonHelper.ts
@@ -8,7 +8,7 @@ export const isEmpty = (variable: unknown) => {
     typeof variable === "undefined" ||
     variable === null ||
     variable === "" ||
-    (variable instanceof Array && variable.length === 0) ||
+    (Array.isArray(variable) && variable.length === 0) ||
     (variable.constructor === Object && Object.keys(variable).length === 0)
   );
 };
@@ -31,6 +31,6 @@ export const toUpperCaseUnderscore = (str: string) => {
   if (str.toUpperCase() === str) return str;
 
   return str
-    .replace(/[A-Z]/g, (upperCaseChar) => "_" + upperCaseChar.toLowerCase())
+    .replace(/[A-Z]/g, (upperCaseChar) => `_${upperCaseChar.toLowerCase()}`)
     .toUpperCase();
 };

--- a/frontend/src/js/common/helpers/dateHelper.ts
+++ b/frontend/src/js/common/helpers/dateHelper.ts
@@ -86,7 +86,11 @@ function handleRaw(
   const yIdx = denseFormat.indexOf("y");
   const y = value.substring(yIdx, yIdx + 4);
 
-  let date: Date | null = new Date(parseInt(y), parseInt(m) - 1, parseInt(d));
+  let date: Date | null = new Date(
+    parseInt(y, 10),
+    parseInt(m, 10) - 1,
+    parseInt(d, 10),
+  );
 
   date = isValid(date) ? date : null;
 
@@ -99,7 +103,7 @@ function handleYear(value: string) {
   if (!match) {
     throw new Error("Quarter.year should match at this point");
   }
-  const year = parseInt(match[1]);
+  const year = parseInt(match[1], 10);
 
   const min = new Date(year, 0, 1);
   const max = new Date(year, 11, 31);
@@ -114,8 +118,8 @@ function handleQuarter(value: string) {
     throw new Error("Quarter.year should match at this point");
   }
 
-  const quarter = parseInt(match[1]);
-  const year = parseInt(match[2]);
+  const quarter = parseInt(match[1], 10);
+  const year = parseInt(match[2], 10);
 
   const min = addQuarters(new Date(year, 0, 1), quarter - 1);
   const max = lastDayOfQuarter(addQuarters(new Date(year, 0, 1), quarter - 1));
@@ -130,8 +134,8 @@ function handleMonth(value: string) {
     throw new Error("Month.year should match at this point");
   }
 
-  const month = parseInt(match[1]);
-  const year = parseInt(match[2]);
+  const month = parseInt(match[1], 10);
+  const year = parseInt(match[2], 10);
 
   const min = addMonths(new Date(year, 0, 1), month - 1);
   const max = endOfMonth(addMonths(new Date(year, 0, 1), month - 1));

--- a/frontend/src/js/common/helpers/useDebounce.ts
+++ b/frontend/src/js/common/helpers/useDebounce.ts
@@ -20,7 +20,6 @@ export const useDebounce = (
     delayRef.current = delay;
   }, [delay]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dependencies are passed in by the caller, so useDebounce works like useEffect
   useEffect(() => {
     if (handle.current) clearTimeout(handle.current);
 
@@ -32,5 +31,6 @@ export const useDebounce = (
     return () => {
       if (handle.current) clearTimeout(handle.current);
     };
+    // biome-ignore lint/correctness/useExhaustiveDependencies: dependencies are passed in by the caller, so useDebounce works like useEffect
   }, debounceTriggers);
 };

--- a/frontend/src/js/concept-trees/ConceptTreeFolder.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeFolder.tsx
@@ -123,12 +123,10 @@ const ConceptTreeFolder = ({
         search={search}
       />
       {isOpen &&
-        tree.children &&
-        tree.children.map((childId) => {
+        tree.children?.map((childId) => {
           const tree = trees[childId];
 
           const treeProps = {
-            key: childId,
             conceptId: childId as ConceptIdT,
             depth: depth + 1,
             search,
@@ -140,6 +138,7 @@ const ConceptTreeFolder = ({
 
             return (
               <ConceptTree
+                key={childId}
                 label={tree.label}
                 error={tree.error}
                 loading={tree.loading}
@@ -155,7 +154,13 @@ const ConceptTreeFolder = ({
               active: tree.active,
             };
 
-            return <ConceptTreeFolder {...treeFolderProps} {...treeProps} />;
+            return (
+              <ConceptTreeFolder
+                key={childId}
+                {...treeFolderProps}
+                {...treeProps}
+              />
+            );
           }
         })}
     </Root>

--- a/frontend/src/js/concept-trees/ConceptTreeNode.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNode.tsx
@@ -101,24 +101,22 @@ const ConceptTreeNode = ({
         onTextClick={toggleOpen}
         search={search}
       />
-      {!!data.children && isOpen && (
-        <>
-          {data.children.map((childId) => {
-            const child = getConceptById(childId);
+      {!!data.children &&
+        isOpen &&
+        data.children.map((childId) => {
+          const child = getConceptById(childId);
 
-            return child ? (
-              <ConceptTreeNode
-                key={childId}
-                rootConceptId={rootConceptId}
-                conceptId={childId}
-                data={child}
-                depth={depth + 1}
-                search={search}
-              />
-            ) : null;
-          })}
-        </>
-      )}
+          return child ? (
+            <ConceptTreeNode
+              key={childId}
+              rootConceptId={rootConceptId}
+              conceptId={childId}
+              data={child}
+              depth={depth + 1}
+              search={search}
+            />
+          ) : null;
+        })}
     </Root>
   );
 };

--- a/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
@@ -16,7 +16,7 @@ const Root = styled("div")<{ depth: number }>`
   cursor: pointer;
   padding: 0 15px 0 15px;
   margin: 2px 0;
-  padding-left: ${({ depth }) => depth * 15 + "px"};
+  padding-left: ${({ depth }) => `${depth * 15}px`};
   display: flex;
 `;
 

--- a/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
+++ b/frontend/src/js/concept-trees/globalTreeStoreHelper.ts
@@ -188,16 +188,17 @@ export const globalSearch = async (trees: TreesT, query: string) => {
   const result = Object.keys(combinedTrees)
     .filter((key) => !combinedTrees[key].parent)
     .reduce<Record<ConceptIdT, number>>(
-      (all, key) => ({
-        ...all,
-        ...findConcepts(
-          combinedTrees,
-          key,
-          key,
-          combinedTrees[key][key],
-          lowerQuery,
+      (all, key) =>
+        Object.assign(
+          all,
+          findConcepts(
+            combinedTrees,
+            key,
+            key,
+            combinedTrees[key][key],
+            lowerQuery,
+          ),
         ),
-      }),
       {},
     );
 

--- a/frontend/src/js/concept-trees/search.ts
+++ b/frontend/src/js/concept-trees/search.ts
@@ -3,13 +3,12 @@ import type { ConceptIdT, ConceptT } from "../api/types";
 export const doesQueryMatchNode = (node: ConceptT, query: string) => {
   return (
     node.label.toLowerCase().includes(query) ||
-    (node.description && node.description.toLowerCase().includes(query)) ||
-    (node.additionalInfos &&
-      node.additionalInfos
-        .map(({ value }) => value)
-        .join("")
-        .toLowerCase()
-        .includes(query))
+    node.description?.toLowerCase().includes(query) ||
+    node.additionalInfos
+      ?.map(({ value }) => value)
+      .join("")
+      .toLowerCase()
+      .includes(query)
   );
 };
 

--- a/frontend/src/js/editor-v2/EditorV2.tsx
+++ b/frontend/src/js/editor-v2/EditorV2.tsx
@@ -123,6 +123,7 @@ const useEditorState = () => {
 
 const useResetOnDatasetChange = (onReset: () => void) => {
   const datasetId = useDatasetId();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset whenever the dataset changes
   useEffect(() => {
     onReset();
   }, [datasetId, onReset]);
@@ -159,7 +160,7 @@ export function EditorV2({
   useResetOnDatasetChange(onReset);
 
   const onFlip = useCallback(() => {
-    if (!selectedNode || !selectedNode.children) return;
+    if (!selectedNode?.children) return;
 
     updateTreeNode(selectedNode.id, (node) => {
       if (!node.children) return;

--- a/frontend/src/js/editor-v2/TreeNode.tsx
+++ b/frontend/src/js/editor-v2/TreeNode.tsx
@@ -353,7 +353,7 @@ export function TreeNode({
                         />
                         {i < items.length - 1 && (
                           <InvisibleDropzoneContainer
-                            key={item.id + "connector"}
+                            key={`${item.id}connector`}
                             acceptedDropTypes={[DNDType.CONCEPT_TREE_NODE]}
                             naked
                             bare

--- a/frontend/src/js/editor-v2/TreeNodeConcept.tsx
+++ b/frontend/src/js/editor-v2/TreeNodeConcept.tsx
@@ -48,8 +48,7 @@ export const TreeNodeConcept = ({
 
   const filtersWithValues = node.tables.flatMap((t) =>
     t.filters.filter(
-      (f) =>
-        exists(f.value) && (!(f.value instanceof Array) || f.value.length > 0),
+      (f) => exists(f.value) && (!Array.isArray(f.value) || f.value.length > 0),
     ),
   );
 
@@ -74,7 +73,7 @@ export const TreeNodeConcept = ({
             <div>
               <SectionHeading>{t("editorV2.filtersSection")}</SectionHeading>
               {filtersWithValues.map((f) => (
-                <Description>
+                <Description key={f.label}>
                   <Bold>{f.label}:</Bold>
                   <Value value={f.value} />
                 </Description>
@@ -103,7 +102,7 @@ const Value = ({
     );
   } else if (typeof value === "boolean") {
     return <span>{value ? "✔" : "✗"}</span>;
-  } else if (value instanceof Array) {
+  } else if (Array.isArray(value)) {
     return (
       <>
         {value.slice(0, 10).map((v, idx) => (

--- a/frontend/src/js/editor-v2/connector-update/useConnectorRotation.ts
+++ b/frontend/src/js/editor-v2/connector-update/useConnectorRotation.ts
@@ -49,7 +49,7 @@ export const useConnectorEditing = ({
   updateTreeNode: (id: string, update: (node: Tree) => void) => void;
 }) => {
   const onRotateConnector = useCallback(() => {
-    if (!enabled || !selectedNode || !selectedNode.children) return;
+    if (!enabled || !selectedNode?.children) return;
 
     updateTreeNode(selectedNode.id, (node) => {
       if (!node.children) return;

--- a/frontend/src/js/editor-v2/date-restriction/DateRange.tsx
+++ b/frontend/src/js/editor-v2/date-restriction/DateRange.tsx
@@ -24,7 +24,7 @@ const getFormattedDate = (date: string | undefined, dateFormat: string) => {
 
   const d = new Date(date);
 
-  if (isNaN(d.getTime())) return null;
+  if (Number.isNaN(d.getTime())) return null;
 
   return formatDate(d, dateFormat);
 };

--- a/frontend/src/js/editor-v2/util.ts
+++ b/frontend/src/js/editor-v2/util.ts
@@ -33,7 +33,7 @@ const getNodeLabel = (
   } else if (node.children) {
     return node.children.items
       .map((n) => getNodeLabel(n, getTranslatedConnection))
-      .join(" " + getTranslatedConnection(node.children.connection) + " ");
+      .join(` ${getTranslatedConnection(node.children.connection)} `);
   } else {
     return "";
   }

--- a/frontend/src/js/entity-history/TimeStratifiedChart.tsx
+++ b/frontend/src/js/entity-history/TimeStratifiedChart.tsx
@@ -47,7 +47,7 @@ export function hexToRgbA(hex: string) {
     if (c.length === 3) {
       c = [c[0], c[0], c[1], c[1], c[2], c[2]];
     }
-    c = "0x" + c.join("");
+    c = `0x${c.join("")}`;
     // @ts-ignore TODO: clarify why this works / use a different / typed algorithm
     return [(c >> 16) & 255, (c >> 8) & 255, c & 255].join(",");
   }
@@ -137,10 +137,10 @@ export const TimeStratifiedChart = ({
           ticks: {
             callback: (idx: string | number) => {
               return labels[idx as number].length > TRUNCATE_X_AXIS_LABELS_LEN
-                ? labels[idx as number].substring(
+                ? `${labels[idx as number].substring(
                     0,
                     TRUNCATE_X_AXIS_LABELS_LEN - 3,
-                  ) + "..."
+                  )}...`
                 : labels[idx as number];
             },
           },

--- a/frontend/src/js/entity-history/TimeStratifiedConceptChart.tsx
+++ b/frontend/src/js/entity-history/TimeStratifiedConceptChart.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { faBan } from "@fortawesome/free-solid-svg-icons";
+import { Fragment } from "react";
 import { useTranslation } from "react-i18next";
 
 import type {
@@ -75,14 +76,12 @@ export const TimeStratifiedConceptChart = ({
 
   const allValues = [
     ...new Set(
-      valuesPerYear
-        .flatMap((v) => v)
-        .sort((a, b) => {
-          const nA = Number(a?.label);
-          const nB = Number(b?.label);
-          if (!isNaN(nA) && !isNaN(nB)) return nA - nB;
-          return a?.label.localeCompare(b?.label);
-        }),
+      valuesPerYear.flat().sort((a, b) => {
+        const nA = Number(a?.label);
+        const nB = Number(b?.label);
+        if (!Number.isNaN(nA) && !Number.isNaN(nB)) return nA - nB;
+        return a?.label.localeCompare(b?.label);
+      }),
     ),
   ];
 
@@ -109,12 +108,16 @@ export const TimeStratifiedConceptChart = ({
         </WithTooltip>
       ))}
       {years.map((year, i) => (
-        <>
+        <Fragment key={year}>
           <Year>{year}</Year>
           {allValues.map((val) =>
-            valuesPerYear[i].includes(val) ? <BubbleYes /> : <BubbleNo />,
+            valuesPerYear[i].includes(val) ? (
+              <BubbleYes key={val.label} />
+            ) : (
+              <BubbleNo key={val.label} />
+            ),
           )}
-        </>
+        </Fragment>
       ))}
     </Container>
   );

--- a/frontend/src/js/entity-history/saveAndLoad.ts
+++ b/frontend/src/js/entity-history/saveAndLoad.ts
@@ -86,7 +86,7 @@ export const useLoadHistory = ({
       }
 
       const loadedEntityStatusOptions: SelectOptionT[] = [
-        ...new Set(Object.values(loadedEntityStatus).flatMap((val) => val)),
+        ...new Set(Object.values(loadedEntityStatus).flat()),
       ];
 
       if (distinctEntityIds.size === 0) {

--- a/frontend/src/js/entity-history/timeline/ConceptName.tsx
+++ b/frontend/src/js/entity-history/timeline/ConceptName.tsx
@@ -35,7 +35,7 @@ const ConceptLabel = ({
 }) => {
   const label = concept
     ? `${concept.label}${
-        concept.description ? " – " + concept.description : ""
+        concept.description ? ` – ${concept.description}` : ""
       }`
     : conceptId;
 
@@ -63,10 +63,10 @@ const RootConceptLabel = ({
   return searchTerm && searchTerm.length > 0 ? (
     <Highlighter
       searchWords={searchTerm.split(" ")}
-      textToHighlight={rootConcept.label + " "}
+      textToHighlight={`${rootConcept.label} `}
     />
   ) : (
-    rootConcept.label + " "
+    `${rootConcept.label} `
   );
 };
 

--- a/frontend/src/js/entity-history/timeline/EventCard.tsx
+++ b/frontend/src/js/entity-history/timeline/EventCard.tsx
@@ -159,7 +159,7 @@ const EventCard = ({
                       thousandSeparator={currencyConfig.thousandSeparator}
                       decimalSeparator={currencyConfig.decimalSeparator}
                       decimalScale={currencyConfig.decimalScale}
-                      suffix={" " + currencyConfig.unit}
+                      suffix={` ${currencyConfig.unit}`}
                       displayType="text"
                       value={parseFloat(row[column.label] as string)}
                     />

--- a/frontend/src/js/entity-history/timeline/YearHead.tsx
+++ b/frontend/src/js/entity-history/timeline/YearHead.tsx
@@ -119,14 +119,14 @@ const TimeStratifiedInfos = ({
                       s.type === "CONCEPT_COLUMN",
                   );
 
-                  if (value instanceof Array) {
+                  if (Array.isArray(value)) {
                     const concepts = value
                       .map((v) => getConceptById(v, semantic!.concept))
                       .filter(exists)
                       .sort((c1, c2) => {
                         const n1 = Number(c1.label);
                         const n2 = Number(c2.label);
-                        if (!isNaN(n1) && !isNaN(n2)) {
+                        if (!Number.isNaN(n1) && !Number.isNaN(n2)) {
                           return n1 - n2;
                         }
                         return c1.label.localeCompare(c2.label);
@@ -163,7 +163,7 @@ const TimeStratifiedInfos = ({
                   valueFormatted = isMoneyColumn(column)
                     ? formatCurrency(value)
                     : Math.round(value);
-                } else if (value instanceof Array) {
+                } else if (Array.isArray(value)) {
                   valueFormatted = value.join(", ");
                 }
 

--- a/frontend/src/js/entity-history/timeline/util/groupByQuarter.ts
+++ b/frontend/src/js/entity-history/timeline/util/groupByQuarter.ts
@@ -70,7 +70,7 @@ export const groupByQuarter = (
   // Bucket by quarter
   for (const row of entityData) {
     const [year, month] = (row[dateColumn.label] as DateRow).from.split("-");
-    const quarter = Math.floor((parseInt(month) - 1) / 3) + 1;
+    const quarter = Math.floor((parseInt(month, 10) - 1) / 3) + 1;
 
     if (!result[year]) {
       result[year] = { [quarter]: [] };
@@ -94,12 +94,15 @@ export const groupByQuarter = (
 
   // Sort within quarter
   const sortedEvents = Object.entries(result)
-    .sort(([yearA], [yearB]) => parseInt(yearB) - parseInt(yearA))
+    .sort(([yearA], [yearB]) => parseInt(yearB, 10) - parseInt(yearA, 10))
     .map(([year, quarterwiseData]) => ({
-      year: parseInt(year),
+      year: parseInt(year, 10),
       quarterwiseData: Object.entries(quarterwiseData)
-        .sort(([qA], [qB]) => parseInt(qB) - parseInt(qA))
-        .map(([quarter, events]) => ({ quarter: parseInt(quarter), events })),
+        .sort(([qA], [qB]) => parseInt(qB, 10) - parseInt(qA, 10))
+        .map(([quarter, events]) => ({
+          quarter: parseInt(quarter, 10),
+          events,
+        })),
     }));
 
   if (sortedEvents.length === 0) {

--- a/frontend/src/js/external-forms/FormsTab.tsx
+++ b/frontend/src/js/external-forms/FormsTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { useDispatch, useSelector, useStore } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { useGetForms } from "../api/api";
 import type { DatasetT } from "../api/types";
@@ -17,7 +17,6 @@ import { collectAllFormFields, getInitialValue } from "./helper";
 import { selectFormConfig } from "./stateSelectors";
 
 const useLoadForms = ({ datasetId }: { datasetId: DatasetT["id"] | null }) => {
-  const store = useStore();
   const getForms = useGetForms();
   const dispatch = useDispatch();
 
@@ -37,7 +36,7 @@ const useLoadForms = ({ datasetId }: { datasetId: DatasetT["id"] | null }) => {
     }
 
     loadForms();
-  }, [store, datasetId, getForms, dispatch]);
+  }, [datasetId, getForms, dispatch]);
 };
 
 export const useDatasetOptions = () => {
@@ -93,6 +92,7 @@ const useInitializeForm = ({
     mode: "onChange",
   });
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-validate whenever the form config changes
   useEffect(
     function triggerValidationInitially() {
       methods.trigger();

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptCopyModal.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptCopyModal.tsx
@@ -117,10 +117,7 @@ const FormConceptCopyModal = ({
 
   function onToggleAllConcepts() {
     const allChecked = Object.fromEntries(
-      Object.entries(valuesChecked).map(([key]) => [
-        key,
-        allConceptsSelected ? false : true,
-      ]),
+      Object.entries(valuesChecked).map(([key]) => [key, !allConceptsSelected]),
     );
 
     setValuesChecked(allChecked);

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
@@ -314,7 +314,7 @@ const FormConceptGroup = (props: Props) => {
           );
         }}
         items={props.value.map((row, i) => (
-          <div>
+          <div key={i}>
             {props.renderRowPrefix
               ? props.renderRowPrefix({
                   value: props.value,
@@ -407,6 +407,7 @@ const FormConceptGroup = (props: Props) => {
                   />
                 ) : (
                   <DropzoneWithFileInput /* TODO: ADD GENERIC TYPE <DragItemConceptTreeNode> */
+                    key={j}
                     acceptedDropTypes={DROP_TYPES}
                     onImportLines={(lines, filename) =>
                       onImportLines(

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptNode.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptNode.tsx
@@ -149,9 +149,10 @@ const FormConceptNode: FC<PropsT> = ({
       >
         <div>
           <WithTooltip text={tooltipText}>
+            {/* biome-ignore lint/complexity/noUselessFragments: WithTooltip takes a single child */}
             <>
               {rootNodeLabel && <RootNode>{rootNodeLabel}</RootNode>}
-              <Label>{conceptNode && conceptNode.label}</Label>
+              <Label>{conceptNode?.label}</Label>
               {conceptNode && !!conceptNode.description && (
                 <Description>{conceptNode.description}</Description>
               )}
@@ -159,7 +160,7 @@ const FormConceptNode: FC<PropsT> = ({
           </WithTooltip>
         </div>
         <Right>
-          {expand && expand.expandable && (
+          {expand?.expandable && (
             <WithTooltip text={t("externalForms.common.concept.expand")}>
               <SxIconButton
                 icon={expand.active ? faCompressArrowsAlt : faExpandArrowsAlt}

--- a/frontend/src/js/external-forms/form-concept-group/formConceptGroupState.ts
+++ b/frontend/src/js/external-forms/form-concept-group/formConceptGroupState.ts
@@ -188,7 +188,7 @@ export const onToggleIncludeSubnodes = (
 
   const conceptData = getConceptById(concept.ids[0]);
 
-  if (!conceptData || !conceptData.children) return value;
+  if (!conceptData?.children) return value;
 
   const childIds: string[] = [];
   const elements: FormConceptGroupT[] = conceptData.children

--- a/frontend/src/js/external-forms/form/Form.tsx
+++ b/frontend/src/js/external-forms/form/Form.tsx
@@ -29,7 +29,7 @@ const Form = memo(({ config, datasetOptions, methods }: Props) => {
 
   return (
     <div className="w-full flex flex-col gap-2">
-      {config.description && config.description[activeLang] && (
+      {config.description?.[activeLang] && (
         <SxFormHeader
           description={config.description[activeLang]!}
           manualUrl={config.manualUrl}

--- a/frontend/src/js/external-forms/form/fields/GroupField.tsx
+++ b/frontend/src/js/external-forms/form/fields/GroupField.tsx
@@ -27,7 +27,7 @@ export const GroupField = ({
       )}
       <GroupContainer
         style={{
-          display: (field.style && field.style.display) || "flex",
+          display: field.style?.display || "flex",
           gap: field.style?.display === "grid" ? "7px 12px" : "7px 8px",
           gridTemplateColumns: `repeat(${field.style?.gridColumns || 1}, 1fr)`,
         }}

--- a/frontend/src/js/external-forms/form/fields/NumberField.tsx
+++ b/frontend/src/js/external-forms/form/fields/NumberField.tsx
@@ -24,7 +24,7 @@ export const NumberField = ({
           ref={ref}
           inputType="number"
           label={field.label[locale] || ""}
-          placeholder={(field.placeholder && field.placeholder[locale]) || ""}
+          placeholder={field.placeholder?.[locale] || ""}
           value={fieldProps.value as number | null}
           onChange={(value) => setValue(field.name, value, setValueConfig)}
           inputProps={{

--- a/frontend/src/js/external-forms/form/fields/StringField.tsx
+++ b/frontend/src/js/external-forms/form/fields/StringField.tsx
@@ -24,7 +24,7 @@ export const StringField = ({
           ref={ref}
           inputType="text"
           label={field.label[locale] || ""}
-          placeholder={(field.placeholder && field.placeholder[locale]) || ""}
+          placeholder={field.placeholder?.[locale] || ""}
           fullWidth={field.style ? field.style.fullWidth : false}
           value={fieldProps.value as string}
           onChange={(value) => setValue(field.name, value, setValueConfig)}

--- a/frontend/src/js/external-forms/form/fields/TextAreaField.tsx
+++ b/frontend/src/js/external-forms/form/fields/TextAreaField.tsx
@@ -23,7 +23,7 @@ export const TextAreaField = ({
         <InputTextarea
           ref={ref}
           label={field.label[locale] || ""}
-          placeholder={(field.placeholder && field.placeholder[locale]) || ""}
+          placeholder={field.placeholder?.[locale] || ""}
           rows={field.style?.rows ?? 4}
           value={fieldProps.value as string}
           onChange={(value) => {

--- a/frontend/src/js/external-forms/validators.ts
+++ b/frontend/src/js/external-forms/validators.ts
@@ -49,7 +49,7 @@ export const validateDateRangeRequired = (
     max: string;
   } | null,
 ): string | null => {
-  if (!value || !value.min || !value.max)
+  if (!value?.min || !value.max)
     return t("externalForms.formValidation.isRequired");
 
   return validateDateRange(t, value);

--- a/frontend/src/js/model/select.ts
+++ b/frontend/src/js/model/select.ts
@@ -10,14 +10,10 @@ import type { NodeResetConfig } from "./node";
 export function objectHasNonDefaultSelects(
   obj: ConceptQueryNodeType | TableWithFilterValueT,
 ) {
-  return (
-    obj &&
-    obj.selects &&
-    obj.selects.some(
-      (select) =>
-        (select.selected && !select.default) ||
-        (!select.selected && !!select.default),
-    )
+  return obj?.selects?.some(
+    (select) =>
+      (select.selected && !select.default) ||
+      (!select.selected && !!select.default),
   );
 }
 

--- a/frontend/src/js/model/table.ts
+++ b/frontend/src/js/model/table.ts
@@ -40,8 +40,7 @@ export const tablesHaveFilterValues = (tables: TableWithFilterValueT[]) =>
 export const tableHasNonDefaultSettings = (table: TableWithFilterValueT) => {
   const activeSelects = objectHasNonDefaultSelects(table);
   const activeDateColumn = tableHasNonDefaultDateColumn(table);
-  const activeFilters =
-    table.filters && table.filters.some(filterValueDiffersFromDefault);
+  const activeFilters = table.filters?.some(filterValueDiffersFromDefault);
 
   return activeSelects || activeDateColumn || activeFilters;
 };

--- a/frontend/src/js/pane/Pane.tsx
+++ b/frontend/src/js/pane/Pane.tsx
@@ -38,7 +38,7 @@ const Pane = ({ tabs, left, children, className, dataTestId }: Props) => {
           paneType={paneType}
           dataTestId={dataTestId}
         />
-        <Container data-test-id={dataTestId + "-container"}>
+        <Container data-test-id={`${dataTestId}-container`}>
           {children}
         </Container>
       </Container>

--- a/frontend/src/js/preview/Charts.tsx
+++ b/frontend/src/js/preview/Charts.tsx
@@ -71,37 +71,35 @@ export default function Charts({
   useHotkeys("right", () => updatePage(1), [page]);
 
   return (
-    <>
-      <Root className={className}>
-        <DiagramContainer>
-          {diagramsOnPage.map((statistic) => {
-            return (
-              <div key={statistic.label}>
-                <SxDiagram
-                  stat={statistic}
-                  onClick={() => showPopup(statistic)}
-                />
-              </div>
-            );
-          })}
-        </DiagramContainer>
-        <DirectionSelector>
-          <SxIconButton
-            icon={faArrowLeft}
-            onClick={() => updatePage(-1)}
-            disabled={page === 0}
-          />
-          <span>
-            {t("preview.page")} {page + 1}/
-            {Math.ceil(statistics.length / DIAGRAMS_PER_PAGE)}
-          </span>
-          <SxIconButton
-            icon={faArrowRight}
-            onClick={() => updatePage(1)}
-            disabled={page === maxPage - 1}
-          />
-        </DirectionSelector>
-      </Root>
-    </>
+    <Root className={className}>
+      <DiagramContainer>
+        {diagramsOnPage.map((statistic) => {
+          return (
+            <div key={statistic.label}>
+              <SxDiagram
+                stat={statistic}
+                onClick={() => showPopup(statistic)}
+              />
+            </div>
+          );
+        })}
+      </DiagramContainer>
+      <DirectionSelector>
+        <SxIconButton
+          icon={faArrowLeft}
+          onClick={() => updatePage(-1)}
+          disabled={page === 0}
+        />
+        <span>
+          {t("preview.page")} {page + 1}/
+          {Math.ceil(statistics.length / DIAGRAMS_PER_PAGE)}
+        </span>
+        <SxIconButton
+          icon={faArrowRight}
+          onClick={() => updatePage(1)}
+          disabled={page === maxPage - 1}
+        />
+      </DirectionSelector>
+    </Root>
   );
 }

--- a/frontend/src/js/preview/Diagram.tsx
+++ b/frontend/src/js/preview/Diagram.tsx
@@ -218,7 +218,7 @@ export default function Diagram({
         <Bar
           options={options as ChartOptions<"bar">}
           data={data as ChartData<"bar">}
-          onClick={() => onClick && onClick()}
+          onClick={() => onClick?.()}
           height={height}
           width={width}
         />
@@ -226,7 +226,7 @@ export default function Diagram({
         <Line
           options={options as ChartOptions<"line">}
           data={data as ChartData<"line">}
-          onClick={() => onClick && onClick()}
+          onClick={() => onClick?.()}
           height={height}
           width={width}
         />

--- a/frontend/src/js/preview/ScrollBox.tsx
+++ b/frontend/src/js/preview/ScrollBox.tsx
@@ -46,7 +46,7 @@ export default function ScrollBox({
       passive: true,
     });
     return () => scrollBox?.removeEventListener("scroll", scrollHandler);
-  }, [scrollBoxRef, threshold]);
+  }, [threshold]);
 
   return (
     <Root ref={scrollBoxRef} {...props}>

--- a/frontend/src/js/preview/tableUtils.ts
+++ b/frontend/src/js/preview/tableUtils.ts
@@ -28,9 +28,8 @@ export function useCustomTableRenderers(queryData: GetQueryResponseDoneT) {
       });
 
       if (cellType.indexOf("LIST") === 0) {
-        const listType = cellType.match(/LIST\[(?<listtype>.*)\]/)?.groups?.[
-          "listtype"
-        ];
+        const listType = cellType.match(/LIST\[(?<listtype>.*)\]/)?.groups
+          ?.listtype;
         if (listType) {
           const listTypeRenderFunction = getRenderFunction(listType);
           return (value) =>
@@ -48,7 +47,7 @@ export function useCustomTableRenderers(queryData: GetQueryResponseDoneT) {
         });
 
         return (value) => {
-          if (value && !isNaN(value as unknown as number)) {
+          if (value && !Number.isNaN(Number(value))) {
             return numnberFormatter.format(value as unknown as number);
           }
           return "";
@@ -70,7 +69,7 @@ export function useCustomTableRenderers(queryData: GetQueryResponseDoneT) {
         };
       } else if (cellType === "MONEY") {
         return (value) => {
-          if (value && !isNaN(value as unknown as number)) {
+          if (value && !Number.isNaN(Number(value))) {
             return currencyFormatter.format((value as unknown as number) / 100); // MONEY is sent as cent
           }
           return "";

--- a/frontend/src/js/previous-queries/list/Folders.tsx
+++ b/frontend/src/js/previous-queries/list/Folders.tsx
@@ -245,7 +245,7 @@ const Folders: FC<Props> = ({ className }) => {
         folder={t("folders.allQueries")}
         active={folderFilter.length === 0 && !noFoldersActive}
         onClick={onResetFolderFilter}
-        resultCount={searchResult ? searchResult["__all__"] : null}
+        resultCount={searchResult ? searchResult.__all__ : null}
         resultWords={[]}
       />
       <SxPreviousQueriesFolder
@@ -254,7 +254,7 @@ const Folders: FC<Props> = ({ className }) => {
         folder={t("folders.noFolders")}
         active={noFoldersActive}
         onClick={onToggleNoFoldersActive}
-        resultCount={searchResult ? searchResult["__without_folder__"] : null}
+        resultCount={searchResult ? searchResult.__without_folder__ : null}
         resultWords={[]}
       />
       <ScrollContainer>

--- a/frontend/src/js/previous-queries/list/ShareProjectItemModal.tsx
+++ b/frontend/src/js/previous-queries/list/ShareProjectItemModal.tsx
@@ -34,7 +34,7 @@ const getInitialUserGroupsValue = (
   userGroups: UserGroupT[],
   projectItem?: ProjectItemT,
 ) => {
-  return projectItem && projectItem.groups
+  return projectItem?.groups
     ? userGroups
         .filter((group) => projectItem.groups?.includes(group.id))
         .map((group) => ({

--- a/frontend/src/js/previous-queries/list/reducer.ts
+++ b/frontend/src/js/previous-queries/list/reducer.ts
@@ -169,7 +169,7 @@ const removeLocalFolder = (
   { folderName }: { folderName: string },
 ) => {
   const { localFolders } = state;
-  const idx = localFolders.findIndex((f) => f === folderName);
+  const idx = localFolders.indexOf(folderName);
 
   return idx === -1
     ? state

--- a/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
+++ b/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
@@ -161,9 +161,9 @@ const CSVColumnPicker: FC<PropsT> = ({
   ];
 
   const DELIMITER_OPTIONS = [
-    { label: t("csvColumnPicker.semicolon") + " ( ; )", value: ";" },
-    { label: t("csvColumnPicker.comma") + " ( , )", value: "," },
-    { label: t("csvColumnPicker.colon") + " ( : )", value: ":" },
+    { label: `${t("csvColumnPicker.semicolon")} ( ; )`, value: ";" },
+    { label: `${t("csvColumnPicker.comma")} ( , )`, value: "," },
+    { label: `${t("csvColumnPicker.colon")} ( : )`, value: ":" },
   ];
 
   useEffect(() => {
@@ -212,7 +212,7 @@ const CSVColumnPicker: FC<PropsT> = ({
     }
 
     parse();
-  }, [file, delimiter, config.ids]);
+  }, [file, delimiter]);
 
   function uploadQuery() {
     onUpload({

--- a/frontend/src/js/query-group-modal/QueryGroupModal.tsx
+++ b/frontend/src/js/query-group-modal/QueryGroupModal.tsx
@@ -111,13 +111,13 @@ const QueryGroupModal = ({
           {t("queryGroupModal.headlineStart")}
         </HeadlinePart>
         {group.elements.map((node, i) => (
-          <Fragment key={i + "-headline"}>
+          <Fragment key={`${i}-headline`}>
             <HeadlinePart>
               {node.label ||
                 (nodeIsConceptQueryNode(node) ? node.ids[0] : node.id)}
             </HeadlinePart>
             {i !== group.elements.length - 1 && (
-              <span key={i + "-comma"}>, </span>
+              <span key={`${i}-comma`}>, </span>
             )}
           </Fragment>
         ))}

--- a/frontend/src/js/query-node-editor/ContentColumn.tsx
+++ b/frontend/src/js/query-node-editor/ContentColumn.tsx
@@ -93,11 +93,7 @@ const ContentColumn: FC<PropsT> = ({
   const itemsRef = useRef<(HTMLDivElement | null)[]>(new Array(tables.length));
 
   useEffect(() => {
-    if (
-      selectedTableIdx !== null &&
-      itemsRef.current &&
-      itemsRef.current[selectedTableIdx]
-    ) {
+    if (selectedTableIdx && itemsRef.current?.[selectedTableIdx]) {
       itemsRef.current[selectedTableIdx]?.scrollIntoView({
         block: "start",
         inline: "start",

--- a/frontend/src/js/query-node-editor/MenuColumn.tsx
+++ b/frontend/src/js/query-node-editor/MenuColumn.tsx
@@ -87,9 +87,7 @@ const MenuColumn: FC<PropsT> = ({
   const isEmpty =
     !nodeIsConceptQueryNode(node) ||
     (!showTables &&
-      (!rootConcept ||
-        !rootConcept.children ||
-        rootConcept.children.length === 0));
+      (!rootConcept?.children || rootConcept.children.length === 0));
 
   return (
     <FixedColumn className={className} isEmpty={isEmpty}>
@@ -126,8 +124,7 @@ const MenuColumn: FC<PropsT> = ({
         </>
       )}
       {nodeIsConceptQueryNode(node) &&
-        rootConcept &&
-        rootConcept.children &&
+        rootConcept?.children &&
         rootConcept.children.length > 0 && (
           <AdditionalConceptNodeChildren
             node={node}

--- a/frontend/src/js/query-node-editor/TableFilter.tsx
+++ b/frontend/src/js/query-node-editor/TableFilter.tsx
@@ -183,7 +183,7 @@ const TableFilter = ({
   })();
 
   return filterComponent ? (
-    <Container className={className} data-test-id={"table-filter-" + filter.id}>
+    <Container className={className} data-test-id={`table-filter-${filter.id}`}>
       {filterComponent}
     </Container>
   ) : null;

--- a/frontend/src/js/query-node-editor/UploadFilterListModal.tsx
+++ b/frontend/src/js/query-node-editor/UploadFilterListModal.tsx
@@ -53,9 +53,7 @@ const selectResolvedItemsCount = (
 const selectUnresolvedItemsCount = (
   resolved: PostFilterResolveResponseT | null,
 ) => {
-  return resolved && resolved.unknownCodes && resolved.unknownCodes.length
-    ? resolved.unknownCodes.length
-    : 0;
+  return resolved?.unknownCodes?.length ? resolved.unknownCodes.length : 0;
 };
 
 const UploadFilterListModal = ({

--- a/frontend/src/js/query-node-editor/useAutoLabel.ts
+++ b/frontend/src/js/query-node-editor/useAutoLabel.ts
@@ -9,13 +9,13 @@ interface AutoLabelProps {
   onUpdateLabel: (label: string) => void;
 }
 
+const MAX_AUTOLABEL_LENGTH = 250;
+const DELIMITER = " ";
+
+const formatConceptLabels = (labels: string[]) =>
+  labels.sort().join(DELIMITER).substring(0, MAX_AUTOLABEL_LENGTH);
+
 export function useAutoLabel({ node, onUpdateLabel }: AutoLabelProps) {
-  const MAX_AUTOLABEL_LENGTH = 250;
-  const DELIMITER = " ";
-
-  const formatConceptLabels = (labels: string[]) =>
-    labels.sort().join(DELIMITER).substring(0, MAX_AUTOLABEL_LENGTH);
-
   const autoLabel = useMemo(() => {
     return nodeIsConceptQueryNode(node)
       ? formatConceptLabels(

--- a/frontend/src/js/query-runner/QueryRunnerInfo.tsx
+++ b/frontend/src/js/query-runner/QueryRunnerInfo.tsx
@@ -28,7 +28,7 @@ const useMessage = (queryRunner: QueryRunnerStateT) => {
     return { type: "error", value: t("queryRunner.startError") };
   } else if (queryRunner.stopQuery.error) {
     return { type: "error", value: t("queryRunner.stopError") };
-  } else if (queryRunner.queryResult && queryRunner.queryResult.error) {
+  } else if (queryRunner.queryResult?.error) {
     return {
       type: "error",
       value: queryRunner.queryResult.error,

--- a/frontend/src/js/query-runner/actions.ts
+++ b/frontend/src/js/query-runner/actions.ts
@@ -255,7 +255,6 @@ const useQueryResult = (queryType: QueryTypeT) => {
               QUERY_AGAIN_TIMEOUT,
             );
             break;
-          case "NEW":
           default:
             break;
         }

--- a/frontend/src/js/standard-query-editor/QueryEditor.tsx
+++ b/frontend/src/js/standard-query-editor/QueryEditor.tsx
@@ -22,6 +22,7 @@ export const QueryEditor = () => {
   const datasetId = useDatasetId();
   const onClose = useCallback(() => setEditedNode(null), []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: close the editor whenever the dataset changes
   useEffect(() => {
     onClose();
   }, [datasetId, onClose]);

--- a/frontend/src/js/standard-query-editor/expandNode.ts
+++ b/frontend/src/js/standard-query-editor/expandNode.ts
@@ -51,7 +51,7 @@ const isMultiSelectFilterConfig = (
   type: "MULTI_SELECT" | "BIG_MULTI_SELECT";
 } =>
   (filter.type === "MULTI_SELECT" || filter.type === "BIG_MULTI_SELECT") &&
-  filter.value instanceof Array;
+  Array.isArray(filter.value);
 
 const mergeRangeFilter = (
   savedFilter: RangeFilterWithValueType,
@@ -141,7 +141,7 @@ const mergeFiltersFromSavedConcept = (
   savedTable: TableWithFilterValueT,
   table?: TableConfigT,
 ): FilterWithValueType[] => {
-  if (!table || !table.filters) return savedTable.filters;
+  if (!table?.filters) return savedTable.filters;
 
   return savedTable.filters.map((savedFilter): FilterWithValueType => {
     // TODO: Improve the api and don't use `.filter`, but `.id` or `.filterId`
@@ -199,7 +199,7 @@ const mergeSelects = (
   savedSelects: SelectorT[],
   conceptOrTable?: QueryConceptNodeT | TableConfigT,
 ) => {
-  if (!conceptOrTable || !conceptOrTable.selects) {
+  if (!conceptOrTable?.selects) {
     return savedSelects;
   }
 
@@ -216,7 +216,7 @@ const mergeDateColumn = (
   savedTable: TableWithFilterValueT,
   table?: TableConfigT,
 ) => {
-  if (!table || !table.dateColumn || !savedTable.dateColumn)
+  if (!table?.dateColumn || !savedTable.dateColumn)
     return savedTable.dateColumn;
 
   return {

--- a/frontend/src/js/standard-query-editor/types.ts
+++ b/frontend/src/js/standard-query-editor/types.ts
@@ -95,7 +95,7 @@ export interface PreviousQueryQueryNodeType {
   canExpand?: boolean;
   secondaryId?: string | null;
   availableSecondaryIds?: string[];
-  files?: void;
+  files?: undefined;
 
   own?: boolean;
   shared?: boolean;

--- a/frontend/src/js/tooltip/Tooltip.tsx
+++ b/frontend/src/js/tooltip/Tooltip.tsx
@@ -251,17 +251,16 @@ const Tooltip = () => {
           )}
         </Head>
         <Infos>
-          {infos &&
-            infos.map((info, i) => (
-              <PieceOfInfo key={info.key + i}>
-                <InfoHeadline>
-                  <HighlightedText words={words} text={info.key} />
-                </InfoHeadline>
-                <Markdown remarkPlugins={[remarkGfm, remarkFlexibleMarkers]}>
-                  {mark(info.value, highlightRegex)}
-                </Markdown>
-              </PieceOfInfo>
-            ))}
+          {infos?.map((info, i) => (
+            <PieceOfInfo key={info.key + i}>
+              <InfoHeadline>
+                <HighlightedText words={words} text={info.key} />
+              </InfoHeadline>
+              <Markdown remarkPlugins={[remarkGfm, remarkFlexibleMarkers]}>
+                {mark(info.value, highlightRegex)}
+              </Markdown>
+            </PieceOfInfo>
+          ))}
         </Infos>
       </Content>
     </Root>

--- a/frontend/src/js/tooltip/TooltipEntries.tsx
+++ b/frontend/src/js/tooltip/TooltipEntries.tsx
@@ -88,14 +88,16 @@ const TooltipEntries = (props: Props) => {
   const dateFormat = "yyyy-MM-dd";
   const displayDateFormat = t("inputDateRange.dateFormat");
 
-  const parsedFromDate =
-    dateRange && dateRange.min ? parseDate(dateRange.min, dateFormat) : null;
+  const parsedFromDate = dateRange?.min
+    ? parseDate(dateRange.min, dateFormat)
+    : null;
   const fromDate = parsedFromDate
     ? formatDate(parsedFromDate, displayDateFormat)
     : "- - - - - - -";
 
-  const parsedToDate =
-    dateRange && dateRange.max ? parseDate(dateRange.max, dateFormat) : null;
+  const parsedToDate = dateRange?.max
+    ? parseDate(dateRange.max, dateFormat)
+    : null;
   const toDate = parsedToDate
     ? formatDate(parsedToDate, displayDateFormat)
     : "- - - - - - -";

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -152,7 +152,7 @@ const BaseInput = forwardRef<HTMLInputElement, Props>(
     function safeOnChange(val: string | number | null) {
       if (
         (typeof val === "string" && val.length === 0) ||
-        (typeof val === "number" && isNaN(val))
+        (typeof val === "number" && Number.isNaN(val))
       ) {
         onChange(null);
       } else {

--- a/frontend/src/js/ui-components/CurrencyInput.tsx
+++ b/frontend/src/js/ui-components/CurrencyInput.tsx
@@ -51,13 +51,13 @@ const CurrencyInput: FC<PropsT> = ({
   return (
     <SxNumberFormat
       {...currencyConfig}
-      suffix={" " + currencyConfig?.unit}
+      suffix={` ${currencyConfig?.unit}`}
       placeholder={placeholder}
       type="text"
       value={numberFormatValue}
       large={large}
       onValueChange={(values) => {
-        if (exists(values.floatValue) && !isNaN(values.floatValue)) {
+        if (exists(values.floatValue) && !Number.isNaN(values.floatValue)) {
           setNumberFormatValue(values.floatValue);
           onChange(parseInt((values.floatValue * factor).toFixed(0), 10));
         } else {

--- a/frontend/src/js/ui-components/Dropzone.tsx
+++ b/frontend/src/js/ui-components/Dropzone.tsx
@@ -158,12 +158,11 @@ const Dropzone = <DroppableObject extends PossibleDroppableObject>(
       transparent={transparent}
       bare={bare}
     >
-      {children &&
-        children({
-          isOver,
-          canDrop: canDropResult,
-          item: item as DroppableObject, // Casting because see comment above
-        })}
+      {children?.({
+        isOver,
+        canDrop: canDropResult,
+        item: item as DroppableObject, // Casting because see comment above
+      })}
     </Root>
   );
 };

--- a/frontend/src/js/ui-components/InputRange.tsx
+++ b/frontend/src/js/ui-components/InputRange.tsx
@@ -90,8 +90,8 @@ const InputRange = ({
 
   const inputProps = {
     step: stepSize || null,
-    min: (limits && limits.min) || null,
-    max: (limits && limits.max) || null,
+    min: limits?.min || null,
+    max: limits?.max || null,
     pattern: pattern,
   };
 

--- a/frontend/src/js/user/selectors.ts
+++ b/frontend/src/js/user/selectors.ts
@@ -10,7 +10,7 @@ interface ContextT {
 export function selectPermissions(
   state: StateT,
 ): Record<DatasetT["id"], PermissionsT> | null {
-  return state.user.me && state.user.me.datasetAbilities
+  return state.user.me?.datasetAbilities
     ? state.user.me.datasetAbilities
     : null;
 }
@@ -35,8 +35,9 @@ function canDo(
   if (!permissions) return false;
 
   const { selectedDatasetId } = state.datasets;
-  const datasetId: string | null =
-    context && context.datasetId ? context.datasetId : selectedDatasetId;
+  const datasetId: string | null = context?.datasetId
+    ? context.datasetId
+    : selectedDatasetId;
 
   if (!datasetId) {
     return false;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,8 @@
 /// <reference types="vitest/config" />
+
+import fs from "node:fs";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import fs from "fs";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
Follow-up promised in #3957. Biome goes from 71 warnings / 51 infos to zero without loosening rules; `useJsxKeyInIterable` is now an error, `noArrayIndexKey` stays off with the reason written down.

- mechanical, applied with biome's own fixes: `useOptionalChain` (35), `useTemplate` (20), `useParseIntRadix` (15), `useIsArray` (6), `useNodejsImportProtocol` (5), `useLiteralKeys`, `noUselessFragments`, `noFlatMapIdentity`, `useIndexOf`, `noUselessTernary`, `noUselessSwitchCase`
- `noGlobalIsNan` (9): `Number.isNaN` where the argument is already a number; in the preview table formatters the value is a string, so `Number.isNaN(Number(value))` keeps the previous coercion
- `useJsxKeyInIterable` (7): keys added (concept ids, filter labels, values, indices for static rows)
- `useExhaustiveDependencies` (9): refs / unused values removed from dependency lists; the three intentional "re-run on dataset/config change" effects keep their deps with a commented suppression; `useAutoLabel` constants hoisted out of the hook
- one accumulator spread in the concept search -> `Object.assign`; `files?: void` -> `undefined`; storybook decorator typed as `Decorator`
- one fragment biome flags is required by `WithTooltip` (single child) - suppressed with the reason

typecheck / vitest / vite build / storybook build green. Downstream mirror: biome config only (it extends this one).