### PR TITLE
refactor(frontend): forwardRef -> ref prop

### DIFF
--- a/frontend/src/js/button/BasicButton.tsx
+++ b/frontend/src/js/button/BasicButton.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { type ButtonHTMLAttributes, forwardRef } from "react";
+import type { ButtonHTMLAttributes, Ref } from "react";
 
 export interface BasicButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -37,12 +37,14 @@ const Button = styled("button")<BasicButtonProps>`
   }
 `;
 
-const BasicButton = forwardRef<HTMLButtonElement, BasicButtonProps>(
-  ({ children, ...props }, ref) => (
-    <Button type="button" {...props} ref={ref}>
-      {children}
-    </Button>
-  ),
+const BasicButton = ({
+  ref,
+  children,
+  ...props
+}: BasicButtonProps & { ref?: Ref<HTMLButtonElement> }) => (
+  <Button type="button" {...props} ref={ref}>
+    {children}
+  </Button>
 );
 
 export default BasicButton;

--- a/frontend/src/js/button/DownloadButton.tsx
+++ b/frontend/src/js/button/DownloadButton.tsx
@@ -10,7 +10,7 @@ import {
   faFileExcel,
   faFilePdf,
 } from "@fortawesome/free-solid-svg-icons";
-import { forwardRef, type ReactNode, useContext, useMemo } from "react";
+import { type ReactNode, type Ref, useContext, useMemo } from "react";
 
 import type { ResultUrlWithLabel } from "../api/types";
 import { AuthTokenContext } from "../authorization/AuthTokenProvider";
@@ -65,41 +65,35 @@ interface Props extends Omit<IconButtonPropsT, "icon" | "onClick"> {
   showColoredIcon?: boolean;
 }
 
-const DownloadButton = forwardRef<HTMLAnchorElement, Props>(
-  (
-    {
-      simpleIcon,
-      resultUrl,
-      className,
-      children,
-      onClick,
-      showColoredIcon,
-      ...restProps
-    },
-    ref,
-  ) => {
-    const { authToken } = useContext(AuthTokenContext);
+const DownloadButton = ({
+  ref,
+  simpleIcon,
+  resultUrl,
+  className,
+  children,
+  onClick,
+  showColoredIcon,
+  ...restProps
+}: Props & { ref?: Ref<HTMLAnchorElement> }) => {
+  const { authToken } = useContext(AuthTokenContext);
 
-    const href = `${resultUrl.url}?access_token=${encodeURIComponent(
-      authToken,
-    )}`;
+  const href = `${resultUrl.url}?access_token=${encodeURIComponent(authToken)}`;
 
-    const { icon, color } = useFileIcon(resultUrl.url);
+  const { icon, color } = useFileIcon(resultUrl.url);
 
-    return (
-      <Link href={href} className={className} ref={ref}>
-        <SxIconButton
-          {...restProps}
-          large
-          icon={simpleIcon ? faDownload : icon}
-          onClick={onClick}
-          iconColor={showColoredIcon ? color : undefined}
-        >
-          {children}
-        </SxIconButton>
-      </Link>
-    );
-  },
-);
+  return (
+    <Link href={href} className={className} ref={ref}>
+      <SxIconButton
+        {...restProps}
+        large
+        icon={simpleIcon ? faDownload : icon}
+        onClick={onClick}
+        iconColor={showColoredIcon ? color : undefined}
+      >
+        {children}
+      </SxIconButton>
+    </Link>
+  );
+};
 
 export default DownloadButton;

--- a/frontend/src/js/button/IconButton.tsx
+++ b/frontend/src/js/button/IconButton.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import type { IconProp } from "@fortawesome/fontawesome-svg-core";
-import { forwardRef, memo, useMemo } from "react";
+import { memo, type Ref, useMemo } from "react";
 
 import FaIcon, { type FaIconPropsT, type IconStyleProps } from "../icon/FaIcon";
 
@@ -107,84 +107,80 @@ export interface IconButtonPropsT extends BasicButtonProps {
 }
 
 // A button that is prefixed by an icon
-const IconButton = forwardRef<HTMLButtonElement, IconButtonPropsT>(
-  (
-    {
-      icon,
-      active,
-      red,
-      large,
-      left,
-      children,
-      tight,
-      iconProps,
-      small,
-      secondary,
-      light,
-      fixedIconWidth,
-      bgHover,
-      iconColor,
-      ...restProps
-    },
-    ref,
-  ) => {
-    const iconElement = useMemo(() => {
-      const iconEl = (
-        <SxFaIcon
-          main
-          left={left}
-          large={large}
-          active={active}
-          red={red}
-          secondary={secondary}
-          icon={icon}
-          hasChildren={!!children}
-          tight={tight}
-          small={small}
-          light={light}
-          iconColor={iconColor}
-          {...iconProps}
-        />
-      );
-
-      return fixedIconWidth ? (
-        <FixedIconContainer style={{ width: fixedIconWidth }}>
-          {iconEl}
-        </FixedIconContainer>
-      ) : (
-        iconEl
-      );
-    }, [
-      icon,
-      active,
-      red,
-      large,
-      left,
-      children,
-      tight,
-      iconProps,
-      small,
-      secondary,
-      light,
-      fixedIconWidth,
-      iconColor,
-    ]);
-    return (
-      <SxBasicButton
-        active={active}
-        secondary={secondary}
-        tight={tight}
-        bgHover={bgHover}
-        red={red}
+const IconButton = ({
+  ref,
+  icon,
+  active,
+  red,
+  large,
+  left,
+  children,
+  tight,
+  iconProps,
+  small,
+  secondary,
+  light,
+  fixedIconWidth,
+  bgHover,
+  iconColor,
+  ...restProps
+}: IconButtonPropsT & { ref?: Ref<HTMLButtonElement> }) => {
+  const iconElement = useMemo(() => {
+    const iconEl = (
+      <SxFaIcon
+        main
+        left={left}
         large={large}
-        {...restProps}
-        ref={ref}
-      >
-        {iconElement}
-        {children && <Children>{children}</Children>}
-      </SxBasicButton>
+        active={active}
+        red={red}
+        secondary={secondary}
+        icon={icon}
+        hasChildren={!!children}
+        tight={tight}
+        small={small}
+        light={light}
+        iconColor={iconColor}
+        {...iconProps}
+      />
     );
-  },
-);
+
+    return fixedIconWidth ? (
+      <FixedIconContainer style={{ width: fixedIconWidth }}>
+        {iconEl}
+      </FixedIconContainer>
+    ) : (
+      iconEl
+    );
+  }, [
+    icon,
+    active,
+    red,
+    large,
+    left,
+    children,
+    tight,
+    iconProps,
+    small,
+    secondary,
+    light,
+    fixedIconWidth,
+    iconColor,
+  ]);
+  return (
+    <SxBasicButton
+      active={active}
+      secondary={secondary}
+      tight={tight}
+      bgHover={bgHover}
+      red={red}
+      large={large}
+      {...restProps}
+      ref={ref}
+    >
+      {iconElement}
+      {children && <Children>{children}</Children>}
+    </SxBasicButton>
+  );
+};
 
 export default memo(IconButton);

--- a/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
@@ -5,7 +5,7 @@ import {
   faCaretRight,
   type IconDefinition,
 } from "@fortawesome/free-solid-svg-icons";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 import { Highlighter } from "../common/components/Highlighter";
 
 import FaIcon from "../icon/FaIcon";
@@ -93,89 +93,84 @@ const ResultsNumber = styled("span")`
   font-weight: 700;
 `;
 
-const ConceptTreeNodeText = forwardRef<
-  HTMLDivElement,
-  {
-    label: string;
-    depth: number;
-    icon: IconDefinition;
+const ConceptTreeNodeText = ({
+  ref,
+  label,
+  description,
+  icon,
+  resultCount,
+  searchWords,
+  className,
+  depth,
 
-    className?: string;
-    description?: string;
-    resultCount?: number | null;
-    searchWords?: string[] | null;
-    isOpen?: boolean;
-    hasChildren?: boolean;
-    red?: boolean;
-    disabled?: boolean;
-    onClick?: () => void;
-  }
->(
-  (
-    {
-      label,
-      description,
-      icon,
-      resultCount,
-      searchWords,
-      className,
-      depth,
+  isOpen,
+  red,
+  disabled,
+  hasChildren,
 
-      isOpen,
-      red,
-      disabled,
-      hasChildren,
+  onClick,
+}: {
+  ref?: Ref<HTMLDivElement>;
 
-      onClick,
-    },
-    ref,
-  ) => {
-    return (
-      <Root ref={ref} className={className} depth={depth}>
-        <Text onClick={onClick} isOpen={isOpen} red={red} disabled={disabled}>
-          {hasChildren && (
-            <>
-              <CaretIconContainer>
-                <FaIcon
-                  disabled={disabled}
-                  active
-                  icon={isOpen ? faCaretDown : faCaretRight}
-                />
-              </CaretIconContainer>
-              <FolderIconContainer>
-                <FaIcon active disabled={disabled} icon={icon} />
-              </FolderIconContainer>
-            </>
+  label: string;
+  depth: number;
+  icon: IconDefinition;
+
+  className?: string;
+  description?: string;
+  resultCount?: number | null;
+  searchWords?: string[] | null;
+  isOpen?: boolean;
+  hasChildren?: boolean;
+  red?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}) => {
+  return (
+    <Root ref={ref} className={className} depth={depth}>
+      <Text onClick={onClick} isOpen={isOpen} red={red} disabled={disabled}>
+        {hasChildren && (
+          <>
+            <CaretIconContainer>
+              <FaIcon
+                disabled={disabled}
+                active
+                icon={isOpen ? faCaretDown : faCaretRight}
+              />
+            </CaretIconContainer>
+            <FolderIconContainer>
+              <FaIcon active disabled={disabled} icon={icon} />
+            </FolderIconContainer>
+          </>
+        )}
+        {!hasChildren && (
+          <DashIconContainer>
+            <FaIcon disabled={disabled} large active icon={icon} />
+          </DashIconContainer>
+        )}
+        {resultCount && <ResultsNumber>{resultCount}</ResultsNumber>}
+        <span>
+          {searchWords ? (
+            <Highlighter searchWords={searchWords} textToHighlight={label} />
+          ) : (
+            label
           )}
-          {!hasChildren && (
-            <DashIconContainer>
-              <FaIcon disabled={disabled} large active icon={icon} />
-            </DashIconContainer>
-          )}
-          {resultCount && <ResultsNumber>{resultCount}</ResultsNumber>}
-          <span>
+        </span>
+        {!!description && (
+          <Description>
             {searchWords ? (
-              <Highlighter searchWords={searchWords} textToHighlight={label} />
+              <Highlighter
+                searchWords={searchWords}
+                textToHighlight={description}
+              />
             ) : (
-              label
+              `- ${description}`
             )}
-          </span>
-          {!!description && (
-            <Description>
-              {searchWords ? (
-                <Highlighter
-                  searchWords={searchWords}
-                  textToHighlight={description}
-                />
-              ) : (
-                `- ${description}`
-              )}
-            </Description>
-          )}
-        </Text>
-      </Root>
-    );
-  },
-);
+          </Description>
+        )}
+      </Text>
+    </Root>
+  );
+};
 
 export default ConceptTreeNodeText;

--- a/frontend/src/js/external-forms/form-components/DropzoneList.tsx
+++ b/frontend/src/js/external-forms/form-components/DropzoneList.tsx
@@ -1,12 +1,6 @@
 import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
-import {
-  type ForwardedRef,
-  forwardRef,
-  type ReactElement,
-  type ReactNode,
-  type Ref,
-} from "react";
+import type { ReactNode, Ref } from "react";
 import type { DropTargetMonitor } from "react-dnd";
 
 import IconButton from "../../button/IconButton";
@@ -77,22 +71,20 @@ interface PropsT<DroppableObject> {
   ) => (item: PossibleDroppableObject, monitor: DropTargetMonitor) => void;
 }
 
-const DropzoneList = <DroppableObject extends PossibleDroppableObject>(
-  {
-    className,
-    label,
-    tooltip,
-    dropzoneChildren,
-    items,
-    acceptedDropTypes,
-    onDelete,
-    disallowMultipleColumns,
-    onDrop,
-    onImportLines,
-    dropBetween,
-  }: PropsT<DroppableObject>,
-  ref: Ref<HTMLDivElement>,
-) => {
+const DropzoneList = <DroppableObject extends PossibleDroppableObject>({
+  className,
+  label,
+  tooltip,
+  dropzoneChildren,
+  items,
+  acceptedDropTypes,
+  onDelete,
+  disallowMultipleColumns,
+  onDrop,
+  onImportLines,
+  dropBetween,
+  ref,
+}: PropsT<DroppableObject> & { ref?: Ref<HTMLDivElement> }) => {
   // allow at least one column
   const showDropzone =
     (items && items.length === 0) || !disallowMultipleColumns;
@@ -149,8 +141,4 @@ const DropzoneList = <DroppableObject extends PossibleDroppableObject>(
   );
 };
 
-export default forwardRef(DropzoneList) as <
-  DroppableObject extends PossibleDroppableObject = DragItemFile,
->(
-  props: PropsT<DroppableObject> & { ref?: ForwardedRef<HTMLDivElement> },
-) => ReactElement;
+export default DropzoneList;

--- a/frontend/src/js/icon/FaIcon.tsx
+++ b/frontend/src/js/icon/FaIcon.tsx
@@ -4,7 +4,7 @@ import { keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
 import type { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 
 export interface IconStyleProps {
   left?: boolean;
@@ -70,18 +70,21 @@ export const Icon = styled(FontAwesomeIcon, {
   }
 `;
 
-const FaIcon = forwardRef<SVGSVGElement, FaIconPropsT>(
-  ({ icon, className, ...restProps }, ref) => {
-    return (
-      <Icon
-        // @ts-ignore TODO: ref is working, try fixing the type error
-        ref={ref}
-        className={`fa-fw ${className}`}
-        icon={icon}
-        {...restProps}
-      />
-    );
-  },
-);
+const FaIcon = ({
+  ref,
+  icon,
+  className,
+  ...restProps
+}: FaIconPropsT & { ref?: Ref<SVGSVGElement> }) => {
+  return (
+    <Icon
+      // @ts-ignore TODO: ref is working, try fixing the type error
+      ref={ref}
+      className={`fa-fw ${className}`}
+      icon={icon}
+      {...restProps}
+    />
+  );
+};
 
 export default FaIcon;

--- a/frontend/src/js/previous-queries/list/ProjectItem.tsx
+++ b/frontend/src/js/previous-queries/list/ProjectItem.tsx
@@ -11,7 +11,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { parseISO } from "date-fns";
 import type { TFunction } from "i18next";
-import { forwardRef, useState } from "react";
+import { type Ref, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import type { ResultUrlWithLabel, SecondaryId } from "../../api/types";
@@ -260,17 +260,18 @@ const deriveFlags = (item: ProjectItemT, loadedSecondaryIds: SecondaryId[]) => {
   };
 };
 
-const ProjectItem = forwardRef<
-  HTMLDivElement,
-  {
-    item: ProjectItemT;
-    onIndicateShare: () => void;
-    onIndicateEditFolders: () => void;
-  }
->(function ProjectItemComponent(
-  { item, onIndicateShare, onIndicateEditFolders },
+const ProjectItem = ({
   ref,
-) {
+  item,
+  onIndicateShare,
+  onIndicateEditFolders,
+}: {
+  ref?: Ref<HTMLDivElement>;
+
+  item: ProjectItemT;
+  onIndicateShare: () => void;
+  onIndicateEditFolders: () => void;
+}) => {
   const { t } = useTranslation();
   const highlightedWords = useSelector<StateT, string[]>(
     (state) => state.projectItemsSearch.words,
@@ -358,6 +359,6 @@ const ProjectItem = forwardRef<
       </Content>
     </Root>
   );
-});
+};
 
 export default ProjectItem;

--- a/frontend/src/js/query-node-editor/ContentCell.tsx
+++ b/frontend/src/js/query-node-editor/ContentCell.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { forwardRef, type ReactNode } from "react";
+import type { ReactNode, Ref } from "react";
 
 import { Heading4 } from "../headings/Headings";
 
@@ -25,13 +25,16 @@ interface PropsT {
   headline?: string;
 }
 
-const ContentCell = forwardRef<HTMLDivElement, PropsT>(
-  ({ className, headline, children }, ref) => (
-    <Root ref={ref} className={className}>
-      {headline && <Headline>{headline}</Headline>}
-      <Content>{children}</Content>
-    </Root>
-  ),
+const ContentCell = ({
+  ref,
+  className,
+  headline,
+  children,
+}: PropsT & { ref?: Ref<HTMLDivElement> }) => (
+  <Root ref={ref} className={className}>
+    {headline && <Headline>{headline}</Headline>}
+    <Content>{children}</Content>
+  </Root>
 );
 
 export default ContentCell;

--- a/frontend/src/js/query-runner/QueryRunnerButton.tsx
+++ b/frontend/src/js/query-runner/QueryRunnerButton.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { faPlay, faSpinner, faStop } from "@fortawesome/free-solid-svg-icons";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 import { useTranslation } from "react-i18next";
 
 import BasicButton from "../button/BasicButton";
@@ -60,31 +60,33 @@ interface Props {
 }
 
 // A button that is prefixed by an icon
-const QueryRunnerButton = forwardRef<HTMLDivElement, Props>(
-  ({ onClick, isStartStopLoading, isQueryRunning, disabled }, ref) => {
-    const { t } = useTranslation();
-    const label = isQueryRunning
-      ? t("queryRunner.stop")
-      : t("queryRunner.start");
+const QueryRunnerButton = ({
+  ref,
+  onClick,
+  isStartStopLoading,
+  isQueryRunning,
+  disabled,
+}: Props & { ref?: Ref<HTMLDivElement> }) => {
+  const { t } = useTranslation();
+  const label = isQueryRunning ? t("queryRunner.stop") : t("queryRunner.start");
 
-    const icon = getIcon(isStartStopLoading, isQueryRunning);
+  const icon = getIcon(isStartStopLoading, isQueryRunning);
 
-    return (
-      <Root ref={ref}>
-        <StyledBasicButton
-          type="button"
-          onClick={onClick}
-          disabled={disabled}
-          data-test-id="query-runner-button"
-        >
-          <Left running={isQueryRunning}>
-            <FaIcon white={!isQueryRunning} icon={icon} />
-          </Left>
-          <Label className="query-runner-label">{label}</Label>
-        </StyledBasicButton>
-      </Root>
-    );
-  },
-);
+  return (
+    <Root ref={ref}>
+      <StyledBasicButton
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        data-test-id="query-runner-button"
+      >
+        <Left running={isQueryRunning}>
+          <FaIcon white={!isQueryRunning} icon={icon} />
+        </Left>
+        <Label className="query-runner-label">{label}</Label>
+      </StyledBasicButton>
+    </Root>
+  );
+};
 
 export default QueryRunnerButton;

--- a/frontend/src/js/small-tab-navigation/SmallTabNavigationButton.tsx
+++ b/frontend/src/js/small-tab-navigation/SmallTabNavigationButton.tsx
@@ -1,6 +1,6 @@
 import { css, type Theme, useTheme } from "@emotion/react";
 import styled from "@emotion/styled";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 
 import { HoverNavigatable } from "./HoverNavigatable";
 
@@ -93,17 +93,24 @@ const valueToColor = (theme: Theme, value: string) => {
   }
 };
 
-const SmallTabNavigationButton = forwardRef<
-  HTMLButtonElement,
-  {
-    value: string;
-    size: "M" | "L";
-    isSelected?: boolean;
-    onClick: () => void;
-    children?: React.ReactNode;
-    variant: "primary" | "secondary";
-  }
->(({ value, children, size, isSelected, onClick, variant }, ref) => {
+const SmallTabNavigationButton = ({
+  ref,
+  value,
+  children,
+  size,
+  isSelected,
+  onClick,
+  variant,
+}: {
+  ref?: Ref<HTMLButtonElement>;
+
+  value: string;
+  size: "M" | "L";
+  isSelected?: boolean;
+  onClick: () => void;
+  children?: React.ReactNode;
+  variant: "primary" | "secondary";
+}) => {
   const theme = useTheme();
   const highlightColor = valueToColor(theme, value);
 
@@ -122,6 +129,6 @@ const SmallTabNavigationButton = forwardRef<
       </Button>
     </HoverNavigatable>
   );
-});
+};
 
 export default SmallTabNavigationButton;

--- a/frontend/src/js/standard-query-editor/QueryEditorDropzone.tsx
+++ b/frontend/src/js/standard-query-editor/QueryEditorDropzone.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { forwardRef, memo, useCallback } from "react";
+import { memo, type Ref, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { QueryIdT } from "../api/types";
@@ -53,55 +53,51 @@ interface Props {
   onImportLines?: (lines: string[], filename?: string) => void;
 }
 
-const QueryEditorDropzone = forwardRef<HTMLDivElement, Props>(
-  (
-    {
-      className,
-      isAnd,
-      isInitial,
-      onLoadPreviousQuery,
-      onDropFile,
-      onDropNode,
-      onImportLines,
+const QueryEditorDropzone = ({
+  ref,
+  className,
+  isAnd,
+  isInitial,
+  onLoadPreviousQuery,
+  onDropFile,
+  onDropNode,
+  onImportLines,
+}: Props & { ref?: Ref<HTMLDivElement> }) => {
+  const { t } = useTranslation();
+  const onDrop = useCallback(
+    (item: StandardQueryNodeT | DragItemFile) => {
+      if (item.type === "__NATIVE_FILE__") {
+        onDropFile(item.files[0]);
+      } else {
+        onDropNode(item);
+
+        if (!nodeIsConceptQueryNode(item)) onLoadPreviousQuery(item.id);
+      }
     },
-    ref,
-  ) => {
-    const { t } = useTranslation();
-    const onDrop = useCallback(
-      (item: StandardQueryNodeT | DragItemFile) => {
-        if (item.type === "__NATIVE_FILE__") {
-          onDropFile(item.files[0]);
-        } else {
-          onDropNode(item);
+    [onDropFile, onDropNode, onLoadPreviousQuery],
+  );
 
-          if (!nodeIsConceptQueryNode(item)) onLoadPreviousQuery(item.id);
-        }
-      },
-      [onDropFile, onDropNode, onLoadPreviousQuery],
-    );
-
-    return (
-      <SxDropzoneWithFileInput
-        ref={ref}
-        className={className}
-        isAnd={isAnd}
-        isInitial={isInitial}
-        acceptedDropTypes={DROP_TYPES}
-        onDrop={(item) => onDrop(item as StandardQueryNodeT | DragItemFile)}
-        onSelectFile={onDropFile}
-        disableClick={isInitial}
-        showImportButton={isInitial}
-        onImportLines={onImportLines}
-      >
-        {() => (
-          <>
-            {isInitial && <EmptyQueryEditorDropzone />}
-            {!isInitial && <Text>{t("dropzone.dragElementPlease")}</Text>}
-          </>
-        )}
-      </SxDropzoneWithFileInput>
-    );
-  },
-);
+  return (
+    <SxDropzoneWithFileInput
+      ref={ref}
+      className={className}
+      isAnd={isAnd}
+      isInitial={isInitial}
+      acceptedDropTypes={DROP_TYPES}
+      onDrop={(item) => onDrop(item as StandardQueryNodeT | DragItemFile)}
+      onSelectFile={onDropFile}
+      disableClick={isInitial}
+      showImportButton={isInitial}
+      onImportLines={onImportLines}
+    >
+      {() => (
+        <>
+          {isInitial && <EmptyQueryEditorDropzone />}
+          {!isInitial && <Text>{t("dropzone.dragElementPlease")}</Text>}
+        </>
+      )}
+    </SxDropzoneWithFileInput>
+  );
+};
 
 export default memo(QueryEditorDropzone);

--- a/frontend/src/js/tooltip/WithTooltip.tsx
+++ b/frontend/src/js/tooltip/WithTooltip.tsx
@@ -1,7 +1,7 @@
 import { css, useTheme } from "@emotion/react";
 import styled from "@emotion/styled";
 import Tippy, { type TippyProps } from "@tippyjs/react";
-import { forwardRef, memo, type ReactElement, useMemo } from "react";
+import { memo, type ReactElement, type Ref, useMemo } from "react";
 import "tippy.js/dist/tippy.css";
 import "tippy.js/themes/light.css";
 
@@ -76,68 +76,64 @@ interface Props {
 // Show and hide duration
 const shortDuration = [100, 100] as [number, number];
 
-const WithTooltip = forwardRef<HTMLElement, Props>(
-  (
-    {
-      className,
-      children,
-      text,
-      html,
-      lazy,
-      wide,
-      placement,
-      interactive,
-      trigger,
-      arrow,
-      offset,
-      hideOnClick,
-      popperOptions,
-    },
-    ref,
-  ) => {
-    const theme = useTheme();
+const WithTooltip = ({
+  ref,
+  className,
+  children,
+  text,
+  html,
+  lazy,
+  wide,
+  placement,
+  interactive,
+  trigger,
+  arrow,
+  offset,
+  hideOnClick,
+  popperOptions,
+}: Props & { ref?: Ref<HTMLElement> }) => {
+  const theme = useTheme();
 
-    const content = useMemo(() => {
-      return text ? (
-        <Text
-          theme={theme}
-          wide={wide}
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: tooltip text is concept metadata from the backend
-          dangerouslySetInnerHTML={{ __html: text }}
-        />
-      ) : (
-        html
-      );
-    }, [theme, wide, text, html]);
-
-    const delay = useMemo(
-      () => (lazy ? ([1000, 0] as [number, number]) : 0),
-      [lazy],
+  const content = useMemo(() => {
+    return text ? (
+      <Text
+        theme={theme}
+        wide={wide}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: tooltip text is concept metadata from the backend
+        dangerouslySetInnerHTML={{ __html: text }}
+      />
+    ) : (
+      html
     );
+  }, [theme, wide, text, html]);
 
-    if (!text && !html) return <>{children}</>;
+  const delay = useMemo(
+    () => (lazy ? ([1000, 0] as [number, number]) : 0),
+    [lazy],
+  );
 
-    return (
-      <Tippy
-        className={className}
-        duration={shortDuration}
-        content={content}
-        placement={placement}
-        theme="light"
-        delay={delay}
-        interactive={interactive}
-        trigger={trigger}
-        arrow={arrow}
-        offset={offset}
-        ref={ref}
-        zIndex={9999}
-        popperOptions={popperOptions}
-        hideOnClick={hideOnClick}
-      >
-        {children}
-      </Tippy>
-    );
-  },
-);
+  if (!text && !html) return <>{children}</>;
+
+  return (
+    <Tippy
+      className={className}
+      duration={shortDuration}
+      content={content}
+      placement={placement}
+      theme="light"
+      delay={delay}
+      interactive={interactive}
+      trigger={trigger}
+      arrow={arrow}
+      offset={offset}
+      ref={ref}
+      zIndex={9999}
+      popperOptions={popperOptions}
+      hideOnClick={hideOnClick}
+    >
+      {children}
+    </Tippy>
+  );
+};
 
 export default memo(WithTooltip);

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -6,8 +6,8 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import {
   type FocusEvent,
-  forwardRef,
   type KeyboardEvent,
+  type Ref,
   useCallback,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -121,111 +121,107 @@ const usePatternMatching = ({ pattern }: { pattern?: string }) => {
   return pattern ? { onKeyPress } : {};
 };
 
-const BaseInput = forwardRef<HTMLInputElement, Props>(
-  (
-    {
-      className,
-      inputProps = {},
-      currencyConfig,
-      money,
-      value,
-      onChange,
-      onFocus,
-      onBlur,
-      onClick,
-      placeholder,
-      large,
-      inputType,
-      valid,
-      invalid,
-      invalidText,
-      disabled,
-    },
-    ref,
-  ) => {
-    const { t } = useTranslation();
+const BaseInput = ({
+  ref,
+  className,
+  inputProps = {},
+  currencyConfig,
+  money,
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+  onClick,
+  placeholder,
+  large,
+  inputType,
+  valid,
+  invalid,
+  invalidText,
+  disabled,
+}: Props & { ref?: Ref<HTMLInputElement> }) => {
+  const { t } = useTranslation();
 
-    const patternMatchingProps = usePatternMatching({
-      pattern: inputProps.pattern,
-    });
+  const patternMatchingProps = usePatternMatching({
+    pattern: inputProps.pattern,
+  });
 
-    function safeOnChange(val: string | number | null) {
-      if (
-        (typeof val === "string" && val.length === 0) ||
-        (typeof val === "number" && Number.isNaN(val))
-      ) {
-        onChange(null);
-      } else {
-        onChange(val);
-      }
+  function safeOnChange(val: string | number | null) {
+    if (
+      (typeof val === "string" && val.length === 0) ||
+      (typeof val === "number" && Number.isNaN(val))
+    ) {
+      onChange(null);
+    } else {
+      onChange(val);
     }
+  }
 
-    const isCurrencyInput = money && !!currencyConfig;
+  const isCurrencyInput = money && !!currencyConfig;
 
-    return (
-      <Root className={className}>
-        {isCurrencyInput ? (
-          <CurrencyInput
-            currencyConfig={currencyConfig}
-            placeholder={placeholder}
-            large={large}
-            value={value as number | null}
-            onChange={safeOnChange}
-          />
-        ) : (
-          <Input
-            placeholder={placeholder}
-            type={inputType}
-            ref={ref}
-            onChange={(e) => {
-              let value: string | number | null = e.target.value;
+  return (
+    <Root className={className}>
+      {isCurrencyInput ? (
+        <CurrencyInput
+          currencyConfig={currencyConfig}
+          placeholder={placeholder}
+          large={large}
+          value={value as number | null}
+          onChange={safeOnChange}
+        />
+      ) : (
+        <Input
+          placeholder={placeholder}
+          type={inputType}
+          ref={ref}
+          onChange={(e) => {
+            let value: string | number | null = e.target.value;
 
-              if (inputType === "number") {
-                value = parseFloat(value);
-              }
-
-              safeOnChange(value);
-            }}
-            value={exists(value) ? value : ""}
-            large={large}
-            disabled={disabled}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            onClick={onClick}
-            onWheel={
-              (e) =>
-                (
-                  e.target as HTMLElement
-                ).blur() /* to disable scrolling for number */
+            if (inputType === "number") {
+              value = parseFloat(value);
             }
-            {...inputProps}
-            {...patternMatchingProps}
+
+            safeOnChange(value);
+          }}
+          value={exists(value) ? value : ""}
+          large={large}
+          disabled={disabled}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          onClick={onClick}
+          onWheel={
+            (e) =>
+              (
+                e.target as HTMLElement
+              ).blur() /* to disable scrolling for number */
+          }
+          {...inputProps}
+          {...patternMatchingProps}
+        />
+      )}
+      {exists(value) && !isEmpty(value) && (
+        <>
+          {valid && !invalid && <GreenIcon icon={faCheck} large={large} />}
+          {invalid && (
+            <WithTooltip text={invalidText}>
+              <AbsoluteWrap>
+                <RedIcon icon={faExclamationTriangle} large={large} />
+              </AbsoluteWrap>
+            </WithTooltip>
+          )}
+          <ClearZoneIconButton
+            tiny
+            icon={faTimes}
+            tabIndex={-1}
+            disabled={disabled}
+            title={t("common.clearValue")}
+            aria-label={t("common.clearValue")}
+            onClick={() => onChange(null)}
           />
-        )}
-        {exists(value) && !isEmpty(value) && (
-          <>
-            {valid && !invalid && <GreenIcon icon={faCheck} large={large} />}
-            {invalid && (
-              <WithTooltip text={invalidText}>
-                <AbsoluteWrap>
-                  <RedIcon icon={faExclamationTriangle} large={large} />
-                </AbsoluteWrap>
-              </WithTooltip>
-            )}
-            <ClearZoneIconButton
-              tiny
-              icon={faTimes}
-              tabIndex={-1}
-              disabled={disabled}
-              title={t("common.clearValue")}
-              aria-label={t("common.clearValue")}
-              onClick={() => onChange(null)}
-            />
-          </>
-        )}
-      </Root>
-    );
-  },
-);
+        </>
+      )}
+    </Root>
+  );
+};
 
 export default BaseInput;

--- a/frontend/src/js/ui-components/Dropzone.tsx
+++ b/frontend/src/js/ui-components/Dropzone.tsx
@@ -1,10 +1,5 @@
 import styled from "@emotion/styled";
-import {
-  type ForwardedRef,
-  forwardRef,
-  type ReactElement,
-  type ReactNode,
-} from "react";
+import type { ReactNode, Ref } from "react";
 import { type DropTargetMonitor, useDrop } from "react-dnd";
 
 import { DNDType } from "../common/constants/dndTypes";
@@ -100,21 +95,19 @@ export const isMovedObject = (
   }
 };
 
-const Dropzone = <DroppableObject extends PossibleDroppableObject>(
-  {
-    className,
-    acceptedDropTypes,
-    naked,
-    transparent,
-    bare,
-    canDrop,
-    onDrop,
-    onClick,
-    invisible,
-    children,
-  }: DropzoneProps<DroppableObject>,
-  ref?: ForwardedRef<HTMLDivElement>,
-) => {
+const Dropzone = <DroppableObject extends PossibleDroppableObject>({
+  className,
+  acceptedDropTypes,
+  naked,
+  transparent,
+  bare,
+  canDrop,
+  onDrop,
+  onClick,
+  invisible,
+  children,
+  ref,
+}: DropzoneProps<DroppableObject> & { ref?: Ref<HTMLDivElement> }) => {
   /*  actually, not "any", but ChildArgs<DroppableObject>. But I can't get that to work in JSX */
   const [{ canDrop: canDropResult, isOver, item }, dropRef] = useDrop<
     DroppableObject,
@@ -167,10 +160,4 @@ const Dropzone = <DroppableObject extends PossibleDroppableObject>(
   );
 };
 
-export default forwardRef(Dropzone) as <
-  DroppableObject extends PossibleDroppableObject,
->(
-  props: DropzoneProps<DroppableObject> & {
-    ref?: ForwardedRef<HTMLDivElement>;
-  },
-) => ReactElement;
+export default Dropzone;

--- a/frontend/src/js/ui-components/DropzoneWithFileInput.tsx
+++ b/frontend/src/js/ui-components/DropzoneWithFileInput.tsx
@@ -1,14 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { faFileImport } from "@fortawesome/free-solid-svg-icons";
-import {
-  forwardRef,
-  type ReactElement,
-  type ReactNode,
-  type Ref,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, type Ref, useRef, useState } from "react";
 import type { DropTargetMonitor } from "react-dnd";
 import { NativeTypes } from "react-dnd-html5-backend";
 import { useTranslation } from "react-i18next";
@@ -88,25 +81,23 @@ interface PropsT<DroppableObject> {
 */
 const DropzoneWithFileInput = <
   DroppableObject extends PossibleDroppableObject = DragItemFile,
->(
-  {
-    onSelectFile,
-    onImportLines,
-    importPlaceholder,
-    importDescription,
-    importButtonOutside,
-    acceptedDropTypes,
-    disableClick,
-    showImportButton,
-    children,
-    onDrop,
-    isInitial,
-    className,
-    accept,
-    tight,
-  }: PropsT<DroppableObject>,
-  ref: Ref<HTMLDivElement>,
-) => {
+>({
+  onSelectFile,
+  onImportLines,
+  importPlaceholder,
+  importDescription,
+  importButtonOutside,
+  acceptedDropTypes,
+  disableClick,
+  showImportButton,
+  children,
+  onDrop,
+  isInitial,
+  className,
+  accept,
+  tight,
+  ref,
+}: PropsT<DroppableObject> & { ref?: Ref<HTMLDivElement> }) => {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -191,8 +182,4 @@ const DropzoneWithFileInput = <
   );
 };
 
-export default forwardRef(DropzoneWithFileInput) as <
-  DroppableObject extends PossibleDroppableObject = DragItemFile,
->(
-  p: PropsT<DroppableObject> & { ref?: Ref<HTMLDivElement> },
-) => ReactElement;
+export default DropzoneWithFileInput;

--- a/frontend/src/js/ui-components/InputDate/InputDate.tsx
+++ b/frontend/src/js/ui-components/InputDate/InputDate.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { faCalendar } from "@fortawesome/free-regular-svg-icons";
-import { createElement, forwardRef, useRef } from "react";
+import { createElement, type Ref, useRef } from "react";
 import ReactDatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { mergeRefs } from "react-merge-refs";
@@ -59,61 +59,64 @@ type Props = Omit<BaseInputProps, "inputType"> & {
   onCalendarSelect?: (val: string) => void;
 };
 
-const InputDate = forwardRef<ReactDatePicker, Props>(
-  (
-    { className, value, dateFormat, onChange, onCalendarSelect, ...props },
-    ref,
-  ) => {
-    const datePickerRef = useRef<ReactDatePicker>(null);
+const InputDate = ({
+  ref,
+  className,
+  value,
+  dateFormat,
+  onChange,
+  onCalendarSelect,
+  ...props
+}: Props & { ref?: Ref<ReactDatePicker> }) => {
+  const datePickerRef = useRef<ReactDatePicker>(null);
 
-    return (
-      <Root
-        className={className}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") datePickerRef.current?.setOpen(false);
+  return (
+    <Root
+      className={className}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") datePickerRef.current?.setOpen(false);
+      }}
+    >
+      <StyledBaseInput
+        {...props}
+        inputType="text"
+        value={value}
+        onChange={(val) => {
+          onChange(val as string);
         }}
-      >
-        <StyledBaseInput
-          {...props}
-          inputType="text"
-          value={value}
-          onChange={(val) => {
-            onChange(val as string);
-          }}
-          inputProps={{
-            ...props?.inputProps,
-            onKeyPress: (e) => {
-              datePickerRef.current?.setOpen(false);
-              props.inputProps?.onKeyPress?.(e);
-            },
-          }}
-        />
-        <CalendarButton
-          icon={faCalendar}
-          onClick={() => datePickerRef.current?.setOpen(true)}
-        />
-        <ReactDatePicker
-          ref={mergeRefs([datePickerRef, ref])}
-          selected={value ? parseDate(value, dateFormat) : new Date()}
-          onChange={(val: Date | null) => {
-            if (!val) {
-              return;
-            }
-
-            const selectedDate = formatDate(val, dateFormat);
-            onChange(selectedDate);
-            onCalendarSelect?.(selectedDate);
+        inputProps={{
+          ...props?.inputProps,
+          onKeyPress: (e) => {
             datePickerRef.current?.setOpen(false);
-          }}
-          onClickOutside={() => datePickerRef.current?.setOpen(false)}
-          renderCustomHeader={CustomHeader}
-          customInput={createElement(HiddenInput)}
-          calendarContainer={StyledCalendar}
-          calendarStartDay={1}
-        />
-      </Root>
-    );
-  },
-);
+            props.inputProps?.onKeyPress?.(e);
+          },
+        }}
+      />
+      <CalendarButton
+        icon={faCalendar}
+        onClick={() => datePickerRef.current?.setOpen(true)}
+      />
+      <ReactDatePicker
+        ref={mergeRefs([datePickerRef, ref])}
+        selected={value ? parseDate(value, dateFormat) : new Date()}
+        onChange={(val: Date | null) => {
+          if (!val) {
+            return;
+          }
+
+          const selectedDate = formatDate(val, dateFormat);
+          onChange(selectedDate);
+          onCalendarSelect?.(selectedDate);
+          datePickerRef.current?.setOpen(false);
+        }}
+        onClickOutside={() => datePickerRef.current?.setOpen(false)}
+        renderCustomHeader={CustomHeader}
+        customInput={createElement(HiddenInput)}
+        calendarContainer={StyledCalendar}
+        calendarStartDay={1}
+      />
+    </Root>
+  );
+};
 
 export default InputDate;

--- a/frontend/src/js/ui-components/InputMultiSelect/SelectedItem.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/SelectedItem.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
-import { forwardRef, memo } from "react";
+import { memo, type Ref } from "react";
 import ReactMarkdown from "react-markdown";
 
 import type { SelectOptionT } from "../../api/types";
@@ -28,45 +28,46 @@ const SxIconButton = styled(IconButton)`
   padding: 1px 2px 1px 5px;
 `;
 
-const SelectedItem = forwardRef<
-  HTMLDivElement,
-  {
-    active?: boolean;
-    disabled?: boolean;
-    item: SelectOptionT;
+const SelectedItem = ({
+  ref,
+  index,
+  item,
+  disabled,
+  removeSelectedItem,
+  getSelectedItemProps,
+}: {
+  ref?: Ref<HTMLDivElement>;
+
+  active?: boolean;
+  disabled?: boolean;
+  item: SelectOptionT;
+  index: number;
+  getSelectedItemProps: (props: {
+    selectedItem: SelectOptionT;
     index: number;
-    getSelectedItemProps: (props: {
-      selectedItem: SelectOptionT;
-      index: number;
-    }) => object;
-    removeSelectedItem: (item: SelectOptionT) => void;
-  }
->(
-  (
-    { index, item, disabled, removeSelectedItem, getSelectedItemProps },
-    ref,
-  ) => {
-    const label = item.selectedLabel || item.label || item.value;
+  }) => object;
+  removeSelectedItem: (item: SelectOptionT) => void;
+}) => {
+  const label = item.selectedLabel || item.label || item.value;
 
-    const selectedItemProps = getSelectedItemProps({
-      selectedItem: item,
-      index,
-    });
+  const selectedItemProps = getSelectedItemProps({
+    selectedItem: item,
+    index,
+  });
 
-    return (
-      <Container ref={ref} {...selectedItemProps}>
-        <ReactMarkdown>{String(label)}</ReactMarkdown>
-        <SxIconButton
-          icon={faTimes}
-          disabled={disabled}
-          onClick={(e) => {
-            e.stopPropagation(); // otherwise the click handler on the Container overrides this
-            removeSelectedItem(item);
-          }}
-        />
-      </Container>
-    );
-  },
-);
+  return (
+    <Container ref={ref} {...selectedItemProps}>
+      <ReactMarkdown>{String(label)}</ReactMarkdown>
+      <SxIconButton
+        icon={faTimes}
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation(); // otherwise the click handler on the Container overrides this
+          removeSelectedItem(item);
+        }}
+      />
+    </Container>
+  );
+};
 
 export default memo(SelectedItem);

--- a/frontend/src/js/ui-components/InputPlain/InputPlain.tsx
+++ b/frontend/src/js/ui-components/InputPlain/InputPlain.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { forwardRef } from "react";
+import type { Ref } from "react";
 
 import type { CurrencyConfigT } from "../../api/types";
 import BaseInput from "../BaseInput";
@@ -33,53 +33,49 @@ interface Props {
   tooltip?: string;
 }
 
-const InputPlain = forwardRef<HTMLInputElement, Props>(
-  (
-    {
-      className,
-      fullWidth,
-      label,
-      tinyLabel,
-      large,
-      indexPrefix,
-      tooltip,
-      inputType = "text",
-      money,
-      placeholder,
-      value,
-      onChange,
-      onBlur,
-      currencyConfig,
-      inputProps,
-    },
-    ref,
-  ) => {
-    return (
-      <Labeled
-        className={className}
+const InputPlain = ({
+  ref,
+  className,
+  fullWidth,
+  label,
+  tinyLabel,
+  large,
+  indexPrefix,
+  tooltip,
+  inputType = "text",
+  money,
+  placeholder,
+  value,
+  onChange,
+  onBlur,
+  currencyConfig,
+  inputProps,
+}: Props & { ref?: Ref<HTMLInputElement> }) => {
+  return (
+    <Labeled
+      className={className}
+      fullWidth={fullWidth}
+      label={label}
+      tinyLabel={tinyLabel}
+      largeLabel={large}
+      indexPrefix={indexPrefix}
+      tooltip={tooltip}
+    >
+      <SxBaseInput
+        ref={ref}
+        large={large}
         fullWidth={fullWidth}
-        label={label}
-        tinyLabel={tinyLabel}
-        largeLabel={large}
-        indexPrefix={indexPrefix}
-        tooltip={tooltip}
-      >
-        <SxBaseInput
-          ref={ref}
-          large={large}
-          fullWidth={fullWidth}
-          inputType={inputType}
-          money={money}
-          placeholder={placeholder}
-          value={value}
-          onChange={onChange}
-          onBlur={onBlur}
-          currencyConfig={currencyConfig}
-          inputProps={inputProps}
-        />
-      </Labeled>
-    );
-  },
-);
+        inputType={inputType}
+        money={money}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        currencyConfig={currencyConfig}
+        inputProps={inputProps}
+      />
+    </Labeled>
+  );
+};
 
 export default InputPlain;

--- a/frontend/src/js/ui-components/InputSelect/SelectListOption.tsx
+++ b/frontend/src/js/ui-components/InputSelect/SelectListOption.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { forwardRef, memo } from "react";
+import { memo, type Ref } from "react";
 import ReactMarkdown from "react-markdown";
 
 import type { SelectOptionT } from "../../api/types";
@@ -38,20 +38,22 @@ interface Props extends StyleProps {
   option: SelectOptionT;
 }
 
-const SelectListOption = forwardRef<HTMLDivElement, Props>(
-  ({ option, ...props }, ref) => {
-    const label = option.label || String(option.value);
+const SelectListOption = ({
+  ref,
+  option,
+  ...props
+}: Props & { ref?: Ref<HTMLDivElement> }) => {
+  const label = option.label || String(option.value);
 
-    return (
-      <Container {...props} disabled={option.disabled} ref={ref}>
-        {option.displayLabel ? (
-          option.displayLabel
-        ) : (
-          <ReactMarkdown>{label}</ReactMarkdown>
-        )}
-      </Container>
-    );
-  },
-);
+  return (
+    <Container {...props} disabled={option.disabled} ref={ref}>
+      {option.displayLabel ? (
+        option.displayLabel
+      ) : (
+        <ReactMarkdown>{label}</ReactMarkdown>
+      )}
+    </Container>
+  );
+};
 
 export default memo(SelectListOption);

--- a/frontend/src/js/ui-components/InputTextarea/InputTextarea.tsx
+++ b/frontend/src/js/ui-components/InputTextarea/InputTextarea.tsx
@@ -1,10 +1,6 @@
 import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
-import {
-  type DetailedHTMLProps,
-  forwardRef,
-  type TextareaHTMLAttributes,
-} from "react";
+import type { DetailedHTMLProps, Ref, TextareaHTMLAttributes } from "react";
 import { useTranslation } from "react-i18next";
 
 import IconButton from "../../button/IconButton";
@@ -47,10 +43,15 @@ type InputTextareaProps = DetailedHTMLProps<
   HTMLTextAreaElement
 >;
 
-export const InputTextarea = forwardRef<
-  HTMLTextAreaElement,
-  InputTextareaProps & OtherProps
->(({ label, className, indexPrefix, tooltip, onChange, ...props }, ref) => {
+export const InputTextarea = ({
+  ref,
+  label,
+  className,
+  indexPrefix,
+  tooltip,
+  onChange,
+  ...props
+}: InputTextareaProps & OtherProps & { ref?: Ref<HTMLTextAreaElement> }) => {
   const { t } = useTranslation();
 
   return (
@@ -83,4 +84,4 @@ export const InputTextarea = forwardRef<
       </Root>
     </Labeled>
   );
-});
+};

--- a/frontend/src/js/ui-components/Labeled.tsx
+++ b/frontend/src/js/ui-components/Labeled.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { forwardRef, type ReactNode } from "react";
+import type { ReactNode, Ref } from "react";
 
 import { IndexPrefix } from "../common/components/IndexPrefix";
 import { exists } from "../common/helpers/exists";
@@ -31,37 +31,33 @@ interface Props {
   htmlFor?: string;
 }
 
-const Labeled = forwardRef<HTMLLabelElement, Props>(
-  (
-    {
-      indexPrefix,
-      className,
-      fullWidth,
-      label,
-      tinyLabel,
-      largeLabel,
-      tooltip,
-      htmlFor,
-      children,
-    },
-    ref,
-  ) => {
-    return (
-      <Root
-        ref={ref}
-        className={className}
-        fullWidth={fullWidth}
-        htmlFor={htmlFor}
-      >
-        <Label fullWidth={fullWidth} tiny={tinyLabel} large={largeLabel}>
-          {exists(indexPrefix) && <IndexPrefix># {indexPrefix}</IndexPrefix>}
-          {label}
-          {exists(tooltip) && <InfoTooltip text={tooltip} />}
-        </Label>
-        {children}
-      </Root>
-    );
-  },
-);
+const Labeled = ({
+  ref,
+  indexPrefix,
+  className,
+  fullWidth,
+  label,
+  tinyLabel,
+  largeLabel,
+  tooltip,
+  htmlFor,
+  children,
+}: Props & { ref?: Ref<HTMLLabelElement> }) => {
+  return (
+    <Root
+      ref={ref}
+      className={className}
+      fullWidth={fullWidth}
+      htmlFor={htmlFor}
+    >
+      <Label fullWidth={fullWidth} tiny={tinyLabel} large={largeLabel}>
+        {exists(indexPrefix) && <IndexPrefix># {indexPrefix}</IndexPrefix>}
+        {label}
+        {exists(tooltip) && <InfoTooltip text={tooltip} />}
+      </Label>
+      {children}
+    </Root>
+  );
+};
 
 export default Labeled;


### PR DESCRIPTION
Stacked on #3981.

- react 19: `ref` is a plain prop, `forwardRef` deprecated → `({ ref, ...}: Props & { ref?: Ref<El> })`
- generic `Dropzone` / `DropzoneWithFileInput` / `DropzoneList` lose the `forwardRef(X) as <T>(…) => ReactElement` cast, plain generic components now
- `FaIcon` keeps its `@ts-ignore` on ref: emotion's `styled(FontAwesomeIcon)` intersects two incompatible ref types, goes away with the emotion removal

No runtime change. biome, tsc, vitest, build green.
