### PR TITLE
chore(frontend): tighten biome rules

### DIFF
--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -39,7 +39,16 @@
     },
     "rules": {
       "preset": "recommended",
+      "complexity": {
+        // Visible for now, the worst offenders get refactored separately
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": { "maxAllowedComplexity": 18 }
+        },
+        "noForEach": "error"
+      },
       "correctness": {
+        "noUnusedImports": { "level": "error", "fix": "safe" },
         "noUnusedVariables": {
           "level": "error",
           "options": { "ignoreRestSiblings": true }
@@ -49,10 +58,6 @@
         "useExhaustiveDependencies": "warn",
         "useHookAtTopLevel": "error",
         "useJsxKeyInIterable": "error"
-      },
-      "security": {
-        // Markdown/HTML rendering from trusted backend content is intentional
-        "noDangerouslySetInnerHtml": "off"
       },
       "style": {
         // Was allowed by the previous eslint config

--- a/frontend/src/js/common/useIntersectionObserver.ts
+++ b/frontend/src/js/common/useIntersectionObserver.ts
@@ -22,7 +22,7 @@ export function useIntersectionObserver<T extends Element>(
   const observer = useRef<IntersectionObserver | null>(
     new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
+        for (const entry of entries) {
           const isIntersecting =
             entry.isIntersecting &&
             entry.intersectionRatio > INTERSECTION_THRESHOLD;
@@ -31,7 +31,7 @@ export function useIntersectionObserver<T extends Element>(
             intersecting.current = isIntersecting;
             onChangeRef.current(domNodeRef.current, isIntersecting);
           }
-        });
+        }
       },
       { threshold: [INTERSECTION_THRESHOLD] },
     ),

--- a/frontend/src/js/entity-history/timeline/TimelineEmptyPlaceholder.tsx
+++ b/frontend/src/js/entity-history/timeline/TimelineEmptyPlaceholder.tsx
@@ -84,6 +84,7 @@ export const TimelineEmptyPlaceholder = ({
         <div>
           <Headline>{t("history.emptyTimeline.headline")}</Headline>
           <Description>{t("history.emptyTimeline.description")}</Description>
+          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: message is our own i18n text */}
           <Message dangerouslySetInnerHTML={{ __html: message }} />
         </div>
       </Row>

--- a/frontend/src/js/external-forms/form/Field.tsx
+++ b/frontend/src/js/external-forms/form/Field.tsx
@@ -59,6 +59,7 @@ const Field = ({
     case "DESCRIPTION":
       return (
         <Description
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: labels come from the form configs the backend serves
           dangerouslySetInnerHTML={{ __html: field.label[locale] || "" }}
         />
       );

--- a/frontend/src/js/query-node-editor/UploadFilterListModal.tsx
+++ b/frontend/src/js/query-node-editor/UploadFilterListModal.tsx
@@ -104,6 +104,7 @@ const UploadFilterListModal = ({
             <Msg>
               <ErrorIcon icon={faExclamationCircle} />
               <span
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: i18n text with markup
                 dangerouslySetInnerHTML={{
                   __html: t("uploadConceptListModal.unknownCodes", {
                     count: unresolvedItemsCount,

--- a/frontend/src/js/snack-message/SnackMessage.tsx
+++ b/frontend/src/js/snack-message/SnackMessage.tsx
@@ -46,6 +46,7 @@ export const SnackMessage = memo(function SnackMessageComponent() {
       {message && (
         <Root $success={type === "success"}>
           <div className="relative py-3 pr-10 pl-5">
+            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: messages are our own i18n text */}
             <div dangerouslySetInnerHTML={{ __html: message }} />
             <ClearZone onClick={resetMessage}>
               <FaIcon white large icon={faTimes} />

--- a/frontend/src/js/tooltip/WithTooltip.tsx
+++ b/frontend/src/js/tooltip/WithTooltip.tsx
@@ -102,6 +102,7 @@ const WithTooltip = forwardRef<HTMLElement, Props>(
         <Text
           theme={theme}
           wide={wide}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: tooltip text is concept metadata from the backend
           dangerouslySetInnerHTML={{ __html: text }}
         />
       ) : (

--- a/frontend/src/js/ui-components/ImportModal.tsx
+++ b/frontend/src/js/ui-components/ImportModal.tsx
@@ -163,6 +163,7 @@ export const ImportModal = ({
     >
       <Content>
         {description && (
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: description is our own i18n text
           <Subtitle dangerouslySetInnerHTML={{ __html: description }} />
         )}
         <DropzoneWithFileInput

--- a/frontend/src/js/ui-components/InputDateRange.tsx
+++ b/frontend/src/js/ui-components/InputDateRange.tsx
@@ -183,6 +183,7 @@ const InputDateRange: FC<PropsT> = ({
               {exists(tooltip) && <TooltipMain>{tooltip}</TooltipMain>}
               <TooltipTutorial
                 hasMain={exists(tooltip)}
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: i18n text with markup
                 dangerouslySetInnerHTML={{
                   __html: t("inputDateRange.tooltip.possiblePattern"),
                 }}


### PR DESCRIPTION
Follow-up to #3967.

- `noDangerouslySetInnerHtml`: back to `error`; the seven uses get a per-site suppression that names the trusted source (our own i18n text, backend form configs / concept metadata) - a global off would hide future misuse
- `noUnusedImports`: `error` with a safe fix, so `pnpm fix` removes them
- `noForEach`: `error`, the single site rewritten to `for...of`
- `noExcessiveCognitiveComplexity` (max 18): `warn` for now - 11 functions exceed it (worst: `FormConceptGroup` 39, `query-runner/reducer` 37, `FaIcon` 28); refactoring those is its own PR
- `noNonNullAssertion` stays off on purpose

Downstream needs nothing (biome config is extended).