### PR TITLE
fix(frontend): datepicker popup misaligned and clipped in scroll containers

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -146,11 +146,20 @@ div[data-tippy-root] {
 
 /* react-datepicker inside InputDate */
 .conquery-datepicker {
+  /* The popup anchors to this wrapper, so it must cover the input's box */
   .react-datepicker-wrapper {
     position: absolute;
-    top: 0;
-    bottom: 0;
+    inset: 0;
     z-index: -1;
+  }
+}
+
+/* The popup renders into a body-level portal so that scroll containers
+   (e.g. the form) can neither clip nor misplace it */
+#datepicker-portal {
+  .react-datepicker-popper {
+    /* above the app header (z-3) and panel contents */
+    z-index: 10;
   }
   .react-datepicker-popper[data-placement^="bottom"] {
     padding-top: 4px;

--- a/frontend/src/js/ui-components/InputDate/InputDate.tsx
+++ b/frontend/src/js/ui-components/InputDate/InputDate.tsx
@@ -12,6 +12,7 @@ import BaseInput, { type Props as BaseInputProps } from "../BaseInput";
 import { CustomHeader } from "./CustomHeader";
 
 // react-datepicker's own elements are styled in index.css under this class
+// and under #datepicker-portal (the popup renders into a body-level portal)
 const root = tv({
   base: ["relative", "conquery-datepicker"],
 });
@@ -74,6 +75,7 @@ const InputDate = ({
       />
       <ReactDatePicker
         ref={mergeRefs([datePickerRef, ref])}
+        portalId="datepicker-portal"
         selected={value ? parseDate(value, dateFormat) : new Date()}
         onChange={(val: Date | null) => {
           if (!val) {


### PR DESCRIPTION
Stacked on #3989.

Two defects, one anchor: the popup positioned against a zero-width wrapper at the input's left edge (misaligned) and rendered inline, so scroll containers like the form clipped it. Wrapper now covers the input's box, popup renders into a body-level portal (react-datepicker's `portalId`), popper styles moved from `.conquery-datepicker` scope to the portal - inside `.conquery-datepicker` they could not reach it anymore anyway.

Looks like this now after the fix (not great, but at least not clipped any longer):

<img width="358" height="351" alt="Screenshot 2026-09-02 at 12 56 23" src="https://github.com/user-attachments/assets/6fcf634a-318b-45ee-8848-e5278ec38818" />
