### PR TITLE
feat(frontend): show preview button only when backend marks preview available

### DIFF
--- a/frontend/mock-api/mockApi.ts
+++ b/frontend/mock-api/mockApi.ts
@@ -159,6 +159,7 @@ export default function mockApi(app: Application) {
               status: "DONE",
               label: "Test result",
               numberOfResults: 5,
+              previewAvailable: true,
               resultUrls:
                 dice > 0.85
                   ? [

--- a/frontend/mock-api/stored-queries/25.json
+++ b/frontend/mock-api/stored-queries/25.json
@@ -2,6 +2,7 @@
   "id": 25,
   "status": "DONE",
   "numberOfResults": 5,
+  "previewAvailable": true,
   "label": "Result list",
   "resultUrls": [
     {

--- a/frontend/src/js/api/types.ts
+++ b/frontend/src/js/api/types.ts
@@ -419,6 +419,7 @@ export interface GetQueryResponseDoneT {
   queryType: "CONCEPT_QUERY" | "SECONDARY_ID_QUERY";
   requiredTime: number; // In ms, unused at the moment
   containsDates: boolean;
+  previewAvailable: boolean; // Whether /queries/{id}/statistics can be requested (not the case for most forms)
 }
 
 export interface GetQueryRunningResponseT {

--- a/frontend/src/js/query-runner/QueryResults.tsx
+++ b/frontend/src/js/query-runner/QueryResults.tsx
@@ -42,6 +42,7 @@ interface PropsT {
   resultCount?: number | null; // For forms, won't usually have a count
   resultColumns?: ColumnDescription[] | null; // For forms, won't usually have resultColumns
   queryType?: "CONCEPT_QUERY" | "SECONDARY_ID_QUERY";
+  previewAvailable?: boolean; // Backend decides, e.g. most forms have no preview
 }
 
 const QueryResults: FC<PropsT> = ({
@@ -50,6 +51,7 @@ const QueryResults: FC<PropsT> = ({
   resultCount,
   resultColumns,
   queryType,
+  previewAvailable,
 }) => {
   const { t } = useTranslation();
   const csvUrl = resultUrls.find(({ url }) => url.endsWith("csv"));
@@ -71,7 +73,7 @@ const QueryResults: FC<PropsT> = ({
             : t("queryRunner.resultCount")}
         </LgText>
       )}
-      {canViewPreview && <PreviewButton />}
+      {canViewPreview && previewAvailable && <PreviewButton />}
       {!!csvUrl && canViewHistory && exists(resultColumns) && (
         <QueryResultHistoryButton
           columns={resultColumns}

--- a/frontend/src/js/query-runner/QueryRunner.tsx
+++ b/frontend/src/js/query-runner/QueryRunner.tsx
@@ -93,6 +93,7 @@ const QueryRunner = ({
               resultUrls={queryRunner.queryResult.resultUrls}
               resultColumns={queryRunner.queryResult.resultColumns}
               queryType={queryRunner.queryResult.queryType}
+              previewAvailable={queryRunner.queryResult.previewAvailable}
             />
           )}
       </Right>

--- a/frontend/src/js/query-runner/reducer.ts
+++ b/frontend/src/js/query-runner/reducer.ts
@@ -33,6 +33,7 @@ interface QueryResultT extends APICallType {
   resultUrls?: ResultUrlWithLabel[];
   resultColumns?: ColumnDescription[] | null;
   queryType?: "CONCEPT_QUERY" | "SECONDARY_ID_QUERY";
+  previewAvailable?: boolean;
 }
 
 export interface QueryRunnerStateT {
@@ -58,6 +59,7 @@ const getQueryResult = (
     resultUrls: data.resultUrls,
     resultColumns: data.columnDescriptions,
     queryType: data.queryType,
+    previewAvailable: data.previewAvailable,
   };
 };
 


### PR DESCRIPTION
Uses `previewAvailable` from #3956. The button used to appear on every finished execution, but forms mostly have no `/statistics` endpoint, so the click led nowhere. Permission check stays; both must hold now. Mock api returns `true` so the dev setup is unchanged.