### PR TITLE
feat(frontend): support a single DATE field in form configs

### DIFF
--- a/frontend/mock-api/form-configs/testconf.json
+++ b/frontend/mock-api/form-configs/testconf.json
@@ -15,6 +15,7 @@
     },
     "timeMode": "ABSOLUTE",
     "dateRange": { "min": "2019-01-01", "max": "2019-12-31" },
+    "referenceDate": "2019-06-15",
     "features": [
       {
         "concepts": [

--- a/frontend/mock-api/forms/export-form.json
+++ b/frontend/mock-api/forms/export-form.json
@@ -120,6 +120,16 @@
                 }
               },
               {
+                "name": "referenceDate",
+                "type": "DATE",
+                "label": {
+                  "de": "Stichtag"
+                },
+                "tooltip": {
+                  "de": "Ein einzelnes Datum"
+                }
+              },
+              {
                 "name": "features",
                 "type": "CONCEPT_LIST",
                 "label": {

--- a/frontend/src/js/external-forms/config-types.ts
+++ b/frontend/src/js/external-forms/config-types.ts
@@ -70,6 +70,7 @@ export type Field =
   | DatasetSelectField
   | ResultGroupField
   | ConceptListField
+  | DateField
   | DateRangeField;
 // TODO: At some point, handle multi select as well
 // | MultiSelectField;
@@ -186,6 +187,15 @@ export type DatasetSelectField = CommonField & {
 //   defaultValue?: SelectValue[];
 //   validations?: SelectFieldValidation[];
 // };
+
+/* ------------------------------ */
+
+type DateFieldValidation = NOT_EMPTY_VALIDATION;
+export type DateField = CommonField & {
+  type: "DATE";
+  defaultValue?: string; // "yyyy-MM-dd", default: null
+  validations?: DateFieldValidation[];
+};
 
 /* ------------------------------ */
 

--- a/frontend/src/js/external-forms/form/Field.tsx
+++ b/frontend/src/js/external-forms/form/Field.tsx
@@ -17,6 +17,7 @@ import type { DynamicFormValues } from "./Form";
 import { CheckboxField } from "./fields/CheckboxField";
 import { ConceptListField } from "./fields/ConceptListField";
 import { DatasetSelectField } from "./fields/DatasetSelectField";
+import { DateField } from "./fields/DateField";
 import { DateRangeField } from "./fields/DateRangeField";
 import { DisclosureListField } from "./fields/DisclosureListField";
 import { GroupField } from "./fields/GroupField";
@@ -82,6 +83,14 @@ const Field = ({
     case "NUMBER":
       return (
         <NumberField
+          field={field}
+          defaultValue={defaultValue}
+          commonProps={commonProps}
+        />
+      );
+    case "DATE":
+      return (
+        <DateField
           field={field}
           defaultValue={defaultValue}
           commonProps={commonProps}

--- a/frontend/src/js/external-forms/form/fields/DateField.tsx
+++ b/frontend/src/js/external-forms/form/fields/DateField.tsx
@@ -1,0 +1,78 @@
+import { faCalendar } from "@fortawesome/free-regular-svg-icons";
+import type { ComponentProps } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  formatDateFromState,
+  parseDate,
+  parseDateToState,
+} from "../../../common/helpers/dateHelper";
+import { exists } from "../../../common/helpers/exists";
+import FaIcon from "../../../icon/FaIcon";
+import InfoTooltip from "../../../tooltip/InfoTooltip";
+import InputDate from "../../../ui-components/InputDate/InputDate";
+import Label from "../../../ui-components/Label";
+import type { DateField as DateFieldT } from "../../config-types";
+import { ConnectedField, setValueConfig } from "../ConnectedField";
+import type Field from "../Field";
+
+export const DateField = ({
+  field,
+  defaultValue,
+  commonProps: { control, locale, setValue },
+}: {
+  field: DateFieldT;
+  defaultValue: unknown;
+  commonProps: Omit<ComponentProps<typeof Field>, "field">;
+}) => {
+  const { t } = useTranslation();
+  const displayDateFormat = t("inputDateRange.dateFormat");
+
+  const onChange = (raw: string | number | null) => {
+    const val = raw === null ? "" : String(raw);
+    const date = parseDate(val, displayDateFormat);
+
+    // Keep what was typed until it parses, so the user can see the error
+    setValue(field.name, date ? parseDateToState(date) : val, setValueConfig);
+  };
+
+  return (
+    <ConnectedField
+      formField={field}
+      control={control}
+      defaultValue={defaultValue}
+    >
+      {({ value }) => {
+        const stateValue = (value as string | null) ?? "";
+        const displayValue = formatDateFromState(stateValue, displayDateFormat);
+        const isValid = exists(parseDate(displayValue, displayDateFormat));
+
+        return (
+          <div>
+            <Label>
+              <FaIcon icon={faCalendar} left gray />
+              {field.label[locale]}
+              {field.tooltip && <InfoTooltip text={field.tooltip[locale]} />}
+            </Label>
+            <InputDate
+              // Content-sized, like each single date input inside InputDateRange
+              className="w-fit"
+              value={displayValue}
+              dateFormat={displayDateFormat}
+              valid={isValid}
+              invalid={displayValue.length !== 0 && !isValid}
+              invalidText={t("common.dateInvalid")}
+              placeholder={displayDateFormat.toUpperCase()}
+              onChange={onChange}
+              onBlur={(e) => {
+                if (!parseDate(e.target.value, displayDateFormat)) {
+                  setValue(field.name, null, setValueConfig);
+                }
+              }}
+            />
+          </div>
+        );
+      }}
+    </ConnectedField>
+  );
+};

--- a/frontend/src/js/external-forms/helper.ts
+++ b/frontend/src/js/external-forms/helper.ts
@@ -83,6 +83,7 @@ export function getInitialValue(
   | number
   | boolean
   | undefined
+  | null
   | Array<unknown>
   | { min: null; max: null }
   | SelectOptionT {
@@ -111,6 +112,8 @@ export function getInitialValue(
       return undefined;
     case "CONCEPT_LIST":
       return [];
+    case "DATE":
+      return field.defaultValue ?? null;
     case "DATE_RANGE":
       return {
         min: null,

--- a/frontend/src/js/external-forms/transformQueryToApi.ts
+++ b/frontend/src/js/external-forms/transformQueryToApi.ts
@@ -67,6 +67,8 @@ function transformFieldToApiEntries(
       return [
         [rawFieldname, formValue ? (formValue as DragItemQuery).id : null],
       ];
+    case "DATE":
+      return [[rawFieldname, (formValue as string | null) || null]];
     case "DATE_RANGE":
       return [
         [

--- a/frontend/src/js/external-forms/validators.ts
+++ b/frontend/src/js/external-forms/validators.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next";
 
 import { isEmpty } from "../common/helpers/commonHelper";
+import { parseStdDate } from "../common/helpers/dateHelper";
 import { exists } from "../common/helpers/exists";
 import { isValidSelect } from "../model/select";
 
@@ -24,6 +25,22 @@ export const validatePositive = (t: TFunction, value: number) => {
   return isEmpty(value) || value > 0
     ? null
     : t("externalForms.formValidation.mustBePositiveNumber");
+};
+
+export const validateDate = (t: TFunction, value: string | null) => {
+  // May be empty
+  if (!value) return null;
+
+  return parseStdDate(value) ? null : t("common.dateInvalid");
+};
+
+export const validateDateRequired = (
+  t: TFunction,
+  value: string | null,
+): string | null => {
+  if (!value) return t("externalForms.formValidation.isRequired");
+
+  return validateDate(t, value);
 };
 
 export const validateDateRange = (
@@ -125,6 +142,8 @@ const DEFAULT_VALIDATION_BY_TYPE: Record<
   GROUP: null,
   // MULTI_SELECT: null,
   // @ts-ignore TODO: Refactor using generics to try and tie the `field` to its `value`
+  DATE: validateDate,
+  // @ts-ignore TODO: Refactor using generics to try and tie the `field` to its `value`
   DATE_RANGE: validateDateRange,
   DISCLOSURE_LIST: null,
 };
@@ -133,6 +152,8 @@ function getNotEmptyValidation(fieldType: string) {
   switch (fieldType) {
     case "CONCEPT_LIST":
       return validateConceptGroupFilled;
+    case "DATE":
+      return validateDateRequired;
     case "DATE_RANGE":
       return validateDateRangeRequired;
     default:


### PR DESCRIPTION
Forms could only ask for date ranges; some use cases need a single reference date. New field type `DATE`, value `yyyy-MM-dd` or null, optional `defaultValue`, `NOT_EMPTY` validation. Rendering/validation/api transform mirror DATE_RANGE. Mock export form got a field for manual testing.

Note: the calendar popup clips inside scrolling form containers - pre-existing InputDate issue that DATE_RANGE fields have too; fix follows in a stacked PR.