### PR TITLE
refactor(frontend): ui-components on tailwind-variants

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -143,3 +143,22 @@ div[data-tippy-root] {
     border-color: var(--color-gray-200, currentcolor);
   }
 }
+
+/* react-datepicker inside InputDate */
+.conquery-datepicker {
+  .react-datepicker-wrapper {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: -1;
+  }
+  .react-datepicker-popper[data-placement^="bottom"] {
+    padding-top: 4px;
+  }
+  .react-datepicker-popper[data-placement^="top"] {
+    padding-bottom: 0;
+  }
+  .react-datepicker__day--selected {
+    background: var(--color-primary-500);
+  }
+}

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   faCheck,
   faExclamationTriangle,
@@ -11,6 +10,7 @@ import {
   useCallback,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { CurrencyConfigT } from "../api/types";
 import IconButton from "../button/IconButton";
@@ -21,56 +21,41 @@ import WithTooltip from "../tooltip/WithTooltip";
 
 import CurrencyInput from "./CurrencyInput";
 
-const Root = styled("div")`
-  position: relative;
-`;
+const root = tv({ base: "relative" });
 
-const Input = styled("input")<{ large?: boolean; disabled?: boolean }>`
-  outline: 0;
-  width: 100%;
-  opacity: ${({ disabled }) => (disabled ? 0.5 : 1)};
+const input = tv({
+  base: [
+    "outline-0",
+    "w-full",
+    "border border-gray-400",
+    "rounded",
+    "py-[6px] pr-[30px] pl-[10px]",
+    "text-sm",
+    "font-normal",
+  ],
+  variants: {
+    large: { true: "py-[10px] pr-[30px] pl-[14px] text-xl" },
+    disabled: { true: "opacity-50" },
+  },
+});
 
-  border: 1px solid ${({ theme }) => theme.col.grayMediumLight};
-  padding: ${({ large }) =>
-    large ? "10px 30px 10px 14px" : "6px 30px 6px 10px"};
-  font-size: ${({ theme, large }) => (large ? theme.font.lg : theme.font.sm)};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  font-weight: 400;
-`;
+const greenIcon = tv({
+  base: ["absolute top-2 right-[35px]", "opacity-80", "text-green"],
+});
 
-const SignalIcon = styled(FaIcon)`
-  position: absolute;
-  top: 8px;
-  right: 35px;
-  opacity: 0.8;
-`;
+const redIcon = tv({ base: ["opacity-80", "text-red"] });
 
-const GreenIcon = styled(SignalIcon)`
-  color: ${({ theme }) => theme.col.green};
-`;
-const RedIcon = styled(FaIcon)`
-  color: ${({ theme }) => theme.col.red};
-  opacity: 0.8;
-`;
-const AbsoluteWrap = styled("div")`
-  position: absolute;
-  top: 5px;
-  right: 35px;
-`;
+const absoluteWrap = tv({ base: "absolute top-[5px] right-[35px]" });
 
-const ClearZoneIconButton = styled(IconButton)`
-  position: absolute;
-  top: 0;
-  right: 10px;
-  cursor: pointer;
-  height: 100%;
-  display: flex;
-  align-items: center;
-
-  &:hover {
-    color: ${({ theme }) => theme.col.red};
-  }
-`;
+const clearZoneIconButton = tv({
+  base: [
+    "absolute top-0 right-[10px]",
+    "h-full",
+    "flex items-center",
+    "cursor-pointer",
+    "hover:text-red",
+  ],
+});
 
 interface InputProps {
   autoFocus?: boolean;
@@ -160,7 +145,7 @@ const BaseInput = ({
   const isCurrencyInput = money && !!currencyConfig;
 
   return (
-    <Root className={className}>
+    <div className={root({ className })}>
       {isCurrencyInput ? (
         <CurrencyInput
           currencyConfig={currencyConfig}
@@ -170,7 +155,8 @@ const BaseInput = ({
           onChange={safeOnChange}
         />
       ) : (
-        <Input
+        <input
+          className={input({ large, disabled })}
           placeholder={placeholder}
           type={inputType}
           ref={ref}
@@ -184,7 +170,6 @@ const BaseInput = ({
             safeOnChange(value);
           }}
           value={exists(value) ? value : ""}
-          large={large}
           disabled={disabled}
           onFocus={onFocus}
           onBlur={onBlur}
@@ -201,15 +186,22 @@ const BaseInput = ({
       )}
       {exists(value) && !isEmpty(value) && (
         <>
-          {valid && !invalid && <GreenIcon icon={faCheck} large={large} />}
+          {valid && !invalid && (
+            <FaIcon icon={faCheck} large={large} className={greenIcon()} />
+          )}
           {invalid && (
             <WithTooltip text={invalidText}>
-              <AbsoluteWrap>
-                <RedIcon icon={faExclamationTriangle} large={large} />
-              </AbsoluteWrap>
+              <div className={absoluteWrap()}>
+                <FaIcon
+                  icon={faExclamationTriangle}
+                  large={large}
+                  className={redIcon()}
+                />
+              </div>
             </WithTooltip>
           )}
-          <ClearZoneIconButton
+          <IconButton
+            className={clearZoneIconButton()}
             tiny
             icon={faTimes}
             tabIndex={-1}
@@ -220,7 +212,7 @@ const BaseInput = ({
           />
         </>
       )}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/CurrencyInput.tsx
+++ b/frontend/src/js/ui-components/CurrencyInput.tsx
@@ -1,22 +1,28 @@
-import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
-import { NumericFormat } from "react-number-format";
+import {
+  type InputAttributes,
+  NumericFormat,
+  type NumericFormatProps,
+} from "react-number-format";
+import { tv } from "tailwind-variants";
 
 import type { CurrencyConfigT } from "../api/types";
 import { isEmpty } from "../common/helpers/commonHelper";
 import { exists } from "../common/helpers/exists";
 
-const SxNumberFormat = styled(NumericFormat)<{ large?: boolean }>`
-  outline: 0;
-  min-width: 170px;
-
-  border: 1px solid ${({ theme }) => theme.col.grayMediumLight};
-  font-size: ${({ theme }) => theme.font.md};
-  padding: ${({ large }) =>
-    large ? "10px 30px 10px 14px" : "8px 30px 8px 10px"};
-  font-size: ${({ theme, large }) => (large ? theme.font.lg : theme.font.sm)};
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
+const numberFormat = tv({
+  base: [
+    "outline-0",
+    "min-w-[170px]",
+    "border border-gray-400",
+    "rounded",
+    "py-2 pr-[30px] pl-[10px]",
+    "text-sm",
+  ],
+  variants: {
+    large: { true: "py-[10px] pr-[30px] pl-[14px] text-xl" },
+  },
+});
 
 const CurrencyInput = ({
   currencyConfig,
@@ -46,25 +52,27 @@ const CurrencyInput = ({
       setNumberFormatValue("");
     }
   }, [value]);
-  return (
-    <SxNumberFormat
-      {...currencyConfig}
-      suffix={` ${currencyConfig?.unit}`}
-      placeholder={placeholder}
-      type="text"
-      value={numberFormatValue}
-      large={large}
-      onValueChange={(values) => {
-        if (exists(values.floatValue) && !Number.isNaN(values.floatValue)) {
-          setNumberFormatValue(values.floatValue);
-          onChange(parseInt((values.floatValue * factor).toFixed(0), 10));
-        } else {
-          setNumberFormatValue("");
-          onChange(null);
-        }
-      }}
-    />
-  );
+  // typed up front with an explicit base type: the polymorphic NumericFormat
+  // props are otherwise too complex a union for tsc
+  const props: NumericFormatProps = {
+    ...currencyConfig,
+    className: numberFormat({ large }),
+    suffix: ` ${currencyConfig?.unit}`,
+    placeholder,
+    type: "text",
+    value: numberFormatValue,
+    onValueChange: (values) => {
+      if (exists(values.floatValue) && !Number.isNaN(values.floatValue)) {
+        setNumberFormatValue(values.floatValue);
+        onChange(parseInt((values.floatValue * factor).toFixed(0), 10));
+      } else {
+        setNumberFormatValue("");
+        onChange(null);
+      }
+    },
+  };
+
+  return <NumericFormat<InputAttributes> {...props} />;
 };
 
 export default CurrencyInput;

--- a/frontend/src/js/ui-components/Dropzone.tsx
+++ b/frontend/src/js/ui-components/Dropzone.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import type { ReactNode, Ref } from "react";
 import { type DropTargetMonitor, useDrop } from "react-dnd";
+import { tv } from "tailwind-variants";
 
 import { DNDType } from "../common/constants/dndTypes";
 import { exists } from "../common/helpers/exists";
@@ -12,43 +12,30 @@ import type {
 
 import type { DragItemFile } from "./DropzoneWithFileInput";
 
-const Root = styled("div")<{
-  isOver?: boolean;
-  naked?: boolean;
-  bare?: boolean;
-  transparent?: boolean;
-  canDrop?: boolean;
-  invisible?: boolean;
-}>`
-  border: ${({ theme, isOver, canDrop, naked }) =>
-    naked
-      ? "none"
-      : isOver && !canDrop
-        ? `3px solid ${theme.col.red}`
-        : isOver
-          ? `3px solid ${theme.col.black}`
-          : `3px dashed ${theme.col.grayMediumLight}`};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  padding: ${({ bare }) => (bare ? "0" : "10px")};
-  display: ${({ invisible }) => (invisible ? "none" : "flex")};
-  align-items: center;
-  justify-content: center;
-  background-color: ${({ theme, canDrop, naked, isOver, transparent }) =>
-    naked && isOver && canDrop
-      ? theme.col.grayLight
-      : canDrop
-        ? theme.col.grayVeryLight
-        : transparent
-          ? "transparent"
-          : theme.col.bg};
-  width: 100%;
-  color: ${({ theme, isOver, canDrop }) =>
-    isOver && !canDrop
-      ? theme.col.red
-      : isOver
-        ? theme.col.black
-        : theme.col.gray};
-`;
+const root = tv({
+  base: [
+    "flex items-center justify-center",
+    "w-full",
+    "p-[10px]",
+    "rounded",
+    "border-[3px] border-dashed border-gray-400",
+    "bg-bg-50",
+    "text-gray-500",
+  ],
+  variants: {
+    bare: { true: "p-0" },
+    invisible: { true: "hidden" },
+    // later wins when several are set
+    transparent: { true: "bg-transparent" },
+    canDrop: { true: "bg-gray-50" },
+    isOver: { true: "border-solid border-gray-800 text-gray-800" },
+    naked: { true: "border-none" },
+  },
+  compoundVariants: [
+    { isOver: true, canDrop: false, class: "border-red text-red" },
+    { naked: true, isOver: true, canDrop: true, class: "bg-gray-100" },
+  ],
+});
 
 export interface ChildArgs<DroppableObject> {
   isOver: boolean;
@@ -129,7 +116,9 @@ const Dropzone = <DroppableObject extends PossibleDroppableObject>({
   });
 
   return (
-    <Root
+    // biome-ignore lint/a11y/noStaticElementInteractions: drop target, click opens a file dialog
+    // biome-ignore lint/a11y/useKeyWithClickEvents: drop target, click opens a file dialog
+    <div
       ref={(instance) => {
         dropRef(instance);
 
@@ -142,21 +131,23 @@ const Dropzone = <DroppableObject extends PossibleDroppableObject>({
           }
         }
       }}
-      isOver={isOver}
-      invisible={invisible && !canDropResult}
-      canDrop={canDropResult}
-      className={className}
+      className={root({
+        isOver,
+        invisible: !!invisible && !canDropResult,
+        canDrop: canDropResult,
+        naked,
+        transparent,
+        bare,
+        className,
+      })}
       onClick={onClick}
-      naked={naked}
-      transparent={transparent}
-      bare={bare}
     >
       {children?.({
         isOver,
         canDrop: canDropResult,
         item: item as DroppableObject, // Casting because see comment above
       })}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/DropzoneWithFileInput.tsx
+++ b/frontend/src/js/ui-components/DropzoneWithFileInput.tsx
@@ -1,10 +1,9 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
 import { faFileImport } from "@fortawesome/free-solid-svg-icons";
 import { type ReactNode, type Ref, useRef, useState } from "react";
 import type { DropTargetMonitor } from "react-dnd";
 import { NativeTypes } from "react-dnd-html5-backend";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import { SelectFileButton } from "../button/SelectFileButton";
 import FaIcon from "../icon/FaIcon";
@@ -20,37 +19,32 @@ export interface DragItemFile {
   files: File[];
 }
 
-const FileInput = styled("input")`
-  display: none;
-`;
+const dropzone = tv({
+  base: [
+    "relative",
+    "cursor-pointer",
+    "transition-shadow duration-100",
+    "hover:shadow-[0_0_5px_0_rgba(0,0,0,0.2)]",
+  ],
+  variants: {
+    isInitial: { true: "cursor-[initial]" },
+    tight: { true: "p-[5px]" },
+  },
+});
 
-const SxDropzone = styled(Dropzone)<{ isInitial?: boolean; tight?: boolean }>`
-  cursor: ${({ isInitial }) => (isInitial ? "initial" : "pointer")};
-  transition: box-shadow ${({ theme }) => theme.transitionTime};
-  position: relative;
-  ${({ tight }) =>
-    tight &&
-    css`
-      padding: 5px;
-    `}
+const selectFileButton = tv({
+  base: "absolute",
+  variants: {
+    outside: {
+      true: "-top-[26px] -right-[12px]",
+      false: "top-[3px] right-0",
+    },
+  },
+});
 
-  &:hover {
-    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
-  }
-`;
-
-const SxSelectFileButton = styled(SelectFileButton, {
-  shouldForwardProp: (prop) => prop !== "outside",
-})<{ outside?: boolean }>`
-  position: absolute;
-  top: ${({ outside }) => (outside ? "-26px" : "3px")};
-  right: ${({ outside }) => (outside ? "-12px" : "0")};
-`;
-
-const SxFaIcon = styled(FaIcon)`
-  height: 10px;
-  padding-right: 3px;
-`;
+const importIcon = tv({
+  base: ["h-[10px]", "pr-[3px]"],
+});
 
 interface PropsT<DroppableObject> {
   children: (args: ChildArgs<DroppableObject>) => ReactNode;
@@ -118,8 +112,7 @@ const DropzoneWithFileInput = <
   }
 
   return (
-    <SxDropzone
-      tight={tight}
+    <Dropzone
       acceptedDropTypes={dropTypes}
       onClick={() => {
         if (disableClick) return;
@@ -138,8 +131,7 @@ const DropzoneWithFileInput = <
 
         onDrop(item as DroppableObject | DragItemFile, monitor);
       }}
-      isInitial={isInitial}
-      className={className}
+      className={dropzone({ isInitial, tight, className })}
       ref={ref}
     >
       {(args) => (
@@ -153,16 +145,17 @@ const DropzoneWithFileInput = <
             />
           )}
           {showImportButton && onImportLines && (
-            <SxSelectFileButton
-              outside={importButtonOutside}
+            <SelectFileButton
+              className={selectFileButton({ outside: !!importButtonOutside })}
               onClick={() => setImportModalOpen(true)}
             >
-              <SxFaIcon icon={faFileImport} gray />
+              <FaIcon icon={faFileImport} gray className={importIcon()} />
               {t("common.import")}
-            </SxSelectFileButton>
+            </SelectFileButton>
           )}
           {onSelectFile && (
-            <FileInput
+            <input
+              className="hidden"
               ref={fileInputRef}
               type="file"
               accept={accept}
@@ -180,7 +173,7 @@ const DropzoneWithFileInput = <
           {children(args as ChildArgs<DroppableObject>)}
         </>
       )}
-    </SxDropzone>
+    </Dropzone>
   );
 };
 

--- a/frontend/src/js/ui-components/EditableTagsForm.tsx
+++ b/frontend/src/js/ui-components/EditableTagsForm.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { faCheck, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { type FormEvent, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { SelectOptionT } from "../api/types";
 import IconButton from "../button/IconButton";
@@ -10,20 +10,17 @@ import WithTooltip from "../tooltip/WithTooltip";
 
 import InputMultiSelect from "./InputMultiSelect/InputMultiSelect";
 
-const Form = styled("form")`
-  display: flex;
-  align-items: flex-start;
-`;
+const form = tv({
+  base: "flex items-start",
+});
 
-const SxIconButton = styled(IconButton)`
-  padding: 7px 10px;
-  margin-left: 3px;
-`;
+const saveButton = tv({
+  base: ["ml-[3px]", "px-[10px] py-[7px]"],
+});
 
-const SxInputMultiSelect = styled(InputMultiSelect)`
-  z-index: 2;
-  flex-grow: 1;
-`;
+const multiSelect = tv({
+  base: ["z-2", "grow"],
+});
 
 const EditableTagsForm = ({
   className,
@@ -60,8 +57,9 @@ const EditableTagsForm = ({
   }
 
   return (
-    <Form ref={ref} className={className} onSubmit={submit}>
-      <SxInputMultiSelect
+    <form ref={ref} className={form({ className })} onSubmit={submit}>
+      <InputMultiSelect
+        className={multiSelect()}
         creatable
         autoFocus
         label={label}
@@ -74,14 +72,15 @@ const EditableTagsForm = ({
         placeholder={t("inputMultiSelect.tagPlaceholder")}
       />
       <WithTooltip text={t("common.save")}>
-        <SxIconButton
+        <IconButton
+          className={saveButton()}
           type="submit"
           frame
           disabled={!!loading}
           icon={loading ? faSpinner : faCheck}
         />
       </WithTooltip>
-    </Form>
+    </form>
   );
 };
 

--- a/frontend/src/js/ui-components/EditableText.tsx
+++ b/frontend/src/js/ui-components/EditableText.tsx
@@ -1,5 +1,6 @@
-import styled from "@emotion/styled";
 import { faPen } from "@fortawesome/free-solid-svg-icons";
+import { tv } from "tailwind-variants";
+
 import IconButton from "../button/IconButton";
 import { Highlighter } from "../common/components/Highlighter";
 import HighlightableLabel from "../highlightable-label/HighlightableLabel";
@@ -7,28 +8,29 @@ import WithTooltip from "../tooltip/WithTooltip";
 
 import EditableTextForm from "./EditableTextForm";
 
-const SxIconButton = styled(IconButton)`
-  margin-right: ${({ large }) => (large ? "10px" : "8px")};
-  padding: 2px 0;
-`;
+const editButton = tv({
+  base: ["px-0 py-[2px]"],
+  variants: {
+    large: {
+      true: "mr-[10px]",
+      false: "mr-2",
+    },
+  },
+});
 
-const Text = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
+const text = tv({
+  base: "flex flex-row items-center",
+});
 
-const SxHighlightableLabel = styled(HighlightableLabel)`
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-`;
+const label = tv({
+  base: ["overflow-hidden", "text-ellipsis", "whitespace-nowrap"],
+});
 
 const EditableText = ({
   className,
   loading,
   editing,
-  text,
+  text: textValue,
   tooltip,
   large,
   saveOnClickoutside,
@@ -55,16 +57,17 @@ const EditableText = ({
     <EditableTextForm
       className={className}
       loading={loading}
-      text={text}
+      text={textValue}
       selectTextOnMount={selectTextOnMount}
       saveOnClickoutside={saveOnClickoutside}
       onSubmit={onSubmit}
       onCancel={onToggleEdit}
     />
   ) : (
-    <Text className={className}>
+    <div className={text({ className })}>
       <WithTooltip text={tooltip}>
-        <SxIconButton
+        <IconButton
+          className={editButton({ large: !!large })}
           bare
           icon={faPen}
           onClick={onToggleEdit}
@@ -72,14 +75,17 @@ const EditableText = ({
           large={large}
         />
       </WithTooltip>
-      <SxHighlightableLabel isHighlighted={isHighlighted}>
+      <HighlightableLabel className={label()} isHighlighted={isHighlighted}>
         {highlightedWords && highlightedWords.length > 0 ? (
-          <Highlighter searchWords={highlightedWords} textToHighlight={text} />
+          <Highlighter
+            searchWords={highlightedWords}
+            textToHighlight={textValue}
+          />
         ) : (
-          text
+          textValue
         )}
-      </SxHighlightableLabel>
-    </Text>
+      </HighlightableLabel>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/EditableTextForm.tsx
+++ b/frontend/src/js/ui-components/EditableTextForm.tsx
@@ -1,29 +1,23 @@
-import styled from "@emotion/styled";
 import { faCheck, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { type FormEvent, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
 import { useClickOutside } from "../common/helpers/useClickOutside";
 import WithTooltip from "../tooltip/WithTooltip";
 
-const Input = styled("input")`
-  font-size: ${({ theme }) => theme.font.sm};
-  padding: 0 8px;
-  height: 28px;
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
+const input = tv({
+  base: ["h-[28px]", "px-2", "rounded", "border border-gray-500", "text-sm"],
+});
 
-const Form = styled("form")`
-  display: flex;
-  align-items: center;
-`;
+const form = tv({
+  base: "flex items-center",
+});
 
-const SxIconButton = styled(IconButton)`
-  padding: 6px 10px;
-  margin-left: 3px;
-`;
+const saveButton = tv({
+  base: ["ml-[3px]", "px-[10px] py-[6px]"],
+});
 
 const EditableTextForm = ({
   className,
@@ -56,8 +50,9 @@ const EditableTextForm = ({
   useClickOutside(ref, saveOnClickoutside ? () => onSubmit(value) : onCancel);
 
   return (
-    <Form ref={ref} className={className} onSubmit={onSubmitForm}>
-      <Input
+    <form ref={ref} className={form({ className })} onSubmit={onSubmitForm}>
+      <input
+        className={input()}
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
@@ -73,7 +68,8 @@ const EditableTextForm = ({
       />
       {!saveOnClickoutside && (
         <WithTooltip text={t("common.save")}>
-          <SxIconButton
+          <IconButton
+            className={saveButton()}
             type="submit"
             frame
             disabled={loading}
@@ -81,7 +77,7 @@ const EditableTextForm = ({
           />
         </WithTooltip>
       )}
-    </Form>
+    </form>
   );
 };
 

--- a/frontend/src/js/ui-components/ImportModal.tsx
+++ b/frontend/src/js/ui-components/ImportModal.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { faFile, faPaste } from "@fortawesome/free-solid-svg-icons";
 import {
   type ChangeEvent,
@@ -10,6 +9,7 @@ import {
 import { NativeTypes } from "react-dnd-html5-backend";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
 import PrimaryButton from "../button/PrimaryButton";
@@ -20,32 +20,21 @@ import DropzoneWithFileInput, {
   type DragItemFile,
 } from "./DropzoneWithFileInput";
 
-const Content = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-`;
+const content = tv({
+  base: ["flex flex-col", "gap-5"],
+});
 
-const Row = styled("div")`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 10px;
-`;
+const row = tv({
+  base: ["flex items-center justify-end", "gap-[10px]"],
+});
 
-const Textarea = styled("textarea")`
-  font-family: monospace;
-  width: 100%;
-`;
+const textarea = tv({
+  base: ["font-mono", "w-full"],
+});
 
-const HiddenFileInput = styled("input")`
-  display: none;
-`;
-
-const Subtitle = styled(`p`)`
-  margin: 0;
-  max-width: 600px;
-`;
+const subtitle = tv({
+  base: ["m-0", "max-w-[600px]"],
+});
 
 const acceptedDropTypes = [NativeTypes.FILE];
 
@@ -161,10 +150,13 @@ export const ImportModal = ({
       subtitle={t("importModal.subtitle")}
       onClose={onClose}
     >
-      <Content>
+      <div className={content()}>
         {description && (
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: description is our own i18n text
-          <Subtitle dangerouslySetInnerHTML={{ __html: description }} />
+          <p
+            className={subtitle()}
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: description is our own i18n text
+            dangerouslySetInnerHTML={{ __html: description }}
+          />
         )}
         <DropzoneWithFileInput
           onDrop={onDrop}
@@ -173,7 +165,8 @@ export const ImportModal = ({
           accept="text/plain,text/csv"
         >
           {() => (
-            <Textarea
+            <textarea
+              className={textarea()}
               rows={15}
               value={textInput}
               onChange={onChange}
@@ -181,7 +174,7 @@ export const ImportModal = ({
             />
           )}
         </DropzoneWithFileInput>
-        <Row>
+        <div className={row()}>
           <IconButton icon={faFile} onClick={onOpenFileDialog}>
             {t("common.openFileDialog")}
           </IconButton>
@@ -196,8 +189,9 @@ export const ImportModal = ({
           >
             {t("importModal.submit")}
           </PrimaryButton>
-        </Row>
-        <HiddenFileInput
+        </div>
+        <input
+          className="hidden"
           type="file"
           ref={fileInputRef}
           accept="text/plain,text/csv"
@@ -211,7 +205,7 @@ export const ImportModal = ({
             }
           }}
         />
-      </Content>
+      </div>
     </Modal>,
     document.getElementById("root")!,
   );

--- a/frontend/src/js/ui-components/InputCheckbox.tsx
+++ b/frontend/src/js/ui-components/InputCheckbox.tsx
@@ -1,38 +1,48 @@
-import styled from "@emotion/styled";
-
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { tv } from "tailwind-variants";
 import { exists } from "../common/helpers/exists";
 import FaIcon from "../icon/FaIcon";
 import InfoTooltip from "../tooltip/InfoTooltip";
 import WithTooltip from "../tooltip/WithTooltip";
 
-const Row = styled("div")<{ $disabled?: boolean }>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
-`;
+const row = tv({
+  base: ["flex flex-row items-center", "cursor-pointer"],
+  variants: {
+    disabled: { true: "cursor-not-allowed" },
+  },
+});
 
-const Label = styled("span")`
-  margin-left: 10px;
-  font-size: ${({ theme }) => theme.font.sm};
-  line-height: 1;
-`;
+const label = tv({ base: ["ml-[10px]", "text-sm", "leading-none"] });
 
-const Container = styled("div")<{ $disabled?: boolean }>`
-  flex-shrink: 0;
-  position: relative;
-  font-size: 22px;
-  width: 20px;
-  height: 20px;
-  border: 2px solid ${({ theme }) => theme.col.blueGrayDark};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  box-sizing: content-box;
-  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
-`;
+const container = tv({
+  base: [
+    "relative",
+    "shrink-0",
+    "box-content",
+    "h-5 w-5",
+    "border-2 border-primary-500",
+    "rounded",
+    "text-[22px]",
+  ],
+  variants: {
+    disabled: { true: "opacity-50" },
+  },
+});
+
+const checkmark = tv({
+  base: [
+    "absolute top-0 left-0",
+    "flex items-center justify-center",
+    "h-5 w-5",
+    "bg-primary-500",
+    "text-white",
+  ],
+});
+
+const checkmarkIcon = tv({ base: ["text-white!", "scale-125"] });
 
 const InputCheckbox = ({
-  label,
+  label: labelText,
   className,
   tooltip,
   tooltipLazy,
@@ -50,25 +60,26 @@ const InputCheckbox = ({
   onChange: (checked: boolean) => void;
   disabled?: boolean;
 }) => (
-  <Row
-    className={className}
+  // biome-ignore lint/a11y/useKeyWithClickEvents: TODO make this a real checkbox
+  // biome-ignore lint/a11y/noStaticElementInteractions: see above
+  <div
+    className={row({ disabled, className })}
     onClick={() => {
       if (!disabled) onChange(!value);
     }}
-    $disabled={disabled}
   >
     <WithTooltip text={tooltip} lazy={tooltipLazy}>
-      <Container $disabled={disabled}>
+      <div className={container({ disabled })}>
         {!!value && (
-          <div className="absolute top-0 left-0 w-5 h-5 bg-primary-500 flex items-center justify-center text-white">
-            <FaIcon icon={faCheck} className="!text-white scale-125" />
+          <div className={checkmark()}>
+            <FaIcon icon={faCheck} className={checkmarkIcon()} />
           </div>
         )}
-      </Container>
+      </div>
     </WithTooltip>
-    <Label>{label}</Label>
+    <span className={label()}>{labelText}</span>
     {exists(infoTooltip) && <InfoTooltip text={infoTooltip} />}
-  </Row>
+  </div>
 );
 
 export default InputCheckbox;

--- a/frontend/src/js/ui-components/InputDate/CustomHeader.tsx
+++ b/frontend/src/js/ui-components/InputDate/CustomHeader.tsx
@@ -1,10 +1,10 @@
-import styled from "@emotion/styled";
 import {
   faChevronLeft,
   faChevronRight,
 } from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 import type { ReactDatePickerCustomHeaderProps } from "react-datepicker";
+import { tv } from "tailwind-variants";
 
 import type { SelectOptionT } from "../../api/types";
 import IconButton from "../../button/IconButton";
@@ -12,43 +12,32 @@ import { TransparentButton } from "../../button/TransparentButton";
 import { useMonthName, useMonthNames } from "../../common/helpers/dateHelper";
 import { List, Menu } from "../InputSelect/InputSelectComponents";
 
-export const Root = styled("div")`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
+const root = tv({
+  base: "flex items-center justify-between",
+});
 
-export const SelectMenuContainer = styled("div")`
-  position: absolute;
-  top: 40px;
-  left: 0;
-  width: 100%;
-`;
+const selectMenuContainer = tv({
+  base: ["absolute top-[40px] left-0", "w-full"],
+});
 
-export const MonthListContainer = styled(List)`
-  display: grid;
-  grid-template-columns: auto auto;
-  gap: 5px;
-`;
+const optionList = tv({
+  base: "gap-[5px]",
+  variants: {
+    layout: {
+      twoColumns: "grid grid-cols-[auto_auto]",
+      oneColumn: ["flex flex-col-reverse", "h-[200px]", "overflow-auto"],
+    },
+  },
+});
 
-export const YearListContainer = styled(List)`
-  display: flex;
-  flex-direction: column-reverse;
-  gap: 5px;
-  height: 200px;
-  overflow: auto;
-`;
-
-export const MonthYearLabel = styled("div")`
-  font-weight: bold;
-  cursor: pointer;
-  transition: opacity ${({ theme }) => theme.transitionTime};
-  opacity: 0.75;
-
-  &:hover {
-    opacity: 1;
-  }
-`;
+const monthYearLabel = tv({
+  base: [
+    "font-bold",
+    "cursor-pointer",
+    "transition-opacity duration-100",
+    "opacity-75 hover:opacity-100",
+  ],
+});
 
 const SelectMenu = ({
   date,
@@ -60,12 +49,10 @@ const SelectMenu = ({
   layout: "oneColumn" | "twoColumns";
   onSelect: (n: number) => void;
 }) => {
-  const OptionList =
-    layout === "twoColumns" ? MonthListContainer : YearListContainer;
   return (
-    <SelectMenuContainer>
+    <div className={selectMenuContainer()}>
       <Menu>
-        <OptionList>
+        <List className={optionList({ layout })}>
           {options.map((option) => (
             <TransparentButton
               small
@@ -79,9 +66,9 @@ const SelectMenu = ({
               {option.label}
             </TransparentButton>
           ))}
-        </OptionList>
+        </List>
       </Menu>
-    </SelectMenuContainer>
+    </div>
   );
 };
 
@@ -116,9 +103,11 @@ const YearMonthSelect = ({
 
   return (
     <>
-      <MonthYearLabel onClick={handleClick}>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: TODO make this a button */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: TODO make this a button */}
+      <div className={monthYearLabel()} onClick={handleClick}>
         {useMonthName(date)} {date.getFullYear()}
-      </MonthYearLabel>
+      </div>
       {yearSelectOpen && (
         <SelectMenu
           date={date}
@@ -156,7 +145,7 @@ export const CustomHeader = ({
   nextMonthButtonDisabled,
 }: ReactDatePickerCustomHeaderProps) => {
   return (
-    <Root>
+    <div className={root()}>
       <IconButton
         icon={faChevronLeft}
         onClick={decreaseMonth}
@@ -172,6 +161,6 @@ export const CustomHeader = ({
         onClick={increaseMonth}
         disabled={nextMonthButtonDisabled}
       />
-    </Root>
+    </div>
   );
 };

--- a/frontend/src/js/ui-components/InputDate/InputDate.tsx
+++ b/frontend/src/js/ui-components/InputDate/InputDate.tsx
@@ -1,9 +1,9 @@
-import styled from "@emotion/styled";
 import { faCalendar } from "@fortawesome/free-regular-svg-icons";
-import { createElement, type Ref, useRef } from "react";
+import { type Ref, useRef } from "react";
 import ReactDatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { mergeRefs } from "react-merge-refs";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../../button/IconButton";
 import { formatDate, parseDate } from "../../common/helpers/dateHelper";
@@ -11,45 +11,18 @@ import BaseInput, { type Props as BaseInputProps } from "../BaseInput";
 
 import { CustomHeader } from "./CustomHeader";
 
-const Root = styled("div")`
-  position: relative;
+// react-datepicker's own elements are styled in index.css under this class
+const root = tv({
+  base: ["relative", "conquery-datepicker"],
+});
 
-  .react-datepicker-wrapper {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    z-index: -1;
-  }
-  .react-datepicker-popper[data-placement^="bottom"] {
-    padding-top: 4px;
-  }
-  .react-datepicker-popper[data-placement^="top"] {
-    padding-bottom: 0;
-  }
-`;
+const calendarButton = tv({
+  base: ["absolute top-0 left-0", "px-[10px] py-2"],
+});
 
-const CalendarButton = styled(IconButton)`
-  position: absolute;
-  left: 0;
-  top: 0;
-  padding: 8px 10px;
-`;
-
-const StyledBaseInput = styled(BaseInput)`
-  input {
-    padding-left: 28px;
-  }
-`;
-
-const HiddenInput = styled("input")`
-  display: none;
-`;
-
-const StyledCalendar = styled("div")`
-  .react-datepicker__day--selected {
-    background: ${({ theme }) => theme.col.blueGrayDark};
-  }
-`;
+const baseInput = tv({
+  base: "[&_input]:pl-[28px]",
+});
 
 type Props = Omit<BaseInputProps, "inputType"> & {
   value: string | null;
@@ -71,14 +44,16 @@ const InputDate = ({
   const datePickerRef = useRef<ReactDatePicker>(null);
 
   return (
-    <Root
-      className={className}
+    // biome-ignore lint/a11y/noStaticElementInteractions: escape closes the calendar of the input inside
+    <div
+      className={root({ className })}
       onKeyDown={(e) => {
         if (e.key === "Escape") datePickerRef.current?.setOpen(false);
       }}
     >
-      <StyledBaseInput
+      <BaseInput
         {...props}
+        className={baseInput()}
         inputType="text"
         value={value}
         onChange={(val) => {
@@ -92,7 +67,8 @@ const InputDate = ({
           },
         }}
       />
-      <CalendarButton
+      <IconButton
+        className={calendarButton()}
         icon={faCalendar}
         onClick={() => datePickerRef.current?.setOpen(true)}
       />
@@ -111,11 +87,10 @@ const InputDate = ({
         }}
         onClickOutside={() => datePickerRef.current?.setOpen(false)}
         renderCustomHeader={CustomHeader}
-        customInput={createElement(HiddenInput)}
-        calendarContainer={StyledCalendar}
+        customInput={<input className="hidden" />}
         calendarStartDay={1}
       />
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/InputDateRange.tsx
+++ b/frontend/src/js/ui-components/InputDateRange.tsx
@@ -1,9 +1,8 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
 import { faCalendar } from "@fortawesome/free-regular-svg-icons";
 import { createRef, type ReactNode, useMemo } from "react";
 import type ReactDatePicker from "react-datepicker";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import { IndexPrefix } from "../common/components/IndexPrefix";
 import {
@@ -21,61 +20,61 @@ import InputDate from "./InputDate/InputDate";
 import Label from "./Label";
 import Labeled from "./Labeled";
 
-const Root = styled("div")<{ center?: boolean }>`
-  text-align: ${({ center }) => (center ? "center" : "left")};
-`;
-const Pickers = styled("div")<{ inline?: boolean; center?: boolean }>`
-  display: flex;
-  flex-direction: ${({ inline }) => (inline ? "row" : "column")};
-  justify-content: ${({ center }) => (center ? "center" : "flex-start")};
-`;
+const root = tv({
+  variants: {
+    center: {
+      true: "text-center",
+      false: "text-left",
+    },
+  },
+});
 
-const StyledLabel = styled(Label)<{ large?: boolean }>`
-  ${({ theme, large }) =>
-    large &&
-    css`
-      font-size: ${theme.font.md};
-    `}
-`;
+const pickers = tv({
+  base: "flex",
+  variants: {
+    inline: {
+      true: "flex-row",
+      false: "flex-col",
+    },
+    center: {
+      true: "justify-center",
+      false: "justify-start",
+    },
+  },
+});
 
-const SxLabeled = styled(Labeled)`
-  &:first-of-type {
-    margin-right: 10px;
-  }
-`;
+const labeled = tv({
+  base: "first-of-type:mr-[10px]",
+});
 
-const CustomTooltip = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px 14px;
+const customTooltip = tv({
+  base: [
+    "flex flex-col",
+    "gap-2",
+    "px-[14px] py-2",
+    "text-base",
+    "font-normal",
+    "[&_table]:mt-[5px] [&_table]:w-full",
+    "[&_table]:border [&_th]:border [&_td]:border",
+    "[&_table]:border-gray-100 [&_th]:border-gray-100 [&_td]:border-gray-100",
+    "[&_table]:border-collapse [&_th]:border-collapse [&_td]:border-collapse",
+    "[&_td]:px-[5px] [&_td]:py-[2px]",
+    "[&_td]:leading-[1.2]",
+  ],
+});
 
-  font-size: ${({ theme }) => theme.font.md};
-  font-weight: 400;
-  table {
-    margin-top: 5px;
-    width: 100%;
-  }
-  table,
-  th,
-  td {
-    border: 1px solid ${({ theme }) => theme.col.grayLight};
-    border-collapse: collapse;
-  }
-  td {
-    padding: 2px 5px;
-    line-height: 1.2;
-  }
-`;
+const tooltipMain = tv({
+  base: "text-base",
+});
 
-const TooltipMain = styled("div")`
-  font-size: ${({ theme }) => theme.font.md};
-`;
-
-const TooltipTutorial = styled("div")<{ hasMain?: boolean }>`
-  font-size: ${({ theme, hasMain }) =>
-    hasMain ? theme.font.sm : theme.font.md};
-`;
+const tooltipTutorial = tv({
+  variants: {
+    hasMain: {
+      true: "text-sm",
+      false: "text-base",
+    },
+  },
+});
 
 function getDisplayDate(
   what: "min" | "max",
@@ -171,34 +170,36 @@ const InputDateRange = ({
     if (!label) return null;
 
     return (
-      <StyledLabel large={large}>
+      <Label large={large}>
         <FaIcon icon={faCalendar} left gray />
         {exists(indexPrefix) && <IndexPrefix># {indexPrefix}</IndexPrefix>}
         {label}
         <InfoTooltip
           html={
-            <CustomTooltip>
-              {exists(tooltip) && <TooltipMain>{tooltip}</TooltipMain>}
-              <TooltipTutorial
-                hasMain={exists(tooltip)}
+            <div className={customTooltip()}>
+              {exists(tooltip) && (
+                <div className={tooltipMain()}>{tooltip}</div>
+              )}
+              <div
+                className={tooltipTutorial({ hasMain: exists(tooltip) })}
                 // biome-ignore lint/security/noDangerouslySetInnerHtml: i18n text with markup
                 dangerouslySetInnerHTML={{
                   __html: t("inputDateRange.tooltip.possiblePattern"),
                 }}
               />
-            </CustomTooltip>
+            </div>
           }
         />
         {labelSuffix && labelSuffix}
-      </StyledLabel>
+      </Label>
     );
   }, [t, label, labelSuffix, large, tooltip, indexPrefix]);
 
   return (
-    <Root center={center}>
+    <div className={root({ center: !!center })}>
       {labelWithSuffix}
-      <Pickers inline={inline} center={center}>
-        <SxLabeled label={t("inputDateRange.from")}>
+      <div className={pickers({ inline: !!inline, center: !!center })}>
+        <Labeled className={labeled()} label={t("inputDateRange.from")}>
           <InputDate
             value={min}
             dateFormat={displayDateFormat}
@@ -215,8 +216,8 @@ const InputDateRange = ({
               autoFocus,
             }}
           />
-        </SxLabeled>
-        <SxLabeled label={t("inputDateRange.to")}>
+        </Labeled>
+        <Labeled className={labeled()} label={t("inputDateRange.to")}>
           <InputDate
             ref={maxRef}
             value={max}
@@ -230,9 +231,9 @@ const InputDateRange = ({
             }
             onBlur={(e) => applyDate("max", e.target.value, displayDateFormat)}
           />
-        </SxLabeled>
-      </Pickers>
-    </Root>
+        </Labeled>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/InputMultiSelect/InputMultiSelect.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/InputMultiSelect.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   faChevronDown,
   faSpinner,
@@ -52,10 +51,6 @@ const getSentinelInsertIndex = (optionsLength: number) => {
 
   return optionsLength - SENTINEL_INSERT_INDEX_FROM_BOTTOM;
 };
-
-const SxFaIcon = styled(FaIcon)`
-  margin: 3px 6px;
-`;
 
 interface Props {
   label?: string;
@@ -323,7 +318,7 @@ const InputMultiSelect = ({
             }}
           />
         </ItemsInputContainer>
-        {loading && <SxFaIcon icon={faSpinner} />}
+        {loading && <FaIcon className="mx-[6px] my-[3px]" icon={faSpinner} />}
         {!loading && (inputValue.length > 0 || selectedItems.length > 0) && (
           <ResetButton
             icon={faTimes}

--- a/frontend/src/js/ui-components/InputMultiSelect/LoadMoreSentinel.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/LoadMoreSentinel.tsx
@@ -1,15 +1,11 @@
-import styled from "@emotion/styled";
 import { useCallback, useRef } from "react";
+import { tv } from "tailwind-variants";
 
 import { useIntersectionObserver } from "../../common/useIntersectionObserver";
 
-const Span = styled("span")`
-  width: 1px;
-  height: 1px;
-  background: transparent;
-  pointer-events: none;
-  display: block;
-`;
+const sentinel = tv({
+  base: ["block", "w-px h-px", "bg-transparent", "pointer-events-none"],
+});
 
 interface Props {
   className?: string;
@@ -31,7 +27,9 @@ const LoadMoreSentinel = ({ onLoadMore, className }: Props) => {
     ),
   );
 
-  return <Span className={className} ref={intersectionObserverRef} />;
+  return (
+    <span className={sentinel({ className })} ref={intersectionObserverRef} />
+  );
 };
 
 export default LoadMoreSentinel;

--- a/frontend/src/js/ui-components/InputMultiSelect/MenuActionBar.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/MenuActionBar.tsx
@@ -1,23 +1,20 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import { TransparentButton } from "../../button/TransparentButton";
 import { exists } from "../../common/helpers/exists";
 
-const Row = styled("div")`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 5px 10px;
-  border-bottom: 1px solid #ccc;
-`;
+const row = tv({
+  base: [
+    "flex items-center justify-between",
+    "px-[10px] py-[5px]",
+    "border-b border-[#ccc]",
+  ],
+});
 
-const InfoText = styled("p")`
-  margin: 0;
-  color: ${({ theme }) => theme.col.gray};
-  font-size: ${({ theme }) => theme.font.xs};
-  margin-right: 10px;
-`;
+const infoText = tv({
+  base: ["m-0 mr-[10px]", "text-gray-500", "text-xs"],
+});
 
 interface Props {
   optionsCount: number;
@@ -29,13 +26,13 @@ const MenuActionBar = ({ optionsCount, total, onInsertAllClick }: Props) => {
   const { t } = useTranslation();
 
   return (
-    <Row>
-      <InfoText>
+    <div className={row()}>
+      <p className={infoText()}>
         {t("inputMultiSelect.options", { count: optionsCount })}
         {exists(total) &&
           total !== optionsCount &&
           t("inputMultiSelect.ofTotal", { count: total })}
-      </InfoText>
+      </p>
       <TransparentButton
         tiny
         disabled={optionsCount === 0}
@@ -43,7 +40,7 @@ const MenuActionBar = ({ optionsCount, total, onInsertAllClick }: Props) => {
       >
         {t("inputMultiSelect.insertAll")}
       </TransparentButton>
-    </Row>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/InputMultiSelect/SelectedItem.tsx
+++ b/frontend/src/js/ui-components/InputMultiSelect/SelectedItem.tsx
@@ -1,32 +1,26 @@
-import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { memo, type Ref } from "react";
 import ReactMarkdown from "react-markdown";
+import { tv } from "tailwind-variants";
 
 import type { SelectOptionT } from "../../api/types";
 import IconButton from "../../button/IconButton";
 
-const Container = styled("div")<{ active?: boolean }>`
-  border-radius: ${({ theme }) => theme.borderRadius};
-  display: flex;
-  align-items: center;
-  background-color: ${({ theme }) => theme.col.grayVeryLight};
-  padding: 0px 5px;
-  font-size: ${({ theme }) => theme.font.sm};
-  color: ${({ theme }) => theme.col.black};
-  box-shadow:
-    0.5px 0.5px 1px 0 rgb(0 0 0 / 20%),
-    inset 0 0 0 1px #ccc;
+const container = tv({
+  base: [
+    "flex items-center",
+    "rounded",
+    "bg-gray-50",
+    "px-[5px] py-0",
+    "text-sm",
+    "text-gray-800",
+    "shadow-[0.5px_0.5px_1px_0_rgb(0_0_0/20%),inset_0_0_0_1px_#ccc]",
+    // to style react-markdown
+    "[&_p]:m-0",
+  ],
+});
 
-  /* to style react-markdown */
-  p {
-    margin: 0;
-  }
-`;
-
-const SxIconButton = styled(IconButton)`
-  padding: 1px 2px 1px 5px;
-`;
+const removeButton = tv({ base: "py-px pr-[2px] pl-[5px]" });
 
 const SelectedItem = ({
   ref,
@@ -56,9 +50,10 @@ const SelectedItem = ({
   });
 
   return (
-    <Container ref={ref} {...selectedItemProps}>
+    <div className={container()} ref={ref} {...selectedItemProps}>
       <ReactMarkdown>{String(label)}</ReactMarkdown>
-      <SxIconButton
+      <IconButton
+        className={removeButton()}
         icon={faTimes}
         disabled={disabled}
         onClick={(e) => {
@@ -66,7 +61,7 @@ const SelectedItem = ({
           removeSelectedItem(item);
         }}
       />
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/InputPlain/InputPlain.tsx
+++ b/frontend/src/js/ui-components/InputPlain/InputPlain.tsx
@@ -1,18 +1,15 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
 import type { Ref } from "react";
+import { tv } from "tailwind-variants";
 
 import type { CurrencyConfigT } from "../../api/types";
 import BaseInput from "../BaseInput";
 import Labeled from "../Labeled";
 
-const SxBaseInput = styled(BaseInput)<{ fullWidth?: boolean }>`
-  ${({ fullWidth }) =>
-    fullWidth &&
-    css`
-      width: 100%;
-    `};
-`;
+const input = tv({
+  variants: {
+    fullWidth: { true: "w-full" },
+  },
+});
 
 interface Props {
   label: string;
@@ -61,10 +58,10 @@ const InputPlain = ({
       indexPrefix={indexPrefix}
       tooltip={tooltip}
     >
-      <SxBaseInput
+      <BaseInput
         ref={ref}
+        className={input({ fullWidth })}
         large={large}
-        fullWidth={fullWidth}
         inputType={inputType}
         money={money}
         placeholder={placeholder}

--- a/frontend/src/js/ui-components/InputRange.tsx
+++ b/frontend/src/js/ui-components/InputRange.tsx
@@ -1,5 +1,5 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { CurrencyConfigT } from "../api/types";
 import { exists } from "../common/helpers/exists";
@@ -8,22 +8,11 @@ import InputPlain from "./InputPlain/InputPlain";
 import InputRangeHeader from "./InputRangeHeader";
 import ToggleButton from "./ToggleButton";
 
-const Container = styled("div")`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  margin-top: -3px;
-`;
+const container = tv({ base: ["flex flex-row", "w-full", "-mt-[3px]"] });
 
-const SxInputPlain = styled(InputPlain)`
-  input {
-    width: 100%;
-    min-width: 50px;
-  }
-  &:last-of-type {
-    padding-left: 5px;
-  }
-`;
+const rangeInput = tv({
+  base: ["[&_input]:w-full [&_input]:min-w-[50px]", "last-of-type:pl-[5px]"],
+});
 
 interface ValueT {
   min?: number | null;
@@ -138,10 +127,11 @@ const InputRange = ({
           { value: "exact", label: t("inputRange.exact") },
         ]}
       />
-      <Container>
+      <div className={container()}>
         {isRangeMode ? (
           <>
-            <SxInputPlain
+            <InputPlain
+              className={rangeInput()}
               inputType="number"
               currencyConfig={currencyConfig}
               money={moneyRange}
@@ -153,7 +143,8 @@ const InputRange = ({
               onChange={(value) => onChangeValue("min", value as number | null)}
               inputProps={inputProps}
             />
-            <SxInputPlain
+            <InputPlain
+              className={rangeInput()}
               inputType="number"
               currencyConfig={currencyConfig}
               money={moneyRange}
@@ -180,7 +171,7 @@ const InputRange = ({
             inputProps={inputProps}
           />
         )}
-      </Container>
+      </div>
     </div>
   );
 };

--- a/frontend/src/js/ui-components/InputSelect/InputSelectComponents.tsx
+++ b/frontend/src/js/ui-components/InputSelect/InputSelectComponents.tsx
@@ -1,106 +1,151 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
+import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../../button/IconButton";
 
 import SelectListOption from "./SelectListOption";
 
-export const Control = styled("div")<{ disabled?: boolean }>`
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  border-radius: 4px;
-  display: flex;
-  align-items: flex-start;
-  overflow: hidden;
-  padding: 4px 3px 4px 8px;
-  background-color: white;
-  ${({ disabled }) =>
-    disabled &&
-    css`
-      cursor: not-allowed;
-    `}
+const control = tv({
+  base: [
+    "flex items-start",
+    "overflow-hidden",
+    "rounded-[4px]",
+    "border border-gray-500",
+    "bg-white",
+    "py-1 pr-[3px] pl-2",
+    "focus:outline focus:outline-1 focus:outline-black",
+  ],
+  variants: {
+    disabled: { true: "cursor-not-allowed" },
+  },
+});
 
-  &:focus {
-    outline: 1px solid black;
-  }
-`;
+export const Control = ({
+  className,
+  disabled,
+  ...props
+}: ComponentProps<"div"> & { disabled?: boolean }) => (
+  <div className={control({ disabled, className })} {...props} />
+);
 
-export const SelectContainer = styled("div")`
-  width: 100%;
-  position: relative;
-`;
+const selectContainer = tv({ base: ["relative", "w-full"] });
 
-export const ItemsInputContainer = styled("div")`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 4px;
-  width: 100%;
-`;
+export const SelectContainer = ({
+  className,
+  ...props
+}: ComponentProps<"div">) => (
+  <div className={selectContainer({ className })} {...props} />
+);
 
-export const MenuContainer = styled("div")`
-  position: absolute;
-  width: 100%;
-  z-index: 3;
-  margin-top: 3px;
-  padding-bottom: 10px;
-`;
+const itemsInputContainer = tv({
+  base: ["flex flex-wrap items-center", "gap-1", "w-full"],
+});
 
-export const Menu = styled("div")`
-  width: 100%;
-  border-radius: 4px;
-  box-shadow:
-    0 0 0 1px hsl(0deg 0% 0% / 10%),
-    0 4px 11px hsl(0deg 0% 0% / 10%);
-  background-color: ${({ theme }) => theme.col.bg};
-`;
+export const ItemsInputContainer = ({
+  className,
+  ...props
+}: ComponentProps<"div">) => (
+  <div className={itemsInputContainer({ className })} {...props} />
+);
 
-export const List = styled("div")<{ small?: boolean }>`
-  padding: 3px;
-  max-height: ${({ small }) =>
-    small
-      ? "140px"
-      : "300px"}; /* remove this once we use usePopper / portals for this */
-  overflow-y: auto;
-  --webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
-`;
+const menuContainer = tv({
+  base: ["absolute", "z-3", "w-full", "mt-[3px]", "pb-[10px]"],
+});
 
-export const Input = styled("input")`
-  border: 0;
-  height: 20px;
-  outline: none;
-  flex-grow: 1;
-  width: 0; /* to fix default width */
-  font-weight: 400;
-  font-size: ${({ theme }) => theme.font.sm};
-  ${({ disabled }) =>
-    disabled &&
-    css`
-      cursor: not-allowed;
-      pointer-events: none;
-      &:placehoder {
-        opacity: 0.5;
-      }
-    `}
-`;
+export const MenuContainer = ({
+  className,
+  ...props
+}: ComponentProps<"div">) => (
+  <div className={menuContainer({ className })} {...props} />
+);
 
-export const DropdownToggleButton = styled(IconButton)`
-  padding: 2px 4px 2px 6px;
-`;
+const menu = tv({
+  base: [
+    "w-full",
+    "rounded-[4px]",
+    "shadow-[0_0_0_1px_hsl(0deg_0%_0%/10%),0_4px_11px_hsl(0deg_0%_0%/10%)]",
+    "bg-bg-50",
+  ],
+});
 
-export const ResetButton = styled(IconButton)`
-  padding: 2px 8px;
-  width: 26px;
-`;
+export const Menu = ({ className, ...props }: ComponentProps<"div">) => (
+  <div className={menu({ className })} {...props} />
+);
 
-export const VerticalSeparator = styled("div")`
-  width: 1px;
-  margin: 3px 0;
-  background-color: ${({ theme }) => theme.col.grayLight};
-  align-self: stretch;
-  flex-shrink: 0;
-`;
+const list = tv({
+  base: [
+    "p-[3px]",
+    // remove the max-height once we use usePopper / portals for this
+    "max-h-[300px]",
+    "overflow-y-auto",
+    "[-webkit-overflow-scrolling:touch]",
+    "overscroll-contain",
+  ],
+  variants: {
+    small: { true: "max-h-[140px]" },
+  },
+});
 
-export const SxSelectListOption = styled(SelectListOption)`
-  margin-bottom: 2px;
-`;
+export const List = ({
+  className,
+  small,
+  ...props
+}: ComponentProps<"div"> & { small?: boolean }) => (
+  <div className={list({ small, className })} {...props} />
+);
+
+const input = tv({
+  base: [
+    "grow",
+    "w-0", // to fix default width
+    "h-5",
+    "border-0",
+    "outline-none",
+    "text-sm",
+    "font-normal",
+    "disabled:cursor-not-allowed disabled:pointer-events-none",
+    "disabled:placeholder:opacity-50",
+  ],
+});
+
+export const Input = ({ className, ...props }: ComponentProps<"input">) => (
+  <input className={input({ className })} {...props} />
+);
+
+const dropdownToggleButton = tv({ base: "py-[2px] pr-1 pl-[6px]" });
+
+export const DropdownToggleButton = ({
+  className,
+  ...props
+}: ComponentProps<typeof IconButton>) => (
+  <IconButton className={dropdownToggleButton({ className })} {...props} />
+);
+
+const resetButton = tv({ base: ["w-[26px]", "px-2 py-[2px]"] });
+
+export const ResetButton = ({
+  className,
+  ...props
+}: ComponentProps<typeof IconButton>) => (
+  <IconButton className={resetButton({ className })} {...props} />
+);
+
+const verticalSeparator = tv({
+  base: ["self-stretch", "shrink-0", "w-px", "my-[3px]", "bg-gray-100"],
+});
+
+export const VerticalSeparator = ({
+  className,
+  ...props
+}: ComponentProps<"div">) => (
+  <div className={verticalSeparator({ className })} {...props} />
+);
+
+const sxSelectListOption = tv({ base: "mb-[2px]" });
+
+export const SxSelectListOption = ({
+  className,
+  ...props
+}: ComponentProps<typeof SelectListOption>) => (
+  <SelectListOption className={sxSelectListOption({ className })} {...props} />
+);

--- a/frontend/src/js/ui-components/InputSelect/SelectListOption.tsx
+++ b/frontend/src/js/ui-components/InputSelect/SelectListOption.tsx
@@ -1,58 +1,57 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
-import { memo, type Ref } from "react";
+import { type ComponentProps, memo, type Ref } from "react";
 import ReactMarkdown from "react-markdown";
+import { tv } from "tailwind-variants";
 
 import type { SelectOptionT } from "../../api/types";
 
-const Container = styled("div")<StyleProps>`
-  padding: 3px 8px;
-  cursor: pointer;
-  color: ${({ theme }) => theme.col.black};
-  font-size: ${({ theme }) => theme.font.md};
-  font-weight: 300;
-
-  transition: background-color ${({ theme }) => theme.transitionTime};
-
-  ${({ active, theme }) =>
-    active &&
-    css`
-      background-color: ${theme.col.blueGrayVeryLight};
-    `};
-
-  opacity: ${({ disabled }) => (disabled ? 0.4 : 1)};
-  cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
-
-  /* to style react-markdown */
-  p {
-    margin: 0;
-  }
-`;
+const container = tv({
+  base: [
+    "px-2 py-[3px]",
+    "cursor-pointer",
+    "text-gray-800",
+    "text-base",
+    "font-light",
+    "transition-[background-color] duration-100",
+    // to style react-markdown
+    "[&_p]:m-0",
+  ],
+  variants: {
+    active: { true: "bg-primary-50" },
+    disabled: { true: "cursor-not-allowed opacity-40" },
+  },
+});
 
 interface StyleProps {
   active?: boolean;
   disabled?: boolean;
 }
 
-interface Props extends StyleProps {
+interface Props extends StyleProps, Omit<ComponentProps<"div">, "ref"> {
   option: SelectOptionT;
 }
 
 const SelectListOption = ({
   ref,
   option,
+  active,
+  disabled: _disabled, // the option decides, see below
+  className,
   ...props
 }: Props & { ref?: Ref<HTMLDivElement> }) => {
   const label = option.label || String(option.value);
 
   return (
-    <Container {...props} disabled={option.disabled} ref={ref}>
+    <div
+      {...props}
+      className={container({ active, disabled: option.disabled, className })}
+      ref={ref}
+    >
       {option.displayLabel ? (
         option.displayLabel
       ) : (
         <ReactMarkdown>{label}</ReactMarkdown>
       )}
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/InputTextarea/InputTextarea.tsx
+++ b/frontend/src/js/ui-components/InputTextarea/InputTextarea.tsx
@@ -1,33 +1,30 @@
-import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import type { DetailedHTMLProps, Ref, TextareaHTMLAttributes } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../../button/IconButton";
 import Labeled from "../Labeled";
 
-const Root = styled("div")`
-  position: relative;
-`;
+const textarea = tv({
+  base: [
+    "outline-0",
+    "w-full",
+    "rounded",
+    "border border-gray-400",
+    "py-[6px] pr-[30px] pl-[10px]",
+    "text-sm",
+  ],
+});
 
-const Textarea = styled("textarea")`
-  outline: 0;
-  width: 100%;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  border: 1px solid ${({ theme }) => theme.col.grayMediumLight};
-  padding: 6px 30px 6px 10px;
-  font-size: ${({ theme }) => theme.font.sm};
-`;
-
-const ClearZoneIconButton = styled(IconButton)`
-  position: absolute;
-  top: 0;
-  right: 10px;
-  height: 30px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-`;
+const clearZoneIconButton = tv({
+  base: [
+    "absolute top-0 right-[10px]",
+    "h-[30px]",
+    "flex items-center",
+    "cursor-pointer",
+  ],
+});
 
 interface OtherProps {
   label: string;
@@ -62,9 +59,10 @@ export const InputTextarea = ({
       fullWidth
       tooltip={tooltip}
     >
-      <Root>
-        <Textarea
+      <div className="relative">
+        <textarea
           ref={ref}
+          className={textarea()}
           {...props}
           onChange={({ target: { value } }) =>
             value.length === 0 ? onChange(null) : onChange(value)
@@ -72,7 +70,8 @@ export const InputTextarea = ({
           value={props.value || ""}
         />
         {props.value && (
-          <ClearZoneIconButton
+          <IconButton
+            className={clearZoneIconButton()}
             tiny
             icon={faTimes}
             tabIndex={-1}
@@ -81,7 +80,7 @@ export const InputTextarea = ({
             onClick={() => onChange(null)}
           />
         )}
-      </Root>
+      </div>
     </Labeled>
   );
 };

--- a/frontend/src/js/ui-components/Label.tsx
+++ b/frontend/src/js/ui-components/Label.tsx
@@ -1,20 +1,41 @@
-import styled from "@emotion/styled";
+import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
-const Label = styled("span")<{
+const label = tv({
+  base: [
+    "flex items-center",
+    "mx-0 mt-[6px] mb-[3px]",
+    "w-[inherit]",
+    "text-sm",
+    "font-normal",
+    "text-gray-800",
+  ],
+  variants: {
+    // later wins when both are set
+    tiny: { true: "text-xs" },
+    large: { true: "text-base" },
+    disabled: { true: "text-gray-500" },
+    fullWidth: { true: "w-full" },
+  },
+});
+
+const Label = ({
+  className,
+  tiny,
+  large,
+  disabled,
+  fullWidth,
+  ...props
+}: ComponentProps<"span"> & {
   tiny?: boolean;
   large?: boolean;
   disabled?: boolean;
   fullWidth?: boolean;
-}>`
-  font-weight: 400;
-  font-size: ${({ theme, tiny, large }) =>
-    large ? theme.font.md : tiny ? theme.font.xs : theme.font.sm};
-  display: flex;
-  align-items: center;
-  margin: 6px 0 3px;
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.col.gray : theme.col.black};
-  width: ${({ fullWidth }) => (fullWidth ? "100%" : "inherit")};
-`;
+}) => (
+  <span
+    className={label({ tiny, large, disabled, fullWidth, className })}
+    {...props}
+  />
+);
 
 export default Label;

--- a/frontend/src/js/ui-components/Labeled.tsx
+++ b/frontend/src/js/ui-components/Labeled.tsx
@@ -1,6 +1,5 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
 import type { ReactNode, Ref } from "react";
+import { tv } from "tailwind-variants";
 
 import { IndexPrefix } from "../common/components/IndexPrefix";
 import { exists } from "../common/helpers/exists";
@@ -8,16 +7,11 @@ import InfoTooltip from "../tooltip/InfoTooltip";
 
 import Label from "./Label";
 
-const Root = styled("label")<{ fullWidth?: boolean }>`
-  ${({ fullWidth }) =>
-    fullWidth &&
-    css`
-      width: 100%;
-      input {
-        width: 100%;
-      }
-    `};
-`;
+const root = tv({
+  variants: {
+    fullWidth: { true: "w-full [&_input]:w-full" },
+  },
+});
 
 interface Props {
   label: ReactNode;
@@ -44,10 +38,9 @@ const Labeled = ({
   children,
 }: Props & { ref?: Ref<HTMLLabelElement> }) => {
   return (
-    <Root
+    <label
       ref={ref}
-      className={className}
-      fullWidth={fullWidth}
+      className={root({ fullWidth, className })}
       htmlFor={htmlFor}
     >
       <Label fullWidth={fullWidth} tiny={tinyLabel} large={largeLabel}>
@@ -56,7 +49,7 @@ const Labeled = ({
         {exists(tooltip) && <InfoTooltip text={tooltip} />}
       </Label>
       {children}
-    </Root>
+    </label>
   );
 };
 

--- a/frontend/src/js/ui-components/SelectEmptyPlaceholder.tsx
+++ b/frontend/src/js/ui-components/SelectEmptyPlaceholder.tsx
@@ -1,19 +1,19 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
-const Container = styled("div")`
-  width: 100%;
-  padding: 6px 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.col.gray};
-  font-size: ${({ theme }) => theme.font.sm};
-`;
+const container = tv({
+  base: [
+    "flex items-center justify-center",
+    "w-full",
+    "py-[6px]",
+    "text-sm",
+    "text-gray-500",
+  ],
+});
 
 const SelectEmptyPlaceholder = () => {
   const { t } = useTranslation();
-  return <Container>{t("inputSelect.empty")}</Container>;
+  return <div className={container()}>{t("inputSelect.empty")}</div>;
 };
 
 export default SelectEmptyPlaceholder;

--- a/frontend/src/js/ui-components/ToggleButton.tsx
+++ b/frontend/src/js/ui-components/ToggleButton.tsx
@@ -1,54 +1,28 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
+import { tv } from "tailwind-variants";
 
 import WithTooltip from "../tooltip/WithTooltip";
 
-const Root = styled("div")`
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-`;
+const root = tv({ base: ["m-0", "flex flex-wrap items-center"] });
 
-const Option = styled("span")<{
-  active?: boolean;
-  isFirst?: boolean;
-  isLast?: boolean;
-}>`
-  font-size: ${({ theme }) => theme.font.xs};
-  display: inline-block;
-  padding: 4px 8px;
-  cursor: pointer;
-  transition:
-    color ${({ theme }) => theme.transitionTime},
-    background-color ${({ theme }) => theme.transitionTime};
-  color: ${({ theme, active }) => (active ? theme.col.black : theme.col.gray)};
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  background-color: ${({ theme, active }) =>
-    active ? "white" : theme.col.grayVeryLight};
-
-  margin-left: -1px;
-  margin-bottom: 2px;
-
-  &:hover {
-    background-color: ${({ theme, active }) =>
-      active ? "white" : theme.col.bg};
-  }
-
-  ${({ isFirst }) =>
-    isFirst &&
-    css`
-      margin-left: 0;
-      border-top-left-radius: 2px;
-      border-bottom-left-radius: 2px;
-    `}
-  ${({ isLast }) =>
-    isLast &&
-    css`
-      border-top-right-radius: 2px;
-      border-bottom-right-radius: 2px;
-    `}
-`;
+const option = tv({
+  base: [
+    "inline-block",
+    "px-2 py-1",
+    "-ml-px mb-[2px]",
+    "cursor-pointer",
+    "border border-gray-500",
+    "text-xs",
+    "transition-[color,background-color] duration-100",
+  ],
+  variants: {
+    active: {
+      true: ["text-gray-800", "bg-white hover:bg-white"],
+      false: ["text-gray-500", "bg-gray-50 hover:bg-bg-50"],
+    },
+    isFirst: { true: ["ml-0", "rounded-l-[2px]"] },
+    isLast: { true: "rounded-r-[2px]" },
+  },
+});
 
 interface OptionsT {
   label: string;
@@ -68,22 +42,25 @@ const ToggleButton = ({
   onChange: (value: string) => void;
 }) => {
   return (
-    <Root className={className}>
+    <div className={root({ className })}>
       {options.map(({ value, label, description }, i) => (
         <WithTooltip key={value} text={description}>
-          <Option
-            isFirst={i === 0}
-            isLast={i === options.length - 1}
-            active={inputValue === value}
+          <button
+            type="button"
+            className={option({
+              isFirst: i === 0,
+              isLast: i === options.length - 1,
+              active: inputValue === value,
+            })}
             onClick={() => {
               if (value !== inputValue) onChange(value);
             }}
           >
             {label}
-          </Option>
+          </button>
         </WithTooltip>
       ))}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/TooManyValues.tsx
+++ b/frontend/src/js/ui-components/TooManyValues.tsx
@@ -1,22 +1,19 @@
-import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
 
-const Root = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 3px 10px;
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
+const root = tv({
+  base: [
+    "flex flex-row items-center",
+    "px-[10px] py-[3px]",
+    "border border-gray-500",
+    "rounded",
+  ],
+});
 
-const Text = styled("p")`
-  margin: 0;
-  line-height: 1;
-`;
+const text = tv({ base: ["m-0", "leading-none"] });
 
 const TooManyValues = ({
   count,
@@ -28,8 +25,8 @@ const TooManyValues = ({
   const { t } = useTranslation();
 
   return (
-    <Root>
-      <Text>{t("queryNodeEditor.tooManyValues", { count })}</Text>
+    <div className={root()}>
+      <p className={text()}>{t("queryNodeEditor.tooManyValues", { count })}</p>
       <IconButton
         icon={faTimes}
         tiny
@@ -37,7 +34,7 @@ const TooManyValues = ({
         aria-label={t("common.clearValue")}
         onClick={onClear}
       />
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/ui-components/VerticalToggleButton.tsx
+++ b/frontend/src/js/ui-components/VerticalToggleButton.tsx
@@ -1,4 +1,5 @@
-import styled from "@emotion/styled";
+import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
 type PropsType = {
   className?: string;
@@ -10,45 +11,40 @@ type PropsType = {
   }[];
 };
 
-const Btn = styled("p")`
-  margin: 0 auto;
-`;
+const btn = tv({ base: "mx-auto my-0" });
 
-export const Option = styled("span")<{ active?: boolean }>`
-  font-size: ${({ theme }) => theme.font.xs};
-  display: block;
-  padding: 2px 8px;
-  cursor: pointer;
-  transition: ${({ theme }) =>
-    `color ${theme.transitionTime}, background-color ${theme.transitionTime}`};
-  color: ${({ theme, active }) => (active ? theme.col.black : theme.col.gray)};
-  border-left: 1px solid ${({ theme }) => theme.col.blueGray};
-  border-right: 1px solid ${({ theme }) => theme.col.blueGray};
-  background-color: ${({ theme, active }) =>
-    active ? theme.col.blueGrayVeryLight : "white"};
+const option = tv({
+  base: [
+    "block",
+    "px-2 py-[2px]",
+    "cursor-pointer",
+    "text-xs",
+    "transition-[color,background-color] duration-100",
+    "border-x border-primary-200",
+    // first child's left border does not overlap
+    "first-of-type:ml-0",
+    "first-of-type:border-t first-of-type:rounded-t-[2px]",
+    "last-of-type:border-b last-of-type:rounded-b-[2px]",
+  ],
+  variants: {
+    active: {
+      true: ["text-gray-800", "bg-primary-50 hover:bg-primary-50"],
+      false: ["text-gray-500", "bg-white hover:bg-gray-50"],
+    },
+  },
+});
 
-  &:first-of-type {
-    margin-left: 0; /* first childs left border does not overlap */
-    border-top: 1px solid ${({ theme }) => theme.col.blueGray};
-    border-top-left-radius: 2px;
-    border-top-right-radius: 2px;
-  }
-
-  &:last-of-type {
-    border-bottom: 1px solid ${({ theme }) => theme.col.blueGray};
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
-  }
-
-  &:hover {
-    background-color: ${({ theme, active }) =>
-      active ? theme.col.blueGrayVeryLight : theme.col.grayVeryLight};
-  }
-`;
+export const Option = ({
+  className,
+  active,
+  ...props
+}: ComponentProps<"span"> & { active?: boolean }) => (
+  <span className={option({ active: !!active, className })} {...props} />
+);
 
 const VerticalToggleButton = (props: PropsType) => {
   return (
-    <Btn className={props.className}>
+    <p className={btn({ className: props.className })}>
       {props.options.map(({ value, label }, i) => (
         <Option
           key={i}
@@ -60,7 +56,7 @@ const VerticalToggleButton = (props: PropsType) => {
           {label}
         </Option>
       ))}
-    </Btn>
+    </p>
   );
 };
 


### PR DESCRIPTION
Third step of the emotion → tailwind migration: `src/js/ui-components/**` (27 files) is emotion-free.

- inputs, selects, multi-select, date pickers, dropzones, toggles, editable text/tags, import modal: every `styled()` is a `tv()` now, flags → variants, precedence of conflicting flags encoded by variant order (commented)
- `InputSelectComponents` exports stay, as small components taking `className` + the same flags; downshift props/refs still spread through
- react-datepicker internals (`InputDate`) styled via a scoped `.conquery-datepicker` block in `index.css`, `calendarContainer` override dropped
- `DropzoneWithFileInput`: the `shouldForwardProp` shim from #3985 is gone, `outside` is a variant
- emotion hid raw elements from biome's a11y rules: `ToggleButton` options are `<button>`s now; `Dropzone`, `InputCheckbox`, `CustomHeader`'s month/year label and `InputDate`'s escape handler keep their `div onClick` with `biome-ignore` + TODO
- `SelectListOption`: `disabled` no longer lands as a DOM attribute on the div (was never functional)
- `Input`'s disabled placeholder opacity now applies (old selector had a typo `&:placehoder`)
