### PR TITLE
refactor(frontend): bring every function under cognitive complexity 18

### DIFF
--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -40,9 +40,8 @@
     "rules": {
       "preset": "recommended",
       "complexity": {
-        // Visible for now, the worst offenders get refactored separately
         "noExcessiveCognitiveComplexity": {
-          "level": "warn",
+          "level": "error",
           "options": { "maxAllowedComplexity": 18 }
         },
         "noForEach": "error"

--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -79,6 +79,15 @@
   },
   "overrides": [
     {
+      // mock data generators are branchy on purpose
+      "includes": ["mock-api/**"],
+      "linter": {
+        "rules": {
+          "complexity": { "noExcessiveCognitiveComplexity": "off" }
+        }
+      }
+    },
+    {
       // tailwind v3 entry directives
       "includes": ["src/index.css"],
       "linter": { "rules": { "suspicious": { "noUnknownAtRules": "off" } } }

--- a/frontend/src/js/editor-v2/expand/useExpandQuery.ts
+++ b/frontend/src/js/editor-v2/expand/useExpandQuery.ts
@@ -25,6 +25,86 @@ import type {
 import type { Tree } from "../types";
 import { findNodeById } from "../util";
 
+interface ExpandConfig {
+  parentId?: string;
+  negation?: boolean;
+  dateRestriction?: DateRangeT;
+}
+
+type ExpandableNode =
+  | AndNodeT
+  | DateRestrictionNodeT
+  | OrNodeT
+  | NegationNodeT
+  | QueryConceptNodeT
+  | SavedQueryNodeT;
+
+// AND / OR with a single child collapse into that child
+const expandGroup = (
+  children: ExpandableNode[],
+  config: ExpandConfig,
+  connection: "and" | "or",
+  expand: (node: ExpandableNode, config: ExpandConfig) => Tree,
+): Tree => {
+  if (children.length === 1) {
+    return expand(children[0], config);
+  }
+  const id = createId();
+  return {
+    id,
+    ...config,
+    children: {
+      connection,
+      direction: connection === "and" ? "horizontal" : "vertical",
+      items: children.map((child) => expand(child, { parentId: id })),
+    },
+  };
+};
+
+const conceptNodeToTree = (
+  queryNode: QueryConceptNodeT,
+  config: ExpandConfig,
+  rootConcepts: TreesT,
+): Tree => {
+  const lookupResult = getConceptsByIdsWithTablesAndSelects(
+    rootConcepts,
+    queryNode.ids,
+    { useDefaults: false },
+  );
+  if (!lookupResult) {
+    throw new Error("Concept not found");
+  }
+  const { tables, selects } = mergeFromSavedConceptIntoNode(queryNode, {
+    tables: lookupResult.tables,
+    selects: lookupResult.selects || [],
+  });
+  const label = queryNode.label || lookupResult.concepts[0].label;
+  const description = lookupResult.concepts[0].description;
+
+  const dataNode: DragItemConceptTreeNode = {
+    ...queryNode,
+    dragContext: { width: 0, height: 0 },
+    additionalInfos: lookupResult.concepts[0].additionalInfos,
+    matchingEntities: lookupResult.concepts[0].matchingEntities,
+    matchingEntries: lookupResult.concepts[0].matchingEntries,
+    type: DNDType.CONCEPT_TREE_NODE,
+    label,
+    description,
+    tables,
+    selects,
+    tree: lookupResult.root,
+  };
+
+  const dates = config.dateRestriction
+    ? {
+        ...config.dateRestriction,
+        ...(queryNode.excludeFromTimeAggregation ? { excluded: true } : {}),
+      }
+    : undefined;
+
+  return { id: createId(), data: dataNode, dates, ...config };
+};
+
 export const useExpandQuery = ({
   selectedNode,
   hotkey,
@@ -44,53 +124,12 @@ export const useExpandQuery = ({
     (state) => state.conceptTrees.trees,
   );
   const expandNode = useCallback(
-    (
-      queryNode:
-        | AndNodeT
-        | DateRestrictionNodeT
-        | OrNodeT
-        | NegationNodeT
-        | QueryConceptNodeT
-        | SavedQueryNodeT,
-      config: {
-        parentId?: string;
-        negation?: boolean;
-        dateRestriction?: DateRangeT;
-      } = {},
-    ): Tree => {
+    (queryNode: ExpandableNode, config: ExpandConfig = {}): Tree => {
       switch (queryNode.type) {
         case "AND":
-          if (queryNode.children.length === 1) {
-            return expandNode(queryNode.children[0], config);
-          }
-          const andid = createId();
-          return {
-            id: andid,
-            ...config,
-            children: {
-              connection: "and",
-              direction: "horizontal",
-              items: queryNode.children.map((child) =>
-                expandNode(child, { parentId: andid }),
-              ),
-            },
-          };
+          return expandGroup(queryNode.children, config, "and", expandNode);
         case "OR":
-          if (queryNode.children.length === 1) {
-            return expandNode(queryNode.children[0], config);
-          }
-          const orid = createId();
-          return {
-            id: orid,
-            ...config,
-            children: {
-              connection: "or",
-              direction: "vertical",
-              items: queryNode.children.map((child) =>
-                expandNode(child, { parentId: orid }),
-              ),
-            },
-          };
+          return expandGroup(queryNode.children, config, "or", expandNode);
         case "NEGATION":
           return expandNode(queryNode.child, { ...config, negation: true });
         case "DATE_RESTRICTION":
@@ -99,48 +138,7 @@ export const useExpandQuery = ({
             dateRestriction: queryNode.dateRange,
           });
         case "CONCEPT":
-          const lookupResult = getConceptsByIdsWithTablesAndSelects(
-            rootConcepts,
-            queryNode.ids,
-            { useDefaults: false },
-          );
-          if (!lookupResult) {
-            throw new Error("Concept not found");
-          }
-          const { tables, selects } = mergeFromSavedConceptIntoNode(queryNode, {
-            tables: lookupResult.tables,
-            selects: lookupResult.selects || [],
-          });
-          const label = queryNode.label || lookupResult.concepts[0].label;
-          const description = lookupResult.concepts[0].description;
-
-          const dataNode: DragItemConceptTreeNode = {
-            ...queryNode,
-            dragContext: { width: 0, height: 0 },
-            additionalInfos: lookupResult.concepts[0].additionalInfos,
-            matchingEntities: lookupResult.concepts[0].matchingEntities,
-            matchingEntries: lookupResult.concepts[0].matchingEntries,
-            type: DNDType.CONCEPT_TREE_NODE,
-            label,
-            description,
-            tables,
-            selects,
-            tree: lookupResult.root,
-          };
-
-          return {
-            id: createId(),
-            data: dataNode,
-            dates: config.dateRestriction
-              ? {
-                  ...config.dateRestriction,
-                  ...(queryNode.excludeFromTimeAggregation
-                    ? { excluded: true }
-                    : {}),
-                }
-              : undefined,
-            ...config,
-          };
+          return conceptNodeToTree(queryNode, config, rootConcepts);
         case "SAVED_QUERY":
           const dataQuery: DragItemQuery = {
             ...queryNode,

--- a/frontend/src/js/entity-history/timeline/YearHead.tsx
+++ b/frontend/src/js/entity-history/timeline/YearHead.tsx
@@ -72,6 +72,63 @@ const Label = styled("div")`
   text-overflow: ellipsis;
 `;
 
+type YearValue = TimeStratifiedInfo["years"][number]["values"][string];
+type Column = TimeStratifiedInfo["columns"][number];
+
+const byNumericThenAlphabeticLabel = (
+  c1: { label: string },
+  c2: { label: string },
+) => {
+  const n1 = Number(c1.label);
+  const n2 = Number(c2.label);
+  if (!Number.isNaN(n1) && !Number.isNaN(n2)) {
+    return n1 - n2;
+  }
+  return c1.label.localeCompare(c2.label);
+};
+
+const formatValue = (column: Column, value: YearValue) => {
+  if (typeof value === "number") {
+    return isMoneyColumn(column) ? formatCurrency(value) : Math.round(value);
+  }
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  return value;
+};
+
+const ConceptValues = ({
+  label,
+  column,
+  values,
+}: {
+  label: string;
+  column: Column;
+  values: string[];
+}) => {
+  const semantic = column.semantics.find(
+    (s): s is ColumnDescriptionSemanticConceptColumn =>
+      s.type === "CONCEPT_COLUMN",
+  );
+  const concepts = values
+    .map((v) => getConceptById(v, semantic!.concept))
+    .filter(exists)
+    .sort(byNumericThenAlphabeticLabel);
+
+  return (
+    <>
+      <Label style={{ gridColumn: "span 2" }}>{label}</Label>
+      <ConceptRow>
+        {concepts.map((concept) => (
+          <WithTooltip key={concept.label} text={concept.description}>
+            <ConceptBubble>{concept.label}</ConceptBubble>
+          </WithTooltip>
+        ))}
+      </ConceptRow>
+    </>
+  );
+};
+
 const TimeStratifiedInfos = ({
   year,
   timeStratifiedInfos,
@@ -113,59 +170,19 @@ const TimeStratifiedInfos = ({
                   return null;
                 }
 
-                if (isConceptColumn(column)) {
-                  const semantic = column.semantics.find(
-                    (s): s is ColumnDescriptionSemanticConceptColumn =>
-                      s.type === "CONCEPT_COLUMN",
+                // TODO: Potentially support single-value concepts
+                if (isConceptColumn(column) && Array.isArray(value)) {
+                  return (
+                    <ConceptValues
+                      key={label}
+                      label={label}
+                      column={column}
+                      values={value}
+                    />
                   );
-
-                  if (Array.isArray(value)) {
-                    const concepts = value
-                      .map((v) => getConceptById(v, semantic!.concept))
-                      .filter(exists)
-                      .sort((c1, c2) => {
-                        const n1 = Number(c1.label);
-                        const n2 = Number(c2.label);
-                        if (!Number.isNaN(n1) && !Number.isNaN(n2)) {
-                          return n1 - n2;
-                        }
-                        return c1.label.localeCompare(c2.label);
-                      });
-
-                    return (
-                      <Fragment key={label}>
-                        <Label
-                          style={{
-                            gridColumn: "span 2",
-                          }}
-                        >
-                          {label}
-                        </Label>
-                        <ConceptRow>
-                          {concepts.map((concept) => (
-                            <WithTooltip
-                              key={concept.label}
-                              text={concept.description}
-                            >
-                              <ConceptBubble>{concept.label}</ConceptBubble>
-                            </WithTooltip>
-                          ))}
-                        </ConceptRow>
-                      </Fragment>
-                    );
-                  }
-
-                  // TOOD: Potentially support single-value concepts
                 }
 
-                let valueFormatted: string | number | string[] = value;
-                if (typeof value === "number") {
-                  valueFormatted = isMoneyColumn(column)
-                    ? formatCurrency(value)
-                    : Math.round(value);
-                } else if (Array.isArray(value)) {
-                  valueFormatted = value.join(", ");
-                }
+                const valueFormatted = formatValue(column, value);
 
                 return (
                   <Fragment key={label}>

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
@@ -117,6 +117,124 @@ export interface EditedFormQueryNodePosition {
 
 const DROP_TYPES = [DNDType.CONCEPT_TREE_NODE];
 
+interface ConceptContext {
+  defaults: ConceptListDefaultsType;
+  tableConfig: Parameters<typeof initializeConcept>[2];
+  selectConfig: Parameters<typeof initializeConcept>[3];
+}
+
+const toConcept = (item: DragItemConceptTreeNode, ctx: ConceptContext) =>
+  isMovedObject(item)
+    ? copyConcept(item)
+    : initializeConcept(item, ctx.defaults, ctx.tableConfig, ctx.selectConfig);
+
+const cloneNewValue = (props: Props) =>
+  JSON.parse(JSON.stringify(props.newValue));
+
+const removeConceptOrRow = (props: Props, i: number, j: number) =>
+  props.value[i].concepts.length === 1
+    ? removeValue(props.value, i)
+    : removeConcept(props.value, i, j);
+
+// A concept dropped between two rows opens a new row there. If it was moved from
+// within the same field, its old slot is removed first, which may shift the index.
+const dropConceptBetweenRows = (
+  props: Props,
+  ctx: ConceptContext,
+  i: number,
+  item: PossibleDroppableObject,
+) => {
+  if (item.type !== DNDType.CONCEPT_TREE_NODE) return null;
+  if (props.isValidConcept && !props.isValidConcept(item)) return null;
+
+  const concept = toConcept(item, ctx);
+
+  let insertIndex = i;
+  let newPropsValue = props.value;
+  const newValue = cloneNewValue(props);
+
+  if (isMovedObject(item)) {
+    const { movedFromFieldName, movedFromAndIdx, movedFromOrIdx } =
+      item.dragContext;
+
+    if (movedFromFieldName === props.fieldName) {
+      const movedConceptWasLast =
+        props.value[movedFromAndIdx].concepts.length === 1;
+      const willConceptMoveDown = i > movedFromAndIdx && movedConceptWasLast;
+
+      if (willConceptMoveDown) {
+        insertIndex = i - 1;
+      }
+      newPropsValue = movedConceptWasLast
+        ? removeValue(props.value, movedFromAndIdx)
+        : removeConcept(props.value, movedFromAndIdx, movedFromOrIdx);
+
+      // rowPrefixField is a special property that is only used in an edge case form,
+      // used for tagging concepts. We only need to pass it back into the value
+      // if the concept is moved to a different position in the same field.
+      if (props.rowPrefixFieldname) {
+        newValue[props.rowPrefixFieldname] =
+          // @ts-ignore rowPrefixFieldname is dynamic, and since it's an edge case, we're not typing this
+          props.value[movedFromAndIdx][props.rowPrefixFieldname];
+      }
+    } else if (exists(item.dragContext.deleteFromOtherField)) {
+      item.dragContext.deleteFromOtherField();
+    }
+  }
+
+  return props.onChange(
+    addConcept(
+      insertValue(newPropsValue, insertIndex, newValue),
+      insertIndex,
+      concept,
+    ),
+  );
+};
+
+// A concept dropped on the group's own dropzone gets a new row at the end
+const dropConceptOnGroup = (
+  props: Props,
+  ctx: ConceptContext,
+  item: DragItemConceptTreeNode,
+) => {
+  if (props.isValidConcept && !props.isValidConcept(item)) return;
+
+  const newValue = cloneNewValue(props);
+
+  // rowPrefixField is a special property that is only used in an edge case form,
+  // for a detailed explanation see dropConceptBetweenRows
+  if (isMovedObject(item)) {
+    const { movedFromFieldName, movedFromAndIdx } = item.dragContext;
+
+    if (movedFromFieldName === props.fieldName && props.rowPrefixFieldname) {
+      newValue[props.rowPrefixFieldname] =
+        // @ts-ignore rowPrefixFieldname is dynamic, and since it's an edge case, we're not typing this
+        props.value[movedFromAndIdx][props.rowPrefixFieldname];
+    }
+  }
+
+  return props.onChange(
+    addConcept(
+      addValue(props.value, newValue),
+      props.value.length, // Assuming the last index has increased after addValue
+      toConcept(item, ctx),
+    ),
+  );
+};
+
+// A concept dropped on an empty slot inside a row fills that slot
+const dropConceptOnSlot = (
+  props: Props,
+  ctx: ConceptContext,
+  i: number,
+  j: number,
+  item: DragItemConceptTreeNode,
+) => {
+  if (props.isValidConcept && !props.isValidConcept(item)) return null;
+
+  return props.onChange(setConcept(props.value, i, j, toConcept(item, ctx)));
+};
+
 const FormConceptGroup = (props: Props) => {
   const { t } = useTranslation();
   const newValue = props.newValue;
@@ -128,6 +246,11 @@ const FormConceptGroup = (props: Props) => {
   const selectConfig = {
     allowlistedSelects: props.allowlistedSelects,
     blocklistedSelects: props.blocklistedSelects,
+  };
+  const conceptContext: ConceptContext = {
+    defaults,
+    tableConfig,
+    selectConfig,
   };
 
   // indicator if it should be scrolled down back to the dropZone
@@ -210,62 +333,9 @@ const FormConceptGroup = (props: Props) => {
             ? t("externalForms.common.concept.copying")
             : props.attributeDropzoneText
         }
-        dropBetween={(i: number) => {
-          return (item: PossibleDroppableObject) => {
-            if (item.type !== DNDType.CONCEPT_TREE_NODE) return null;
-
-            if (props.isValidConcept && !props.isValidConcept(item))
-              return null;
-
-            const concept = isMovedObject(item)
-              ? copyConcept(item)
-              : initializeConcept(item, defaults, tableConfig, selectConfig);
-
-            let insertIndex = i;
-            let newPropsValue = props.value;
-            const newValue = JSON.parse(JSON.stringify(props.newValue));
-
-            if (isMovedObject(item)) {
-              const { movedFromFieldName, movedFromAndIdx, movedFromOrIdx } =
-                item.dragContext;
-
-              if (movedFromFieldName === props.fieldName) {
-                const movedConceptWasLast =
-                  props.value[movedFromAndIdx].concepts.length === 1;
-                const willConceptMoveDown =
-                  i > movedFromAndIdx && movedConceptWasLast;
-
-                if (willConceptMoveDown) {
-                  insertIndex = i - 1;
-                }
-                newPropsValue = movedConceptWasLast
-                  ? removeValue(props.value, movedFromAndIdx)
-                  : removeConcept(props.value, movedFromAndIdx, movedFromOrIdx);
-
-                // rowPrefixField is a special property that is only used in an edge case form,
-                // used for tagging concepts. We only need to pass it back into the value
-                // if the concept is moved to a different position in the same field.
-                if (props.rowPrefixFieldname) {
-                  newValue[props.rowPrefixFieldname] =
-                    // @ts-ignore rowPrefixFieldname is dynamic, and since it's an edge case, we're not typing this
-                    props.value[movedFromAndIdx][props.rowPrefixFieldname];
-                }
-              } else {
-                if (exists(item.dragContext.deleteFromOtherField)) {
-                  item.dragContext.deleteFromOtherField();
-                }
-              }
-            }
-
-            return props.onChange(
-              addConcept(
-                insertValue(newPropsValue, insertIndex, newValue),
-                insertIndex,
-                concept,
-              ),
-            );
-          };
-        }}
+        dropBetween={(i: number) => (item: PossibleDroppableObject) =>
+          dropConceptBetweenRows(props, conceptContext, i, item)
+        }
         acceptedDropTypes={[DNDType.CONCEPT_TREE_NODE]}
         disallowMultipleColumns={props.disallowMultipleColumns}
         onDelete={(i) => props.onChange(removeValue(props.value, i))}
@@ -283,35 +353,7 @@ const FormConceptGroup = (props: Props) => {
             return;
           }
 
-          if (props.isValidConcept && !props.isValidConcept(item)) return;
-
-          const newValue = JSON.parse(JSON.stringify(props.newValue));
-
-          // rowPrefixField is a special property that is only used in an edge case form,
-          // for a detailed explanation see the comment in the dropBetween function
-          if (isMovedObject(item)) {
-            const { movedFromFieldName, movedFromAndIdx } = item.dragContext;
-
-            if (
-              movedFromFieldName === props.fieldName &&
-              props.rowPrefixFieldname
-            ) {
-              newValue[props.rowPrefixFieldname] =
-                // @ts-ignore rowPrefixFieldname is dynamic, and since it's an edge case, we're not typing this
-                props.value[movedFromAndIdx][props.rowPrefixFieldname];
-            }
-          }
-
-          const concept = isMovedObject(item)
-            ? copyConcept(item)
-            : initializeConcept(item, defaults, tableConfig, selectConfig);
-          return props.onChange(
-            addConcept(
-              addValue(props.value, newValue),
-              props.value.length, // Assuming the last index has increased after addValue
-              concept,
-            ),
-          );
+          return dropConceptOnGroup(props, conceptContext, item);
         }}
         items={props.value.map((row, i) => (
           <div key={i}>
@@ -351,11 +393,7 @@ const FormConceptGroup = (props: Props) => {
                 props.onChange(addConcept(props.value, i, null))
               }
               onRemoveClick={(j) =>
-                props.onChange(
-                  props.value && props.value[i].concepts.length === 1
-                    ? removeValue(props.value, i)
-                    : removeConcept(props.value, i, j),
-                )
+                props.onChange(removeConceptOrRow(props, i, j))
               }
               items={row.concepts.map((concept, j) =>
                 concept ? (
@@ -377,13 +415,9 @@ const FormConceptGroup = (props: Props) => {
                       })
                     }
                     fieldName={props.fieldName}
-                    deleteFromOtherField={() => {
-                      return props.onChange(
-                        props.value[i].concepts.length === 1
-                          ? removeValue(props.value, i)
-                          : removeConcept(props.value, i, j),
-                      );
-                    }}
+                    deleteFromOtherField={() =>
+                      props.onChange(removeConceptOrRow(props, i, j))
+                    }
                     // row_prefix is a special property that is only used in an edge case form.
                     // To support reordering of concepts this property needs
                     // to be passed to the concept node
@@ -425,27 +459,12 @@ const FormConceptGroup = (props: Props) => {
                         return;
                       }
 
-                      if (props.isValidConcept && !props.isValidConcept(item))
-                        return null;
-
-                      if (isMovedObject(item)) {
-                        return props.onChange(
-                          setConcept(props.value, i, j, copyConcept(item)),
-                        );
-                      }
-
-                      return props.onChange(
-                        setConcept(
-                          props.value,
-                          i,
-                          j,
-                          initializeConcept(
-                            item,
-                            defaults,
-                            tableConfig,
-                            selectConfig,
-                          ),
-                        ),
+                      return dropConceptOnSlot(
+                        props,
+                        conceptContext,
+                        i,
+                        j,
+                        item,
                       );
                     }}
                   >

--- a/frontend/src/js/icon/FaIcon.tsx
+++ b/frontend/src/js/icon/FaIcon.tsx
@@ -1,4 +1,5 @@
 import isPropValid from "@emotion/is-prop-valid";
+import type { Theme } from "@emotion/react";
 import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
 import type { IconProp } from "@fortawesome/fontawesome-svg-core";
@@ -39,6 +40,18 @@ const spin = keyframes`
 const shouldForwardProp = (prop: keyof FaIconPropsT) =>
   isPropValid(prop) || prop === "icon" || prop === "className";
 
+// First matching flag wins, in this order
+const iconColor = (theme: Theme, props: IconStyleProps) => {
+  if (props.disabled) return theme.col.grayMediumLight;
+  if (props.red) return theme.col.red;
+  if (props.gray) return theme.col.gray;
+  if (props.active) return theme.col.blueGrayDark;
+  if (props.white) return "#fff";
+  if (props.light) return theme.col.blueGrayLight;
+  if (props.main) return theme.col.blueGray;
+  return theme.col.black;
+};
+
 // @ts-ignore TODO: Figure out how to avoid a type error with styled here
 export const Icon = styled(FontAwesomeIcon, {
   shouldForwardProp,
@@ -48,22 +61,7 @@ export const Icon = styled(FontAwesomeIcon, {
   text-align: ${({ center }) => (center ? "center" : "left")};
   font-size: ${({ theme, large, tiny }) =>
     large ? theme.font.md : tiny ? theme.font.tiny : theme.font.sm};
-  color: ${({ theme, white, gray, red, light, main, active, disabled }) =>
-    disabled
-      ? theme.col.grayMediumLight
-      : red
-        ? theme.col.red
-        : gray
-          ? theme.col.gray
-          : active
-            ? theme.col.blueGrayDark
-            : white
-              ? "#fff"
-              : light
-                ? theme.col.blueGrayLight
-                : main
-                  ? theme.col.blueGray
-                  : theme.col.black};
+  color: ${({ theme, ...props }) => iconColor(theme, props)};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "inherit")};
   width: initial !important;
 

--- a/frontend/src/js/previous-queries/list/ProjectItem.tsx
+++ b/frontend/src/js/previous-queries/list/ProjectItem.tsx
@@ -10,10 +10,11 @@ import {
   faUser,
 } from "@fortawesome/free-solid-svg-icons";
 import { parseISO } from "date-fns";
+import type { TFunction } from "i18next";
 import { forwardRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import type { SecondaryId } from "../../api/types";
+import type { ResultUrlWithLabel, SecondaryId } from "../../api/types";
 import type { StateT } from "../../app/reducers";
 import DownloadButton from "../../button/DownloadButton";
 import IconButton from "../../button/IconButton";
@@ -140,6 +141,125 @@ const FoldersButton = styled(IconButton)`
   margin-right: 10px;
 `;
 
+const getTopLeftLabel = (
+  item: ProjectItemT,
+  formLabel: string | null | undefined,
+  t: TFunction,
+) => {
+  if (isFormConfig(item)) return formLabel!;
+  if (exists(item.numberOfResults)) {
+    return `${item.numberOfResults} ${t("previousQueries.results")}`;
+  }
+  return t("previousQuery.notExecuted");
+};
+
+const HighlightedText = ({
+  text,
+  highlightedWords,
+}: {
+  text: string;
+  highlightedWords: string[];
+}) =>
+  highlightedWords.length > 0 ? (
+    <Highlighter searchWords={highlightedWords} textToHighlight={text} />
+  ) : (
+    text
+  );
+
+const FoldersTooltip = ({ folders }: { folders: string[] }) => {
+  const { t } = useTranslation();
+  return (
+    <TooltipText>
+      {t("previousQuery.editFolders")}
+      {folders.length > 0 && (
+        <ActiveFolders>
+          {folders.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ActiveFolders>
+      )}
+    </TooltipText>
+  );
+};
+
+const ShareButton = ({
+  isShared,
+  onClick,
+}: {
+  isShared: boolean;
+  onClick: () => void;
+}) => {
+  const { t } = useTranslation();
+  return (
+    <WithTooltip
+      html={
+        <TooltipText>
+          {isShared ? t("common.shared") : t("common.share")}
+        </TooltipText>
+      }
+    >
+      <IconButton
+        icon={isShared ? faUser : faUserRegular}
+        bare
+        title="share"
+        data-test-id="share"
+        onClick={onClick}
+      />
+    </WithTooltip>
+  );
+};
+
+const useRenameProjectItem = (item: ProjectItemT) => {
+  const { t } = useTranslation();
+  const { updateQuery } = useUpdateQuery();
+  const { updateFormConfig } = useUpdateFormConfig();
+
+  return (label: string) => {
+    if (isFormConfig(item)) {
+      updateFormConfig(item.id, { label }, t("formConfig.renameError"));
+    } else {
+      updateQuery(item.id, { label }, t("previousQuery.renameError"));
+    }
+  };
+};
+
+const ResultsLabel = ({
+  label,
+  resultUrl,
+}: {
+  label: string;
+  resultUrl: ResultUrlWithLabel | null;
+}) => {
+  const { t } = useTranslation();
+  if (!resultUrl) return <NonBreakingText>{label}</NonBreakingText>;
+  return (
+    <WithTooltip text={t("previousQuery.downloadResults")}>
+      <SxDownloadButton tight small bare simpleIcon resultUrl={resultUrl}>
+        {label}
+      </SxDownloadButton>
+    </WithTooltip>
+  );
+};
+
+const deriveFlags = (item: ProjectItemT, loadedSecondaryIds: SecondaryId[]) => {
+  const isForm = isFormConfig(item);
+  const isShared = item.shared || (item.groups && item.groups.length > 0);
+  const secondaryId =
+    !isForm && item.secondaryId && item.queryType === "SECONDARY_ID_QUERY"
+      ? loadedSecondaryIds.find((secId) => item.secondaryId === secId.id)
+      : null;
+
+  return {
+    isShared,
+    isSystem: !!item.system || (!item.own && !isShared),
+    mayEdit: item.own || isShared,
+    secondaryId,
+    resultUrl:
+      !isForm && item.resultUrls.length > 0 ? item.resultUrls[0] : null,
+    hasNoDates: !isForm && !item.containsDates,
+  };
+};
+
 const ProjectItem = forwardRef<
   HTMLDivElement,
   {
@@ -160,66 +280,31 @@ const ProjectItem = forwardRef<
     (state) => state.conceptTrees.secondaryIds,
   );
 
-  const { updateQuery } = useUpdateQuery();
-  const { updateFormConfig } = useUpdateFormConfig();
-
-  const formLabel = useFormLabelByType(
-    isFormConfig(item) ? item.formType : null,
-  );
-  const topLeftLabel = isFormConfig(item)
-    ? formLabel!
-    : exists(item.numberOfResults)
-      ? `${item.numberOfResults} ${t("previousQueries.results")}`
-      : t("previousQuery.notExecuted");
+  const isForm = isFormConfig(item);
+  const formLabel = useFormLabelByType(isForm ? item.formType : null);
+  const topLeftLabel = getTopLeftLabel(item, formLabel, t);
 
   const dateFormat = `${t("inputDateRange.dateFormat")} HH:mm`;
   const executedAtDate = parseISO(item.createdAt);
   const executedAt = formatDate(executedAtDate, dateFormat);
 
-  const isShared = item.shared || (item.groups && item.groups.length > 0);
   const label = item.label || item.id.toString();
-  const mayEdit = item.own || isShared;
-
-  const secondaryId =
-    !isFormConfig(item) && item.secondaryId
-      ? loadedSecondaryIds.find((secId) => item.secondaryId === secId.id)
-      : null;
+  const { isShared, isSystem, mayEdit, secondaryId, resultUrl, hasNoDates } =
+    deriveFlags(item, loadedSecondaryIds);
 
   const [isEditingLabel, setIsEditingLabel] = useState<boolean>(false);
 
   const folders = item.tags;
 
-  const onRenameLabel = (label: string) => {
-    if (isFormConfig(item)) {
-      updateFormConfig(item.id, { label }, t("formConfig.renameError"));
-    } else {
-      updateQuery(item.id, { label }, t("previousQuery.renameError"));
-    }
-  };
+  const onRenameLabel = useRenameProjectItem(item);
 
   return (
     <Root ref={ref}>
-      {isFormConfig(item) ? <SxFormSymbol /> : <SxQuerySymbol />}
-      <Content
-        own={!!item.own}
-        system={!!item.system || (!item.own && !isShared)}
-      >
+      {isForm ? <SxFormSymbol /> : <SxQuerySymbol />}
+      <Content own={!!item.own} system={isSystem}>
         <TopInfos>
           <TopLeft>
-            <WithTooltip
-              html={
-                <TooltipText>
-                  {t("previousQuery.editFolders")}
-                  {folders.length > 0 && (
-                    <ActiveFolders>
-                      {folders.map((f) => (
-                        <li key={f}>{f}</li>
-                      ))}
-                    </ActiveFolders>
-                  )}
-                </TooltipText>
-              }
-            >
+            <WithTooltip html={<FoldersTooltip folders={folders} />}>
               <FoldersButton
                 icon={folders.length === 0 ? faFolderRegular : faFolder}
                 tight
@@ -230,22 +315,8 @@ const ProjectItem = forwardRef<
               />
             </WithTooltip>
             <div className="flex items-center gap-2">
-              {!isFormConfig(item) && item.resultUrls.length > 0 ? (
-                <WithTooltip text={t("previousQuery.downloadResults")}>
-                  <SxDownloadButton
-                    tight
-                    small
-                    bare
-                    simpleIcon
-                    resultUrl={item.resultUrls[0]}
-                  >
-                    {topLeftLabel}
-                  </SxDownloadButton>
-                </WithTooltip>
-              ) : (
-                <NonBreakingText>{topLeftLabel}</NonBreakingText>
-              )}
-              {!isFormConfig(item) && !item.containsDates && (
+              <ResultsLabel label={topLeftLabel} resultUrl={resultUrl} />
+              {hasNoDates && (
                 <WithTooltip text={t("previousQuery.hasNoDates")}>
                   <SxFaIcon red icon={faCalendar} />
                 </WithTooltip>
@@ -254,31 +325,15 @@ const ProjectItem = forwardRef<
           </TopLeft>
           <TopRight>
             {executedAt}
-            {secondaryId &&
-              !isFormConfig(item) &&
-              item.queryType === "SECONDARY_ID_QUERY" && (
-                <WithTooltip
-                  text={`${t("queryEditor.secondaryId")}: ${secondaryId.label}`}
-                >
-                  <IconButton icon={faMicroscope} bare onClick={() => {}} />
-                </WithTooltip>
-              )}
-            {item.own && (
+            {secondaryId && (
               <WithTooltip
-                html={
-                  <TooltipText>
-                    {isShared ? t("common.shared") : t("common.share")}
-                  </TooltipText>
-                }
+                text={`${t("queryEditor.secondaryId")}: ${secondaryId.label}`}
               >
-                <IconButton
-                  icon={isShared ? faUser : faUserRegular}
-                  bare
-                  title="share"
-                  data-test-id="share"
-                  onClick={onIndicateShare}
-                />
+                <IconButton icon={faMicroscope} bare onClick={() => {}} />
               </WithTooltip>
+            )}
+            {item.own && (
+              <ShareButton isShared={!!isShared} onClick={onIndicateShare} />
             )}
             {item.own && <DeleteProjectItemButton item={item} />}
           </TopRight>
@@ -294,14 +349,10 @@ const ProjectItem = forwardRef<
             setIsEditing={setIsEditingLabel}
           />
           <OwnerName>
-            {highlightedWords.length > 0 ? (
-              <Highlighter
-                searchWords={highlightedWords}
-                textToHighlight={item.ownerName}
-              />
-            ) : (
-              item.ownerName
-            )}
+            <HighlightedText
+              text={item.ownerName}
+              highlightedWords={highlightedWords}
+            />
           </OwnerName>
         </LabelRow>
       </Content>

--- a/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
+++ b/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
@@ -9,6 +9,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { format } from "date-fns";
 import { saveAs } from "file-saver";
+import type { TFunction } from "i18next";
 import { type FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -127,6 +128,128 @@ type UploadColumnType =
   | "EXTRA" // (user supplied additional data per entity)
   | "IGNORE"; // (ignore this column)
 
+const getSelectOptions = (
+  config: PropsT["config"],
+  locale: ReturnType<typeof useActiveLang>,
+  t: TFunction,
+): { label: string; value: string }[] => [
+  { label: t("csvColumnPicker.ignore"), value: "IGNORE" },
+  ...config.ids.map(({ name, label }) => ({
+    label: label[locale] || t("common.missingLabel"),
+    value: name,
+  })),
+  { label: t("csvColumnPicker.dateSet"), value: "DATE_SET" },
+  { label: t("csvColumnPicker.startDate"), value: "START_DATE" },
+  { label: t("csvColumnPicker.endDate"), value: "END_DATE" },
+  { label: t("csvColumnPicker.extra"), value: "EXTRA" },
+];
+
+// Parses the file whenever it or the delimiter changes and resets the column mapping to IGNORE
+const useParsedCSV = (
+  file: File,
+  delimiter: string,
+  setCSVHeader: (header: UploadColumnType[]) => void,
+) => {
+  const [csv, setCSV] = useState<string[][]>([]);
+  const [csvLoading, setCSVLoading] = useState(false);
+
+  useEffect(() => {
+    async function parse() {
+      try {
+        setCSVLoading(true);
+        const result = await parseCSV(file, delimiter);
+        setCSVLoading(false);
+
+        if (result.data.length === 0) return;
+
+        setCSV(result.data);
+        setCSVHeader(new Array(result.data[0].length).fill("IGNORE"));
+      } catch {
+        setCSVLoading(false);
+      }
+    }
+
+    parse();
+  }, [file, delimiter, setCSVHeader]);
+
+  return { csv, csvLoading };
+};
+
+const CSVPreviewTable = ({
+  csv,
+  csvLoading,
+  csvHeader,
+  selectOptions,
+  onHeaderChange,
+}: {
+  csv: string[][];
+  csvLoading: boolean;
+  csvHeader: UploadColumnType[];
+  selectOptions: { label: string; value: string }[];
+  onHeaderChange: (header: UploadColumnType[]) => void;
+}) => {
+  const { t } = useTranslation();
+  return (
+    <table className="table-fixed [&_td]:px-1 [&_th]:px-1">
+      <thead>
+        {csvLoading && (
+          <tr>
+            <th>{t("csvColumnPicker.loading")}</th>
+          </tr>
+        )}
+        {csv.length > 0 &&
+          csv.slice(0, 1).map((row, j) => (
+            <tr key={j}>
+              {row.map((cell, i) => (
+                <Th key={cell + i}>
+                  <InputSelect
+                    smallMenu
+                    options={selectOptions}
+                    value={
+                      selectOptions.find((o) => o.value === csvHeader[i]) ||
+                      selectOptions[0]
+                    }
+                    onChange={(value) => {
+                      if (value) {
+                        onHeaderChange([
+                          ...csvHeader.slice(0, i),
+                          value.value as UploadColumnType,
+                          ...csvHeader.slice(i + 1),
+                        ]);
+                      }
+                    }}
+                  />
+                  <SxPadded>{cell}</SxPadded>
+                </Th>
+              ))}
+            </tr>
+          ))}
+      </thead>
+      <tbody>
+        {csv.length > 0 &&
+          csv.slice(1, 6).map((row, j) => (
+            <tr key={j}>
+              {row.map((cell, i) => (
+                <Td key={cell + i}>
+                  <Padded>{cell}</Padded>
+                </Td>
+              ))}
+            </tr>
+          ))}
+        {csv.length > 6 && (
+          <tr>
+            {new Array(csv[0].length).fill(null).map((_, j) => (
+              <Td key={j}>
+                <Padded>...</Padded>
+              </Td>
+            ))}
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
+};
+
 const CSVColumnPicker: FC<PropsT> = ({
   file,
   loading,
@@ -138,81 +261,17 @@ const CSVColumnPicker: FC<PropsT> = ({
 }) => {
   const { t } = useTranslation();
   const locale = useActiveLang();
-  const [csv, setCSV] = useState<string[][]>([]);
   const [delimiter, setDelimiter] = useState<string>(";");
   const [csvHeader, setCSVHeader] = useState<UploadColumnType[]>([]);
-  const [csvLoading, setCSVLoading] = useState(false);
+  const { csv, csvLoading } = useParsedCSV(file, delimiter, setCSVHeader);
 
-  const SELECT_OPTIONS: { label: string; value: string }[] = [
-    { label: t("csvColumnPicker.ignore"), value: "IGNORE" },
-    ...config.ids.map(({ name, label }) => {
-      const labelWithFallback: string =
-        label[locale] || t("common.missingLabel");
-
-      return {
-        label: labelWithFallback,
-        value: name,
-      };
-    }),
-    { label: t("csvColumnPicker.dateSet"), value: "DATE_SET" },
-    { label: t("csvColumnPicker.startDate"), value: "START_DATE" },
-    { label: t("csvColumnPicker.endDate"), value: "END_DATE" },
-    { label: t("csvColumnPicker.extra"), value: "EXTRA" },
-  ];
+  const SELECT_OPTIONS = getSelectOptions(config, locale, t);
 
   const DELIMITER_OPTIONS = [
     { label: `${t("csvColumnPicker.semicolon")} ( ; )`, value: ";" },
     { label: `${t("csvColumnPicker.comma")} ( , )`, value: "," },
     { label: `${t("csvColumnPicker.colon")} ( : )`, value: ":" },
   ];
-
-  useEffect(() => {
-    async function parse() {
-      try {
-        setCSVLoading(true);
-
-        const result = await parseCSV(file, delimiter);
-
-        setCSVLoading(false);
-
-        if (result.data.length > 0) {
-          setCSV(result.data);
-
-          const firstRow = result.data[0];
-
-          const initialCSVHeader = new Array(firstRow.length).fill("IGNORE");
-
-          // NOTE: IT WAS A PREVIOUS REQUIREMENT TO INITIALIZE THE HEADER WITH CERTAIN
-          //       DEFAULT VALUES DEPENDING ON THE NUMBER OF COLUMNS IN THE CSV.
-          //       SINCE WE'LL WANT TO IMPROVE THE INITIALIZATION MECHANISM SOON,
-          //       I'M LEAVING THE CODE HERE FOR THE MOMENT:
-          // External queries (uploaded lists) usually contain three or four columns.
-          // The first two columns are IDs, which will be concatenated
-          // The other two columns are date ranges
-          // const initialIdName =
-          //   config.ids.length > 0 ? config.ids[0].name : "IGNORE";
-          // if (firstRow.length >= 4) {
-          //   initialCSVHeader[0] = initialIdName;
-          //   initialCSVHeader[1] = initialIdName;
-          //   initialCSVHeader[2] = "START_DATE";
-          //   initialCSVHeader[3] = "END_DATE";
-          // } else if (firstRow.length === 3) {
-          //   initialCSVHeader = [initialIdName, initialIdName, "DATE_SET"];
-          // } else if (firstRow.length === 2) {
-          //   initialCSVHeader = [initialIdName, "DATE_SET"];
-          // } else {
-          //   initialCSVHeader = [initialIdName];
-          // }
-
-          setCSVHeader(initialCSVHeader);
-        }
-      } catch {
-        setCSVLoading(false);
-      }
-    }
-
-    parse();
-  }, [file, delimiter]);
 
   function uploadQuery() {
     onUpload({
@@ -273,64 +332,13 @@ const CSVColumnPicker: FC<PropsT> = ({
       </Row>
       <div className="overflow-hidden rounded-sm py-3 px-2 border w-full">
         <div className="overflow-x-auto">
-          <table className="table-fixed [&_td]:px-1 [&_th]:px-1">
-            <thead>
-              {csvLoading && (
-                <tr>
-                  <th>{t("csvColumnPicker.loading")}</th>
-                </tr>
-              )}
-              {csv.length > 0 &&
-                csv.slice(0, 1).map((row, j) => (
-                  <tr key={j}>
-                    {row.map((cell, i) => (
-                      <Th key={cell + i}>
-                        <InputSelect
-                          smallMenu
-                          options={SELECT_OPTIONS}
-                          value={
-                            SELECT_OPTIONS.find(
-                              (o) => o.value === csvHeader[i],
-                            ) || SELECT_OPTIONS[0]
-                          }
-                          onChange={(value) => {
-                            if (value) {
-                              setCSVHeader([
-                                ...csvHeader.slice(0, i),
-                                value.value as UploadColumnType,
-                                ...csvHeader.slice(i + 1),
-                              ]);
-                            }
-                          }}
-                        />
-                        <SxPadded>{cell}</SxPadded>
-                      </Th>
-                    ))}
-                  </tr>
-                ))}
-            </thead>
-            <tbody>
-              {csv.length > 0 &&
-                csv.slice(1, 6).map((row, j) => (
-                  <tr key={j}>
-                    {row.map((cell, i) => (
-                      <Td key={cell + i}>
-                        <Padded>{cell}</Padded>
-                      </Td>
-                    ))}
-                  </tr>
-                ))}
-              {csv.length > 6 && (
-                <tr>
-                  {new Array(csv[0].length).fill(null).map((_, j) => (
-                    <Td key={j}>
-                      <Padded>...</Padded>
-                    </Td>
-                  ))}
-                </tr>
-              )}
-            </tbody>
-          </table>
+          <CSVPreviewTable
+            csv={csv}
+            csvLoading={csvLoading}
+            csvHeader={csvHeader}
+            selectOptions={SELECT_OPTIONS}
+            onHeaderChange={setCSVHeader}
+          />
         </div>
       </div>
       {uploadResult && (

--- a/frontend/src/js/query-runner/reducer.ts
+++ b/frontend/src/js/query-runner/reducer.ts
@@ -70,87 +70,70 @@ export default function createQueryRunnerReducer(type: QueryTypeT) {
     queryResult: null,
   };
 
-  const queryTypeMatches = (action: { payload: { queryType: QueryTypeT } }) => {
-    return action.payload.queryType === type;
-  };
+  const isForThisQueryType = (action: Action) =>
+    (action as { payload?: { queryType?: QueryTypeT } }).payload?.queryType ===
+    type;
 
   return (
     state: QueryRunnerStateT = initialState,
     action: Action,
   ): QueryRunnerStateT => {
+    // Every action handled below carries the query type it belongs to
+    if (!isForThisQueryType(action)) return state;
+
     switch (action.type) {
       case getType(startQuery.request):
-        return queryTypeMatches(action)
-          ? {
-              ...state,
-              stopQuery: {},
-              startQuery: { loading: true },
-              queryResult: null,
-            }
-          : state;
+        return {
+          ...state,
+          stopQuery: {},
+          startQuery: { loading: true },
+          queryResult: null,
+        };
       case getType(startQuery.success):
-        return queryTypeMatches(action)
-          ? {
-              ...state,
-              runningQuery: action.payload.data.id,
-              queryRunning: true,
-              stopQuery: {},
-              startQuery: { success: true },
-            }
-          : state;
+        return {
+          ...state,
+          runningQuery: action.payload.data.id,
+          queryRunning: true,
+          stopQuery: {},
+          startQuery: { success: true },
+        };
       case getType(startQuery.failure):
-        return queryTypeMatches(action)
-          ? {
-              ...state,
-              stopQuery: {},
-              startQuery: {
-                error: action.payload.message || action.payload.status,
-              },
-            }
-          : state;
+        return {
+          ...state,
+          stopQuery: {},
+          startQuery: {
+            error: action.payload.message || action.payload.status,
+          },
+        };
       // To cancel a query
       case getType(stopQuery.request):
-        return queryTypeMatches(action)
-          ? { ...state, startQuery: {}, stopQuery: { loading: true } }
-          : state;
+        return { ...state, startQuery: {}, stopQuery: { loading: true } };
       case getType(stopQuery.success):
-        return queryTypeMatches(action)
-          ? {
-              ...state,
-              runningQuery: null,
-              progress: undefined,
-              queryRunning: false,
-              startQuery: {},
-              stopQuery: { success: true },
-            }
-          : state;
+        return {
+          ...state,
+          runningQuery: null,
+          progress: undefined,
+          queryRunning: false,
+          startQuery: {},
+          stopQuery: { success: true },
+        };
       case getType(stopQuery.failure):
-        return queryTypeMatches(action)
-          ? {
-              ...state,
-              startQuery: {},
-              stopQuery: {
-                error: action.payload.message || action.payload.status,
-              },
-            }
-          : state;
+        return {
+          ...state,
+          startQuery: {},
+          stopQuery: {
+            error: action.payload.message || action.payload.status,
+          },
+        };
 
       // To check for query results
       case getType(queryResultStart):
-        return queryTypeMatches(action)
-          ? { ...state, queryResult: { loading: true } }
-          : state;
+        return { ...state, queryResult: { loading: true } };
       case getType(queryResultRunning):
-        return queryTypeMatches(action)
-          ? { ...state, progress: action.payload.progress }
-          : state;
+        return { ...state, progress: action.payload.progress };
       case getType(queryResultReset):
-        return queryTypeMatches(action)
-          ? { ...state, queryResult: { loading: false } }
-          : state;
+        return { ...state, queryResult: { loading: false } };
       case getType(queryResultSuccess):
-        if (!queryTypeMatches(action)) return state;
-
         return {
           ...state,
           queryResult: getQueryResult(
@@ -162,8 +145,6 @@ export default function createQueryRunnerReducer(type: QueryTypeT) {
           queryRunning: false,
         };
       case getType(queryResultErrorAction):
-        if (!queryTypeMatches(action)) return state;
-
         return {
           ...state,
           runningQuery: null,

--- a/frontend/src/js/ui-components/InputMultiSelect/InputMultiSelect.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/InputMultiSelect.tsx
@@ -99,6 +99,9 @@ const InputMultiSelect = ({
   onLoadAndInsertAll,
 }: Props) => {
   const { t } = useTranslation();
+  const defaultPlaceholder = onResolve
+    ? t("inputMultiSelect.dndPlaceholder")
+    : t("inputSelect.placeholder");
 
   useResolvableSelect({
     defaultValue,
@@ -309,11 +312,7 @@ const InputMultiSelect = ({
             placeholder={
               selectedItems.length > 0
                 ? undefined
-                : placeholder
-                  ? placeholder
-                  : onResolve
-                    ? t("inputMultiSelect.dndPlaceholder")
-                    : t("inputSelect.placeholder")
+                : (placeholder ?? defaultPlaceholder)
             }
             onClick={(e) => {
               inputProps.onClick?.(e);

--- a/frontend/src/js/ui-components/InputRange.tsx
+++ b/frontend/src/js/ui-components/InputRange.tsx
@@ -102,28 +102,23 @@ const InputRange = ({
     const nextValue = exists(newValue) ? newValue : null;
 
     if (type === "exact") {
-      if (nextValue === null) {
-        onChange(null);
-      } else {
-        onChange({ exact: nextValue });
-      }
-    } else if (type === "min" || type === "max") {
-      if (
-        nextValue === null &&
-        ((value && value.min === null && type === "max") ||
-          (value && value.max === null && type === "min"))
-      ) {
-        onChange(null);
-      } else {
-        onChange({
-          min: value ? value.min : null,
-          max: value ? value.max : null,
-          [type]: nextValue,
-        });
-      }
-    } else {
-      onChange(null);
+      onChange(nextValue === null ? null : { exact: nextValue });
+      return;
     }
+
+    // Clearing the one bound that was still set clears the whole range
+    const otherBoundIsEmpty =
+      !!value && (type === "max" ? value.min === null : value.max === null);
+    if (nextValue === null && otherBoundIsEmpty) {
+      onChange(null);
+      return;
+    }
+
+    onChange({
+      min: value ? value.min : null,
+      max: value ? value.max : null,
+      [type]: nextValue,
+    });
   };
 
   return (


### PR DESCRIPTION
Stacked on #3968, which introduced the rule as a warning. All eleven functions over the limit are refactored, behaviour-preserving, and the rule is an `error` now so no new ones creep in; mock-api is exempted instead (mock data generators are branchy on purpose). Biome is back to zero diagnostics.

- `query-runner/reducer`: the query-type check happens once at the top instead of in every case
- `FormConceptGroup`: the three drag & drop handlers (`dropConceptBetweenRows`, `dropConceptOnGroup`, `dropConceptOnSlot`) are module-level functions, plus `removeConceptOrRow`
- `useExpandQuery`: `expandGroup` (AND/OR shared) and `conceptNodeToTree`
- `YearHead`: `ConceptValues` component, `formatValue`, shared label sort
- `ProjectItem`: `deriveFlags`, `ResultsLabel`, `ShareButton`, `FoldersTooltip`, `HighlightedText`, `useRenameProjectItem`
- `CSVColumnPicker`: `useParsedCSV` hook, `getSelectOptions`, `CSVPreviewTable` component
- `FaIcon`: colour cascade as early returns; `InputRange`: `onChangeValue` flattened; `InputMultiSelect`: placeholder precomputed

typecheck / vitest / vite build / storybook build green; e2e covers the query editor, forms and project list paths touched here.
