### PR TITLE
refactor(frontend): concept trees, query runner, query node editor on tailwind-variants

### DIFF
--- a/frontend/src/js/concept-trees/ConceptTree.tsx
+++ b/frontend/src/js/concept-trees/ConceptTree.tsx
@@ -1,39 +1,25 @@
-import styled from "@emotion/styled";
 import {
   faEllipsisH,
   faRedo,
   faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
-
+import { tv } from "tailwind-variants";
 import type { ConceptIdT, ConceptT } from "../api/types";
 import IconButton from "../button/IconButton";
 import FaIcon from "../icon/FaIcon";
-
 import ConceptTreeNode from "./ConceptTreeNode";
 import ConceptTreeNodeText from "./ConceptTreeNodeText";
 import type { SearchT } from "./reducer";
 
-const LoadingTree = styled("p")`
-  font-size: ${({ theme }) => theme.font.sm};
-  margin: 2px 0;
-  line-height: 20px;
-`;
-const ErrorMessage = styled("p")`
-  color: ${({ theme }) => theme.col.red};
-  font-weight: 400;
-  font-size: ${({ theme }) => theme.font.sm};
-  margin: 2px 0;
-  line-height: 20px;
-`;
-
-const ReloadButton = styled(IconButton)`
-  padding: 0 7px 0 12px;
-`;
-
-const Spinner = styled("span")`
-  margin-right: 6px;
-`;
+const message = tv({
+  base: ["my-[2px]", "text-sm", "leading-5"],
+  variants: {
+    error: {
+      true: ["text-red", "font-normal"],
+    },
+  },
+});
 
 const ConceptTree = ({
   depth,
@@ -58,19 +44,27 @@ const ConceptTree = ({
 
   if (loading)
     return (
-      <LoadingTree style={{ paddingLeft: 24 + depth * 15 }}>
-        <Spinner>
+      <p className={message()} style={{ paddingLeft: 24 + depth * 15 }}>
+        <span className="mr-[6px]">
           <FaIcon icon={faSpinner} />
-        </Spinner>
+        </span>
         <span>{label}</span>
-      </LoadingTree>
+      </p>
     );
   else if (error)
     return (
-      <ErrorMessage style={{ paddingLeft: 12 + depth * 15 }}>
-        <ReloadButton red icon={faRedo} onClick={() => onLoadTree(conceptId)} />
+      <p
+        className={message({ error: true })}
+        style={{ paddingLeft: 12 + depth * 15 }}
+      >
+        <IconButton
+          className="py-0 pr-[7px] pl-3"
+          red
+          icon={faRedo}
+          onClick={() => onLoadTree(conceptId)}
+        />
         {t("conceptTreeList.error", { tree: label })}
-      </ErrorMessage>
+      </p>
     );
   else if (tree)
     return (

--- a/frontend/src/js/concept-trees/ConceptTreeFolder.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeFolder.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { useMemo } from "react";
 
 import type { ConceptIdT, ConceptT } from "../api/types";
@@ -9,10 +8,6 @@ import ConceptTreeNodeTextContainer from "./ConceptTreeNodeTextContainer";
 import { getConceptById } from "./globalTreeStoreHelper";
 import type { LoadedConcept, SearchT, TreesT } from "./reducer";
 import { isNodeInSearchResult } from "./selectors";
-
-const Root = styled("div")`
-  font-size: ${({ theme }) => theme.font.sm};
-`;
 
 const sumMatchingEntities = (children: string[], initSum: number) => {
   return children.reduce((sum, treeId) => {
@@ -102,7 +97,7 @@ const ConceptTreeFolder = ({
   const isOpen = open || search.allOpen;
 
   return (
-    <Root>
+    <div className="text-sm">
       <ConceptTreeNodeTextContainer
         node={{
           label: tree.label,
@@ -163,7 +158,7 @@ const ConceptTreeFolder = ({
             );
           }
         })}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/concept-trees/ConceptTreeNode.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNode.tsx
@@ -1,5 +1,3 @@
-import styled from "@emotion/styled";
-
 import type { ConceptElementT, ConceptIdT, ConceptT } from "../api/types";
 import { useOpenableConcept } from "../concept-trees-open/useOpenableConcept";
 import { resetSelects } from "../model/select";
@@ -10,10 +8,6 @@ import ConceptTreeNodeTextContainer from "./ConceptTreeNodeTextContainer";
 import { getConceptById } from "./globalTreeStoreHelper";
 import type { SearchT } from "./reducer";
 import { isNodeInSearchResult } from "./selectors";
-
-const Root = styled("div")`
-  font-size: ${({ theme }) => theme.font.sm};
-`;
 
 const ConceptTreeNode = ({
   data,
@@ -52,7 +46,7 @@ const ConceptTreeNode = ({
   ) as ConceptElementT;
 
   return (
-    <Root>
+    <div className="text-sm">
       <ConceptTreeNodeTextContainer
         node={{
           label: data.label,
@@ -117,7 +111,7 @@ const ConceptTreeNode = ({
             />
           ) : null;
         })}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeNodeText.tsx
@@ -1,97 +1,71 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
 import {
   faCaretDown,
   faCaretRight,
   type IconDefinition,
 } from "@fortawesome/free-solid-svg-icons";
 import type { Ref } from "react";
+import { tv } from "tailwind-variants";
 import { Highlighter } from "../common/components/Highlighter";
 
 import FaIcon from "../icon/FaIcon";
 
-// Root with transparent background
-const Root = styled("div")<{ depth: number }>`
-  position: relative; // Needed to fix a drag & drop issue in Safari
-  cursor: pointer;
-  padding: 0 15px 0 15px;
-  margin: 2px 0;
-  padding-left: ${({ depth }) => `${depth * 15}px`};
-  display: flex;
-`;
+// Root with transparent background.
+// relative: needed to fix a drag & drop issue in Safari
+const root = tv({
+  base: ["relative", "flex", "cursor-pointer", "my-[2px]", "pr-[15px]"],
+});
 
-const Text = styled("p")<{
-  red?: boolean;
-  disabled?: boolean;
-  isOpen?: boolean;
-}>`
-  user-select: none;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  margin: 0;
-  padding: 0 10px;
-  line-height: 18px;
-  color: ${({ theme, red, disabled }) =>
-    red ? theme.col.red : disabled ? theme.col.gray : theme.col.black};
-  display: inline-flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-items: center;
+const text = tv({
+  base: [
+    "inline-flex flex-row flex-nowrap items-center",
+    "select-none",
+    "rounded",
+    "border border-transparent",
+    "px-[10px]",
+    "leading-[18px]",
+    "text-gray-800",
+    "bg-bg-50",
+  ],
+  variants: {
+    // later wins when several are set
+    disabled: {
+      true: "text-gray-500",
+      false: "hover:border-primary-200",
+    },
+    red: { true: "text-red" },
+    isOpen: { true: "bg-gray-50" },
+  },
+});
 
-  border: 1px solid transparent;
-  background-color: ${({ theme, isOpen }) =>
-    isOpen ? theme.col.grayVeryLight : theme.col.bg};
+const caretIconContainer = tv({
+  base: ["inline-block", "w-[14px]", "shrink-0"],
+});
 
-  ${({ theme, disabled }) =>
-    !disabled &&
-    css`
-      &:hover {
-        border-color: ${theme.col.blueGray};
-      }
-    `};
-`;
+const folderIconContainer = tv({
+  base: ["inline-block", "w-5", "shrink-0"],
+});
 
-const noShrink = css`
-  display: inline-block;
-  flex-shrink: 0;
-`;
+const dashIconContainer = tv({
+  base: ["flex items-center", "w-[34px]", "shrink-0", "pl-[14px]", "text-left"],
+});
 
-const DashIconContainer = styled("span")`
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  width: 34px;
-  text-align: left;
-  padding-left: 14px;
-`;
+const descriptionText = tv({
+  base: ["inline-block", "shrink-0", "pl-[3px]"],
+});
 
-const FolderIconContainer = styled("span")`
-  width: 20px;
-  ${noShrink};
-`;
-
-const CaretIconContainer = styled("span")`
-  width: 14px;
-  ${noShrink};
-`;
-
-const Description = styled("span")`
-  padding-left: 3px;
-  ${noShrink};
-`;
-
-const ResultsNumber = styled("span")`
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-  padding: 2px 4px;
-  margin-right: 5px;
-  font-size: ${({ theme }) => theme.font.xs};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  color: ${({ theme }) => theme.col.blueGrayDark};
-  font-weight: 700;
-`;
+const resultsNumber = tv({
+  base: [
+    "inline-flex items-center justify-center",
+    "shrink-0",
+    "px-1 py-[2px]",
+    "mr-[5px]",
+    "leading-none",
+    "text-xs",
+    "rounded",
+    "text-primary-500",
+    "font-bold",
+  ],
+});
 
 const ConceptTreeNodeText = ({
   ref,
@@ -127,28 +101,36 @@ const ConceptTreeNodeText = ({
   onClick?: () => void;
 }) => {
   return (
-    <Root ref={ref} className={className} depth={depth}>
-      <Text onClick={onClick} isOpen={isOpen} red={red} disabled={disabled}>
+    <div
+      ref={ref}
+      className={root({ className })}
+      style={{ paddingLeft: depth * 15 }}
+    >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: TODO make this a button */}
+      <p
+        className={text({ disabled: !!disabled, red, isOpen })}
+        onClick={onClick}
+      >
         {hasChildren && (
           <>
-            <CaretIconContainer>
+            <span className={caretIconContainer()}>
               <FaIcon
                 disabled={disabled}
                 active
                 icon={isOpen ? faCaretDown : faCaretRight}
               />
-            </CaretIconContainer>
-            <FolderIconContainer>
+            </span>
+            <span className={folderIconContainer()}>
               <FaIcon active disabled={disabled} icon={icon} />
-            </FolderIconContainer>
+            </span>
           </>
         )}
         {!hasChildren && (
-          <DashIconContainer>
+          <span className={dashIconContainer()}>
             <FaIcon disabled={disabled} large active icon={icon} />
-          </DashIconContainer>
+          </span>
         )}
-        {resultCount && <ResultsNumber>{resultCount}</ResultsNumber>}
+        {resultCount && <span className={resultsNumber()}>{resultCount}</span>}
         <span>
           {searchWords ? (
             <Highlighter searchWords={searchWords} textToHighlight={label} />
@@ -157,7 +139,7 @@ const ConceptTreeNodeText = ({
           )}
         </span>
         {!!description && (
-          <Description>
+          <span className={descriptionText()}>
             {searchWords ? (
               <Highlighter
                 searchWords={searchWords}
@@ -166,10 +148,10 @@ const ConceptTreeNodeText = ({
             ) : (
               `- ${description}`
             )}
-          </Description>
+          </span>
         )}
-      </Text>
-    </Root>
+      </p>
+    </div>
   );
 };
 

--- a/frontend/src/js/concept-trees/ConceptTreeSearchBox.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreeSearchBox.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { tv } from "tailwind-variants";
 
 import type { StateT } from "../app/reducers";
 import { TransparentButton } from "../button/TransparentButton";
@@ -16,38 +16,19 @@ import {
 } from "./actions";
 import type { SearchT, TreesT } from "./reducer";
 
-const Root = styled("div")`
-  position: relative;
-`;
+const root = tv({ base: "relative" });
 
-const TinyText = styled("p")`
-  margin: 3px 0;
-  font-size: ${({ theme }) => theme.font.xs};
-  color: ${({ theme }) => theme.col.gray};
-`;
+const tinyText = tv({
+  base: ["my-[3px]", "text-xs", "text-gray-500"],
+});
 
-const Row = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-`;
+const row = tv({
+  base: "flex flex-row items-center justify-between",
+});
 
-const Displaying = styled("span")`
-  font-size: ${({ theme }) => theme.font.xs};
-  text-transform: uppercase;
-  color: ${({ theme }) => theme.col.gray};
-`;
-
-const StyledButton = styled(TransparentButton)`
-  margin: 3px 0 3px 5px;
-`;
-
-const TopRow = styled("div")`
-  display: flex;
-  align-items: center;
-  gap: 5px;
-`;
+const displaying = tv({
+  base: ["text-xs", "uppercase", "text-gray-500"],
+});
 
 const ConceptTreeSearchBox = ({ className }: { className?: string }) => {
   const showMismatches = useSelector<StateT, boolean>(
@@ -81,8 +62,8 @@ const ConceptTreeSearchBox = ({ className }: { className?: string }) => {
   const onToggleShowMismatches = () => dispatch(toggleShowMismatches());
 
   return (
-    <Root className={className}>
-      <TopRow>
+    <div className={root({ className })}>
+      <div className="flex items-center gap-[5px]">
         <ConceptTreesOpenButtons />
         <SearchBar
           searchTerm={search.query}
@@ -90,35 +71,39 @@ const ConceptTreeSearchBox = ({ className }: { className?: string }) => {
           onClear={onClearQuery}
           onSearch={onSearch}
         />
-      </TopRow>
+      </div>
       {search.loading ? (
         <AnimatedDots />
       ) : (
         search.result &&
         search.resultCount >= 0 && (
-          <Row>
-            <TinyText>
+          <div className={row()}>
+            <p className={tinyText()}>
               {t("search.resultLabel", {
                 totalResults: search.resultCount,
                 duration: (search.duration / 1000.0).toFixed(2),
               })}
-            </TinyText>
+            </p>
             <div>
-              <Displaying>
+              <span className={displaying()}>
                 {showMismatches
                   ? t("conceptTreeList.showingMismatches")
                   : t("conceptTreeList.showingMatchesOnly")}
-              </Displaying>
-              <StyledButton tiny onClick={onToggleShowMismatches}>
+              </span>
+              <TransparentButton
+                className="my-[3px] ml-[5px]"
+                tiny
+                onClick={onToggleShowMismatches}
+              >
                 {showMismatches
                   ? t("conceptTreeList.showMatchesOnly")
                   : t("conceptTreeList.showMismatches")}
-              </StyledButton>
+              </TransparentButton>
             </div>
-          </Row>
+          </div>
         )
       )}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/concept-trees/ConceptTreesLoading.tsx
+++ b/frontend/src/js/concept-trees/ConceptTreesLoading.tsx
@@ -1,29 +1,17 @@
-import styled from "@emotion/styled";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import FaIcon from "../icon/FaIcon";
 
-const Container = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 5px 12px;
-`;
-
-const StyledFaIcon = styled(FaIcon)`
-  margin-right: 10px;
-`;
-
 const ConceptTreesLoading = () => {
   const { t } = useTranslation();
 
   return (
-    <Container>
-      <StyledFaIcon icon={faSpinner} />
+    <div className="flex flex-row items-center px-3 py-[5px]">
+      <FaIcon className="mr-[10px]" icon={faSpinner} />
       <span>{t("conceptTreeList.loading")}</span>
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/js/concept-trees/ConceptsProgressBar.tsx
+++ b/frontend/src/js/concept-trees/ConceptsProgressBar.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
 
@@ -6,23 +5,6 @@ import ProgressBar from "../common/components/ProgressBar";
 import FaIcon from "../icon/FaIcon";
 
 import type { TreesT } from "./reducer";
-
-const Root = styled("div")`
-  margin: 10px;
-`;
-
-const Row = styled("div")`
-  display: flex;
-  align-items: center;
-`;
-
-const Text = styled("p")`
-  margin: 0 10px;
-`;
-
-const SxProgressBar = styled(ProgressBar)`
-  margin: 10px 0;
-`;
 
 type PropsT = {
   trees: TreesT;
@@ -37,15 +19,15 @@ const ConceptsProgressBar = ({ trees }: PropsT) => {
   const donePercent = (doneCount / treeIds.length) * 100;
 
   return (
-    <Root>
-      <Row>
+    <div className="m-[10px]">
+      <div className="flex items-center">
         <FaIcon icon={faSpinner} />
-        <Text>
+        <p className="mx-[10px]">
           {t("conceptTreeList.loading")} {doneCount} / {treeIds.length}
-        </Text>
-      </Row>
-      <SxProgressBar donePercent={donePercent} />
-    </Root>
+        </p>
+      </div>
+      <ProgressBar className="my-[10px]" donePercent={donePercent} />
+    </div>
   );
 };
 

--- a/frontend/src/js/concept-trees/EmptyConceptTreeList.tsx
+++ b/frontend/src/js/concept-trees/EmptyConceptTreeList.tsx
@@ -1,79 +1,45 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
-const Root = styled("div")`
-  position: relative;
-  display: flex;
-  width: 100%;
-  flex-direction: column;
-  margin-left: 10px;
-`;
+const msgContainer = tv({
+  base: ["flex flex-col items-start justify-center", "w-full", "h-full"],
+});
 
-const MsgContainer = styled("div")`
-  display: flex;
-  width: 100%;
-  height: 100%;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-`;
-
-const Msg = styled("div")`
-  width: 400px;
-  white-space: initial;
-`;
-
-const Message = styled("p")`
-  font-size: ${({ theme }) => theme.font.lg};
-  margin: 10px 0 0;
-  font-weight: 400;
-`;
-
-const SubMessage = styled("p")`
-  font-size: ${({ theme }) => theme.font.md};
-  margin: 0 0 10px;
-`;
-
-const Preview = styled("div")`
-  border-radius: ${({ theme }) => theme.borderRadius};
-  background-color: ${({ theme }) => theme.col.grayVeryLight};
-  height: 20px;
-  margin: 3px 0;
-`;
-
-const Container = styled("div")`
-  padding-left: 20px;
-  display: flex;
-  flex-direction: column;
-`;
+const preview = tv({
+  base: ["rounded", "bg-gray-50", "h-5", "my-[3px]"],
+});
 
 const EmptyConceptTreeList = () => {
   const { t } = useTranslation();
 
   return (
-    <Root>
-      <MsgContainer>
-        <Msg>
-          <Message>{t("conceptTreeList.noTrees")}</Message>
-          <SubMessage>{t("conceptTreeList.noTreesExplanation")}</SubMessage>
-        </Msg>
-      </MsgContainer>
-      <Preview style={{ width: `${200}px` }} />
-      <Preview style={{ width: `${100}px` }} />
-      <Container>
-        <Preview style={{ width: `${250}px` }} />
-        <Preview style={{ width: `${150}px` }} />
-        <Preview style={{ width: `${300}px` }} />
-        <Container>
-          <Preview style={{ width: `${200}px` }} />
-          <Preview style={{ width: `${50}px` }} />
-        </Container>
-      </Container>
-      <Preview style={{ width: `${350}px` }} />
-      <Preview style={{ width: `${200}px` }} />
-      <Preview style={{ width: `${300}px` }} />
-      <Preview style={{ width: `${250}px` }} />
-    </Root>
+    <div className="relative ml-[10px] flex w-full flex-col">
+      <div className={msgContainer()}>
+        <div className="w-[400px] whitespace-normal">
+          <p className="mt-[10px] text-xl font-normal">
+            {t("conceptTreeList.noTrees")}
+          </p>
+          <p className="mb-[10px] text-base">
+            {t("conceptTreeList.noTreesExplanation")}
+          </p>
+        </div>
+      </div>
+      <div className={preview()} style={{ width: `${200}px` }} />
+      <div className={preview()} style={{ width: `${100}px` }} />
+      <div className="flex flex-col pl-5">
+        <div className={preview()} style={{ width: `${250}px` }} />
+        <div className={preview()} style={{ width: `${150}px` }} />
+        <div className={preview()} style={{ width: `${300}px` }} />
+        <div className="flex flex-col pl-5">
+          <div className={preview()} style={{ width: `${200}px` }} />
+          <div className={preview()} style={{ width: `${50}px` }} />
+        </div>
+      </div>
+      <div className={preview()} style={{ width: `${350}px` }} />
+      <div className={preview()} style={{ width: `${200}px` }} />
+      <div className={preview()} style={{ width: `${300}px` }} />
+      <div className={preview()} style={{ width: `${250}px` }} />
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/AdditionalConceptNodeChildren.tsx
+++ b/frontend/src/js/query-node-editor/AdditionalConceptNodeChildren.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { ConceptBaseT, ConceptIdT } from "../api/types";
 import { Heading4 } from "../headings/Headings";
@@ -10,23 +10,17 @@ import ConceptDropzone from "./ConceptDropzone";
 import ConceptEntry from "./ConceptEntry";
 import { HeadingBetween } from "./HeadingBetween";
 
-const Padded = styled("div")`
-  padding: 0 15px 15px;
-  height: 100%;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-`;
-const Scrollable = styled("div")`
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  height: 100%;
-`;
-const Heading4Highlighted = styled(Heading4)`
-  color: ${({ theme }) => theme.col.blueGrayDark};
-  font-weight: 700;
-  margin: 10px 0 5px;
-`;
+const padded = tv({
+  base: ["flex flex-col", "h-full", "overflow-hidden", "px-[15px] pb-[15px]"],
+});
+
+const scrollable = tv({
+  base: ["h-full", "overflow-y-auto", "[-webkit-overflow-scrolling:touch]"],
+});
+
+const heading = tv({
+  base: ["text-primary-500", "font-bold", "mt-[10px] mb-[5px]"],
+});
 
 const AdditionalConceptNodeChildren = ({
   node,
@@ -46,12 +40,12 @@ const AdditionalConceptNodeChildren = ({
   return (
     <>
       <HeadingBetween>{t("queryNodeEditor.dropMoreConcepts")}</HeadingBetween>
-      <Padded>
-        <Heading4Highlighted>{rootConcept.label}</Heading4Highlighted>
+      <div className={padded()}>
+        <Heading4 className={heading()}>{rootConcept.label}</Heading4>
         <div>
           <ConceptDropzone node={node} onDropConcept={onDropConcept} />
         </div>
-        <Scrollable>
+        <div className={scrollable()}>
           {sortedNodeIds.map((conceptId) => (
             <ConceptEntry
               key={conceptId}
@@ -61,8 +55,8 @@ const AdditionalConceptNodeChildren = ({
               onRemoveConcept={onRemoveConcept}
             />
           ))}
-        </Scrollable>
-      </Padded>
+        </div>
+      </div>
     </>
   );
 };

--- a/frontend/src/js/query-node-editor/CommonNodeSettings.tsx
+++ b/frontend/src/js/query-node-editor/CommonNodeSettings.tsx
@@ -1,16 +1,7 @@
-import styled from "@emotion/styled";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import InputCheckbox from "../ui-components/InputCheckbox";
-
-const Container = styled("div")`
-  margin: 15px 10px;
-`;
-const Row = styled("div")`
-  max-width: 300px;
-  margin-bottom: 10px;
-`;
 
 interface Props {
   excludeTimestamps?: boolean;
@@ -28,9 +19,9 @@ const CommonNodeSettings = ({
   const { t } = useTranslation();
 
   return (
-    <Container>
+    <div className="mx-[10px] my-[15px]">
       {onToggleTimestamps && (
-        <Row>
+        <div className="mb-[10px] max-w-[300px]">
           <InputCheckbox
             label={t("queryNodeEditor.excludeTimestamps")}
             tooltip={t("help.excludeTimestamps")}
@@ -38,10 +29,10 @@ const CommonNodeSettings = ({
             value={excludeTimestamps}
             onChange={onToggleTimestamps}
           />
-        </Row>
+        </div>
       )}
       {onToggleSecondaryIdExclude && (
-        <Row>
+        <div className="mb-[10px] max-w-[300px]">
           <InputCheckbox
             label={t("queryNodeEditor.excludeFromSecondaryId")}
             tooltip={t("help.excludeFromSecondaryId")}
@@ -49,9 +40,9 @@ const CommonNodeSettings = ({
             value={excludeFromSecondaryId}
             onChange={onToggleSecondaryIdExclude}
           />
-        </Row>
+        </div>
       )}
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/ConceptDropzone.tsx
+++ b/frontend/src/js/query-node-editor/ConceptDropzone.tsx
@@ -1,14 +1,9 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
 
 import { DNDType } from "../common/constants/dndTypes";
 import { canNodeBeDropped } from "../model/node";
 import type { DragItemConceptTreeNode } from "../standard-query-editor/types";
 import Dropzone from "../ui-components/Dropzone";
-
-const SxDropzone = styled(Dropzone)`
-  width: 100%;
-`;
 
 const DROP_TYPES = [DNDType.CONCEPT_TREE_NODE];
 
@@ -22,13 +17,14 @@ const ConceptDropzone = ({
   const { t } = useTranslation();
 
   return (
-    <SxDropzone
+    <Dropzone
+      className="w-full"
       acceptedDropTypes={DROP_TYPES}
       onDrop={(item) => onDropConcept(item as DragItemConceptTreeNode)}
       canDrop={(item) => canNodeBeDropped(node, item)}
     >
       {() => t("queryNodeEditor.dropConcept")}
-    </SxDropzone>
+    </Dropzone>
   );
 };
 

--- a/frontend/src/js/query-node-editor/ConceptEntry.tsx
+++ b/frontend/src/js/query-node-editor/ConceptEntry.tsx
@@ -1,45 +1,29 @@
-import styled from "@emotion/styled";
 import { faTrashCan } from "@fortawesome/free-regular-svg-icons";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { ConceptIdT, ConceptT } from "../api/types";
 import IconButton from "../button/IconButton";
 import { getConceptById } from "../concept-trees/globalTreeStoreHelper";
 import AdditionalInfoHoverable from "../tooltip/AdditionalInfoHoverable";
 
-const Concept = styled("div")`
-  background-color: white;
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  padding: 5px 15px;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-top: 5px;
-`;
+const concept = tv({
+  base: [
+    "flex flex-row items-center",
+    "mt-[5px]",
+    "rounded",
+    "border border-gray-500",
+    "bg-white",
+    "px-[15px] py-[5px]",
+  ],
+});
 
-const ConceptContainer = styled("div")`
-  flex-grow: 1;
-`;
-
-const ConceptEntryHeadline = styled("h6")`
-  margin: 0;
-  font-size: ${({ theme }) => theme.font.sm};
-  font-weight: 400;
-`;
-
-const ConceptEntryDescription = styled("p")`
-  margin: 0;
-  font-size: ${({ theme }) => theme.font.xs};
-`;
-
-const NotFound = styled(ConceptEntryHeadline)`
-  color: ${({ theme }) => theme.col.red};
-`;
-
-const SxIconButton = styled(IconButton)`
-  flex-shrink: 0;
-`;
+const headline = tv({
+  base: ["m-0", "text-sm", "font-normal"],
+  variants: {
+    notFound: { true: "text-red" },
+  },
+});
 
 interface Props {
   conceptId: ConceptIdT;
@@ -58,29 +42,30 @@ const ConceptEntry = ({
   const node = getConceptById(conceptId);
 
   const ConceptEntryRoot = (
-    <Concept>
-      <ConceptContainer>
+    <div className={concept()}>
+      <div className="grow">
         {!node ? (
-          <NotFound>{t("queryNodeEditor.nodeNotFound")}</NotFound>
+          <h6 className={headline({ notFound: true })}>
+            {t("queryNodeEditor.nodeNotFound")}
+          </h6>
         ) : (
           <>
-            <ConceptEntryHeadline>{node.label}</ConceptEntryHeadline>
+            <h6 className={headline()}>{node.label}</h6>
             {node.description && (
-              <ConceptEntryDescription>
-                {node.description}
-              </ConceptEntryDescription>
+              <p className="m-0 text-xs">{node.description}</p>
             )}
           </>
         )}
-      </ConceptContainer>
+      </div>
       {canRemoveConcepts && (
-        <SxIconButton
+        <IconButton
+          className="shrink-0"
           onClick={() => onRemoveConcept(conceptId)}
           tiny
           icon={faTrashCan}
         />
       )}
-    </Concept>
+    </div>
   );
 
   return node && root ? (

--- a/frontend/src/js/query-node-editor/ContentCell.tsx
+++ b/frontend/src/js/query-node-editor/ContentCell.tsx
@@ -1,23 +1,19 @@
-import styled from "@emotion/styled";
 import type { ReactNode, Ref } from "react";
+import { tv } from "tailwind-variants";
 
 import { Heading4 } from "../headings/Headings";
 
-const Root = styled("div")`
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  min-width: 220px;
-`;
+const root = tv({
+  base: ["shrink-0", "flex flex-col", "min-w-[220px]"],
+});
 
-const Content = styled("div")`
-  flex-grow: 1;
-  padding: 3px 10px;
-`;
+const content = tv({
+  base: ["grow", "px-[10px] py-[3px]"],
+});
 
-const Headline = styled(Heading4)`
-  margin: 14px 10px 0;
-`;
+const headlineHeading = tv({
+  base: ["mx-[10px] mt-[14px]"],
+});
 
 interface PropsT {
   className?: string;
@@ -31,10 +27,10 @@ const ContentCell = ({
   headline,
   children,
 }: PropsT & { ref?: Ref<HTMLDivElement> }) => (
-  <Root ref={ref} className={className}>
-    {headline && <Headline>{headline}</Headline>}
-    <Content>{children}</Content>
-  </Root>
+  <div ref={ref} className={root({ className })}>
+    {headline && <Heading4 className={headlineHeading()}>{headline}</Heading4>}
+    <div className={content()}>{children}</div>
+  </div>
 );
 
 export default ContentCell;

--- a/frontend/src/js/query-node-editor/ContentColumn.tsx
+++ b/frontend/src/js/query-node-editor/ContentColumn.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { PostPrefixForSuggestionsParams } from "../api/api";
 import type {
@@ -22,27 +22,19 @@ import ContentCell from "./ContentCell";
 import NodeSelects from "./NodeSelects";
 import TableView from "./TableView";
 
-const Column = styled("div")`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-`;
+// mb-0 overrides the h3 base margin from index.css
+const sectionHeading = tv({
+  base: ["mx-[10px] mt-[10px] mb-0"],
+});
 
-const SectionHeading = styled(Heading3)`
-  margin: 10px 10px 0;
-`;
-
-const ContentCellGroup = styled(ContentCell)`
-  padding-bottom: 10px;
-  margin-bottom: 10px;
-  border-bottom: 1px solid ${({ theme }) => theme.col.grayLight};
-
-  &:last-of-type {
-    border-bottom: none;
-    padding-bottom: 0;
-    margin-bottom: 0;
-  }
-`;
+const contentCellGroup = tv({
+  base: [
+    "pb-[10px]",
+    "mb-[10px]",
+    "border-b border-gray-100",
+    "last-of-type:border-b-0 last-of-type:pb-0 last-of-type:mb-0",
+  ],
+});
 
 const ContentColumn = ({
   node,
@@ -101,9 +93,11 @@ const ContentColumn = ({
   }, [selectedTableIdx]);
 
   return (
-    <Column>
-      <ContentCellGroup>
-        <SectionHeading>{t("queryNodeEditor.properties")}</SectionHeading>
+    <div className="flex w-full flex-col">
+      <ContentCell className={contentCellGroup()}>
+        <Heading3 className={sectionHeading()}>
+          {t("queryNodeEditor.properties")}
+        </Heading3>
         {(onToggleSecondaryIdExclude || onToggleTimestamps) && (
           <CommonNodeSettings
             excludeFromSecondaryId={node.excludeFromSecondaryId}
@@ -120,20 +114,21 @@ const ContentColumn = ({
             allowlistedSelects={allowlistedSelects}
           />
         )}
-      </ContentCellGroup>
+      </ContentCell>
       {tables.map((table, idx) => {
         if (table.exclude) {
           return null;
         }
 
         return (
-          <ContentCellGroup
+          <ContentCell
+            className={contentCellGroup()}
             key={table.id}
             ref={(instance) => {
               itemsRef.current[idx] = instance;
             }}
           >
-            <SectionHeading>{table.label}</SectionHeading>
+            <Heading3 className={sectionHeading()}>{table.label}</Heading3>
             <TableView
               node={
                 node as ConceptQueryNodeType /* otherwise there won't be tables */
@@ -147,10 +142,10 @@ const ContentColumn = ({
               onSwitchFilterMode={onSwitchFilterMode}
               onLoadFilterSuggestions={onLoadFilterSuggestions}
             />
-          </ContentCellGroup>
+          </ContentCell>
         );
       })}
-    </Column>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/HeadingBetween.tsx
+++ b/frontend/src/js/query-node-editor/HeadingBetween.tsx
@@ -1,7 +1,13 @@
-import styled from "@emotion/styled";
+import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
 import { Heading4 } from "../headings/Headings";
 
-export const HeadingBetween = styled(Heading4)`
-  margin: 15px 15px 0;
-`;
+const headingBetween = tv({ base: ["mx-[15px] mt-[15px]"] });
+
+export const HeadingBetween = ({
+  className,
+  ...props
+}: ComponentProps<typeof Heading4>) => (
+  <Heading4 className={headingBetween({ className })} {...props} />
+);

--- a/frontend/src/js/query-node-editor/MenuColumn.tsx
+++ b/frontend/src/js/query-node-editor/MenuColumn.tsx
@@ -1,5 +1,5 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { ConceptIdT } from "../api/types";
 import { getConceptById } from "../concept-trees/globalTreeStoreHelper";
@@ -14,34 +14,34 @@ import AdditionalConceptNodeChildren from "./AdditionalConceptNodeChildren";
 import { HeadingBetween } from "./HeadingBetween";
 import MenuColumnItem from "./MenuColumnItem";
 
-const FixedColumn = styled("div")<{ isEmpty?: boolean }>`
-  display: flex;
-  flex-direction: column;
-  width: ${({ isEmpty }) => (isEmpty ? "200px" : "270px")};
-  overflow: hidden;
-  flex-shrink: 0;
-  flex-grow: 1;
-  height: 100%;
+const fixedColumn = tv({
+  base: [
+    "flex flex-col",
+    "shrink-0 grow",
+    "h-full",
+    "overflow-hidden",
+    "first-of-type:border-r first-of-type:border-r-gray-100",
+  ],
+  variants: {
+    isEmpty: {
+      true: "w-[200px]",
+      false: "w-[270px]",
+    },
+  },
+});
 
-  &:first-of-type {
-    border-right: 1px solid ${({ theme }) => theme.col.grayLight};
-  }
-`;
+const dimmedNote = tv({
+  base: ["p-[15px]", "text-gray-100", "font-normal"],
+});
 
-const DimmedNote = styled(Heading3)`
-  color: ${({ theme }) => theme.col.grayLight};
-  padding: 15px;
-  font-weight: 400;
-`;
-
-const CommonSettingsLabel = styled(Heading3)`
-  padding: 15px 15px 0;
-  margin: 0;
-  cursor: pointer;
-  &:hover {
-    text-decoration: underline;
-  }
-`;
+const commonSettingsLabel = tv({
+  base: [
+    "px-[15px] pt-[15px] pb-0",
+    "m-0",
+    "cursor-pointer",
+    "hover:underline",
+  ],
+});
 
 const MenuColumn = ({
   className,
@@ -87,15 +87,20 @@ const MenuColumn = ({
       (!rootConcept?.children || rootConcept.children.length === 0));
 
   return (
-    <FixedColumn className={className} isEmpty={isEmpty}>
+    <div className={fixedColumn({ isEmpty, className })}>
       {isEmpty && (
-        <DimmedNote>{t("queryNodeEditor.emptyMenuColumn")}</DimmedNote>
+        <Heading3 className={dimmedNote()}>
+          {t("queryNodeEditor.emptyMenuColumn")}
+        </Heading3>
       )}
       {nodeIsConceptQueryNode(node) && showTables && (
         <>
-          <CommonSettingsLabel onClick={onCommonSettingsClick}>
+          <Heading3
+            className={commonSettingsLabel()}
+            onClick={onCommonSettingsClick}
+          >
             {t("queryNodeEditor.properties")}
-          </CommonSettingsLabel>
+          </Heading3>
           <HeadingBetween>
             {t("queryNodeEditor.conceptNodeTables")}
           </HeadingBetween>
@@ -130,7 +135,7 @@ const MenuColumn = ({
             onRemoveConcept={onRemoveConcept}
           />
         )}
-    </FixedColumn>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/MenuColumnItem.tsx
+++ b/frontend/src/js/query-node-editor/MenuColumnItem.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { faCheckSquare, faSquare } from "@fortawesome/free-regular-svg-icons";
 import { faFilter } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
 import type { NodeResetConfig } from "../model/node";
@@ -9,54 +9,35 @@ import { tableHasFilterValues, tableIsDisabled } from "../model/table";
 import type { TableWithFilterValueT } from "../standard-query-editor/types";
 import WithTooltip from "../tooltip/WithTooltip";
 
-const Container = styled("div")<{ disabled?: boolean }>`
-  font-size: ${({ theme }) => theme.font.md};
-  line-height: 21px;
-  padding: 8px 15px;
-  font-weight: 700;
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.col.gray : theme.col.black};
-  width: 100%;
-  text-align: left;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  background-color: transparent;
-  cursor: pointer;
+const container = tv({
+  base: [
+    "flex flex-row items-center justify-between",
+    "w-full",
+    "bg-transparent",
+    "px-[15px] py-2",
+    "text-base",
+    "leading-[21px]",
+    "font-bold",
+    "text-left",
+    "cursor-pointer",
+    "hover:underline",
+  ],
+  variants: {
+    disabled: {
+      true: "text-gray-500",
+      false: "text-gray-800",
+    },
+  },
+});
 
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
-const SxWithTooltip = styled(WithTooltip)`
-  display: flex !important;
-`;
-
-const SxIconButton = styled(IconButton)`
-  font-size: ${({ theme }) => theme.font.lg};
-  line-height: ${({ theme }) => theme.font.lg};
-  padding: 0;
-
-  svg {
-    font-size: ${({ theme }) => theme.font.lg};
-    line-height: ${({ theme }) => theme.font.lg};
-  }
-`;
-const ResetButton = styled(IconButton)`
-  padding: 0;
-`;
-
-const Label = styled("span")`
-  padding-left: 10px;
-  line-height: ${({ theme }) => theme.font.lg};
-`;
-
-const Row = styled("div")`
-  display: flex;
-  align-items: center;
-`;
+const toggleButton = tv({
+  base: [
+    "p-0",
+    "text-xl",
+    "leading-[20px]",
+    "[&_svg]:text-xl [&_svg]:leading-[20px]",
+  ],
+});
 
 const MenuColumnItem = ({
   table,
@@ -89,9 +70,12 @@ const MenuColumnItem = ({
   const isFilterActive = tableHasFilterValues(table);
 
   return (
-    <Container disabled={isDisabled} onClick={onClick}>
-      <Row>
-        <SxIconButton
+    // biome-ignore lint/a11y/useKeyWithClickEvents: TODO make the table row a real button
+    // biome-ignore lint/a11y/noStaticElementInteractions: see above
+    <div className={container({ disabled: isDisabled })} onClick={onClick}>
+      <div className="flex items-center">
+        <IconButton
+          className={toggleButton()}
           icon={includable ? faSquare : faCheckSquare}
           disabled={isDisabled || (!includable && !excludable)}
           onClick={(event) => {
@@ -107,11 +91,15 @@ const MenuColumnItem = ({
             }
           }}
         />
-        <Label>{table.label}</Label>
-      </Row>
+        <span className="pl-[10px] leading-[20px]">{table.label}</span>
+      </div>
       {isFilterActive && (
-        <SxWithTooltip text={t("queryNodeEditor.clearSettings")}>
-          <ResetButton
+        <WithTooltip
+          className="flex!"
+          text={t("queryNodeEditor.clearSettings")}
+        >
+          <IconButton
+            className="p-0"
             icon={faFilter}
             active
             onClick={(event) => {
@@ -125,9 +113,9 @@ const MenuColumnItem = ({
               onResetTable({ useDefaults: false });
             }}
           />
-        </SxWithTooltip>
+        </WithTooltip>
       )}
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/NodeName.tsx
+++ b/frontend/src/js/query-node-editor/NodeName.tsx
@@ -1,12 +1,7 @@
-import styled from "@emotion/styled";
 import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import EditableText from "../ui-components/EditableText";
-
-const Root = styled("div")`
-  padding: 10px 15px;
-`;
 
 interface Props {
   allowEditing: boolean;
@@ -20,7 +15,7 @@ const NodeName = ({ allowEditing, label, maxWidth, onUpdateLabel }: Props) => {
   const [editingLabel, setEditingLabel] = useState<boolean>(false);
 
   return (
-    <Root style={{ maxWidth }}>
+    <div className="px-[15px] py-[10px]" style={{ maxWidth }}>
       {allowEditing ? (
         <EditableText
           large
@@ -38,7 +33,7 @@ const NodeName = ({ allowEditing, label, maxWidth, onUpdateLabel }: Props) => {
       ) : (
         label
       )}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
+++ b/frontend/src/js/query-node-editor/QueryNodeEditor.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { tv } from "tailwind-variants";
 
 import type { PostPrefixForSuggestionsParams } from "../api/api";
 import type {
@@ -28,62 +28,47 @@ import NodeName from "./NodeName";
 import ResetAndClose from "./ResetAndClose";
 import { useAutoLabel } from "./useAutoLabel";
 
-const Root = styled("div")`
-  padding: 10px;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  position: absolute;
-  z-index: 2;
-  background-color: ${({ theme }) => theme.col.bg};
-`;
+const root = tv({
+  base: ["absolute inset-0", "z-2", "p-[10px]", "bg-bg-50"],
+});
 
-const ContentWrap = styled("div")`
-  background-color: white;
-  box-shadow: 1px 2px 5px 0 rgba(0, 0, 0, 0.2);
-  border: 1px solid ${({ theme }) => theme.col.grayMediumLight};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  flex-grow: 1;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-`;
+const contentWrap = tv({
+  base: [
+    "flex flex-col",
+    "grow",
+    "h-full w-full",
+    "overflow-hidden",
+    "rounded",
+    "border border-gray-400",
+    "bg-white",
+    "shadow-[1px_2px_5px_0_rgba(0,0,0,0.2)]",
+  ],
+});
 
-const Wrapper = styled("div")`
-  flex-grow: 1;
-  width: 100%;
-  overflow: hidden;
-`;
-const ScrollContainer = styled("div")`
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  width: 100%;
-  height: 100%;
-  overflow-y: auto;
-  background-color: ${({ theme }) => theme.col.bg};
-  --webkit-overflow-scrolling: touch;
-`;
+// the original also declared `--webkit-overflow-scrolling: touch` —
+// a typo (double dash) that only defined an unused custom property, dropped
+const scrollContainer = tv({
+  base: [
+    "relative",
+    "flex flex-row",
+    "h-full w-full",
+    "overflow-y-auto",
+    "bg-bg-50",
+  ],
+});
 
-const SxMenuColumn = styled(MenuColumn)`
-  background-color: ${({ theme }) => theme.col.bg};
-  position: sticky;
-  z-index: 2;
-  top: 0;
-  left: 0;
-`;
+const menuColumn = tv({
+  base: ["sticky top-0 left-0", "z-2", "bg-bg-50"],
+});
 
-const Header = styled("div")`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  border-bottom: 1px solid #ccc;
-  padding-right: 10px;
-`;
+const header = tv({
+  base: [
+    "flex items-center justify-between",
+    "w-full",
+    "border-b border-[#ccc]",
+    "pr-[10px]",
+  ],
+});
 
 export interface QueryNodeEditorPropsT {
   name: string;
@@ -178,7 +163,8 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
   );
 
   return (
-    <Root
+    <div
+      className={root()}
       ref={(instance) => {
         if (instance && parentWidth === 0) {
           setParentWidth(instance.getBoundingClientRect().width);
@@ -186,8 +172,8 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
         parentRef.current = instance;
       }}
     >
-      <ContentWrap>
-        <Header>
+      <div className={contentWrap()}>
+        <div className={header()}>
           <NodeName
             maxWidth={nodeNameMaxWidth}
             allowEditing={nodeIsConceptQueryNode(node)}
@@ -203,10 +189,11 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
             onResetAllSettings={props.onResetAllSettings}
             showClearReset={showClearReset}
           />
-        </Header>
-        <Wrapper>
-          <ScrollContainer ref={scrollContainerRef}>
-            <SxMenuColumn
+        </div>
+        <div className="w-full grow overflow-hidden">
+          <div className={scrollContainer()} ref={scrollContainerRef}>
+            <MenuColumn
+              className={menuColumn()}
               node={node}
               selectedTableIdx={selectedTableIdx}
               showTables={props.showTables}
@@ -239,10 +226,10 @@ const QueryNodeEditor = ({ node, ...props }: QueryNodeEditorPropsT) => {
               onSetFilterValue={props.onSetFilterValue}
               onSwitchFilterMode={props.onSwitchFilterMode}
             />
-          </ScrollContainer>
-        </Wrapper>
-      </ContentWrap>
-    </Root>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/ResetAllSettingsButton.tsx
+++ b/frontend/src/js/query-node-editor/ResetAllSettingsButton.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -6,10 +5,6 @@ import { useTranslation } from "react-i18next";
 import IconButton from "../button/IconButton";
 import { ConfirmableTooltip } from "../tooltip/ConfirmableTooltip";
 import WithTooltip from "../tooltip/WithTooltip";
-
-const SxWithTooltip = styled(WithTooltip)`
-  white-space: nowrap;
-`;
 
 const ResetAllSettingsButton = ({
   compact,
@@ -24,9 +19,9 @@ const ResetAllSettingsButton = ({
 
   const button = useMemo(() => {
     return compact ? (
-      <SxWithTooltip text={text}>
+      <WithTooltip className="whitespace-nowrap" text={text}>
         <IconButton icon={faTrash} active />
-      </SxWithTooltip>
+      </WithTooltip>
     ) : (
       <IconButton icon={faTrash} active>
         {text}

--- a/frontend/src/js/query-node-editor/ResetAndClose.tsx
+++ b/frontend/src/js/query-node-editor/ResetAndClose.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -7,11 +6,6 @@ import type { NodeResetConfig } from "../model/node";
 import WithTooltip from "../tooltip/WithTooltip";
 
 import ResetAllSettingsButton from "./ResetAllSettingsButton";
-
-const Row = styled("div")`
-  display: flex;
-  align-items: center;
-`;
 
 interface Props {
   isCompact: boolean;
@@ -29,7 +23,7 @@ const ResetAndClose = ({
   const { t } = useTranslation();
 
   return (
-    <Row>
+    <div className="flex items-center">
       {showClearReset && (
         <ResetAllSettingsButton
           onClick={() => onResetAllSettings({ useDefaults: false })}
@@ -41,7 +35,7 @@ const ResetAndClose = ({
           {t("common.save")}
         </TransparentButton>
       </WithTooltip>
-    </Row>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/TableFilter.tsx
+++ b/frontend/src/js/query-node-editor/TableFilter.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { memo } from "react";
 import { useSelector } from "react-redux";
+import { tv } from "tailwind-variants";
 
 import type {
   CurrencyConfigT,
@@ -15,9 +15,7 @@ import InputSelect from "../ui-components/InputSelect/InputSelect";
 
 import FilterListMultiSelect from "./FilterListMultiSelect";
 
-const Container = styled("div")`
-  margin-bottom: 10px;
-`;
+const container = tv({ base: "mb-[10px]" });
 
 export interface BaseTableFilterProps {
   className?: string;
@@ -183,9 +181,12 @@ const TableFilter = ({
   })();
 
   return filterComponent ? (
-    <Container className={className} data-test-id={`table-filter-${filter.id}`}>
+    <div
+      className={container({ className })}
+      data-test-id={`table-filter-${filter.id}`}
+    >
       {filterComponent}
-    </Container>
+    </div>
   ) : null;
 };
 

--- a/frontend/src/js/query-node-editor/TableView.tsx
+++ b/frontend/src/js/query-node-editor/TableView.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -18,16 +17,6 @@ import ContentCell from "./ContentCell";
 import DateColumnSelect from "./DateColumnSelect";
 import TableFilters from "./TableFilters";
 import TableSelects from "./TableSelects";
-
-const Column = styled("div")`
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-`;
-
-const MaximizedCell = styled(ContentCell)`
-  flex-grow: 1;
-`;
 
 const TableView = ({
   node,
@@ -117,7 +106,7 @@ const TableView = ({
   );
 
   return (
-    <Column>
+    <div className="flex grow flex-col">
       {displaySelects && (
         <ContentCell headline={t("queryNodeEditor.selects")}>
           {table.selects && table.selects.length > 0 && (
@@ -140,7 +129,7 @@ const TableView = ({
         </ContentCell>
       )}
       {displayFilters && (
-        <MaximizedCell headline={t("queryNodeEditor.filters")}>
+        <ContentCell className="grow" headline={t("queryNodeEditor.filters")}>
           <TableFilters
             key={tableIdx}
             filters={table.filters}
@@ -149,9 +138,9 @@ const TableView = ({
             onSwitchFilterMode={setFilterMode}
             onLoadFilterSuggestions={loadFilterSuggestions}
           />
-        </MaximizedCell>
+        </ContentCell>
       )}
-    </Column>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-node-editor/UploadFilterListModal.tsx
+++ b/frontend/src/js/query-node-editor/UploadFilterListModal.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   faCheckCircle,
   faExclamationCircle,
@@ -6,6 +5,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 import type { PostFilterResolveResponseT } from "../api/types";
 import PrimaryButton from "../button/PrimaryButton";
 import FaIcon from "../icon/FaIcon";
@@ -13,36 +13,23 @@ import Modal from "../modal/Modal";
 import ScrollableList from "../scrollable-list/ScrollableList";
 import InputCheckbox from "../ui-components/InputCheckbox";
 
-const Root = styled("div")`
-  padding: 0 0 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 15px;
-`;
-const Col = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-`;
+const root = tv({
+  base: ["flex flex-col", "gap-[15px]", "pb-[10px]"],
+});
 
-const Msg = styled("p")`
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-`;
-const BigIcon = styled(FaIcon)`
-  font-size: 20px;
-`;
-const ErrorIcon = styled(BigIcon)`
-  color: ${({ theme }) => theme.col.red};
-`;
-const SuccessIcon = styled(BigIcon)`
-  color: ${({ theme }) => theme.col.green};
-`;
-const CenteredIcon = styled(FaIcon)`
-  text-align: center;
-`;
+const msg = tv({
+  base: ["m-0", "flex items-center", "gap-[10px]"],
+});
+
+const bigIcon = tv({
+  base: "text-xl",
+  variants: {
+    kind: {
+      error: "text-red",
+      success: "text-green",
+    },
+  },
+});
 
 const selectResolvedItemsCount = (
   resolved: PostFilterResolveResponseT | null,
@@ -91,18 +78,24 @@ const UploadFilterListModal = ({
       doneButton
       headline={t("uploadFilterListModal.headline")}
     >
-      <Root>
-        {loading && <CenteredIcon icon={faSpinner} />}
+      <div className={root()}>
+        {loading && <FaIcon center icon={faSpinner} />}
         {error && (
           <p>
-            <ErrorIcon icon={faExclamationCircle} />
+            <FaIcon
+              className={bigIcon({ kind: "error" })}
+              icon={faExclamationCircle}
+            />
             {t("uploadConceptListModal.error")}
           </p>
         )}
         {hasUnresolvedItems && (
-          <Col>
-            <Msg>
-              <ErrorIcon icon={faExclamationCircle} />
+          <div className="flex flex-col gap-[5px]">
+            <p className={msg()}>
+              <FaIcon
+                className={bigIcon({ kind: "error" })}
+                icon={faExclamationCircle}
+              />
               <span
                 // biome-ignore lint/security/noDangerouslySetInnerHtml: i18n text with markup
                 dangerouslySetInnerHTML={{
@@ -111,22 +104,25 @@ const UploadFilterListModal = ({
                   }),
                 }}
               />
-            </Msg>
+            </p>
             <ScrollableList
               maxVisibleItems={3}
               fullWidth
               items={resolved.unknownCodes || []}
             />
-          </Col>
+          </div>
         )}
-        <Col>
+        <div className="flex flex-col gap-[5px]">
           {hasResolvedItems && (
-            <Msg>
-              <SuccessIcon icon={faCheckCircle} />
+            <p className={msg()}>
+              <FaIcon
+                className={bigIcon({ kind: "success" })}
+                icon={faCheckCircle}
+              />
               {t("uploadConceptListModal.resolvedCodes", {
                 count: resolvedItemsCount,
               })}
-            </Msg>
+            </p>
           )}
           {(resolved.unknownCodes?.length || 0) > 0 && (
             <InputCheckbox
@@ -135,7 +131,7 @@ const UploadFilterListModal = ({
               label={t("uploadConceptListModal.includeUnresolved")}
             />
           )}
-        </Col>
+        </div>
         <PrimaryButton
           disabled={loading || nothingToInsert}
           onClick={() => {
@@ -145,7 +141,7 @@ const UploadFilterListModal = ({
         >
           {t("uploadConceptListModal.insertNode")}
         </PrimaryButton>
-      </Root>
+      </div>
     </Modal>
   );
 };

--- a/frontend/src/js/query-runner/DownloadResultsDropdownButton.tsx
+++ b/frontend/src/js/query-runner/DownloadResultsDropdownButton.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { faCaretDown, faDownload } from "@fortawesome/free-solid-svg-icons";
 import { memo, useEffect, useMemo, useState } from "react";
+import { tv } from "tailwind-variants";
 
 import type { ResultUrlWithLabel } from "../api/types";
 import DownloadButton from "../button/DownloadButton";
@@ -8,40 +8,29 @@ import IconButton from "../button/IconButton";
 import WithTooltip from "../tooltip/WithTooltip";
 import { getUserSettings, storeUserSettings } from "../user/userSettings";
 
-const Frame = styled("div")<{ noborder?: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: ${({ noborder, theme }) =>
-    noborder ? "none" : `1px solid ${theme.col.gray}`};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  transition: opacity ${({ theme }) => theme.transitionTime};
-`;
+const frame = tv({
+  base: [
+    "flex items-center justify-center",
+    "rounded",
+    "border border-gray-500",
+    "transition-opacity duration-100",
+  ],
+  variants: {
+    noborder: { true: "border-none" },
+  },
+});
 
-const List = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 8px;
-  overflow-y: auto;
-  max-height: 60vh;
-`;
+const list = tv({
+  base: ["flex flex-col", "gap-px", "p-2", "max-h-[60vh]", "overflow-y-auto"],
+});
 
-const SxDownloadButton = styled(DownloadButton)`
-  button {
-    width: 100%;
-    padding: 8px 14px;
-  }
-`;
-const SxIconButton = styled(IconButton)`
-  padding: 9px 8px;
-`;
+const downloadButton = tv({
+  base: ["[&_button]:w-full", "[&_button]:px-[14px] [&_button]:py-2"],
+});
 
-const Separator = styled("div")`
-  width: 1px;
-  height: 33px;
-  background-color: ${({ theme }) => theme.col.gray};
-`;
+const dropdownOpenButton = tv({ base: "px-2 py-[9px]" });
+
+const separator = tv({ base: ["h-[33px] w-px", "bg-gray-500"] });
 
 const popperOptions = {
   modifiers: [
@@ -114,12 +103,13 @@ const DownloadResultsDropdownButton = ({
 
   const dropdown = useMemo(() => {
     return (
-      <List>
+      <div className={list()}>
         {resultUrls.map((resultUrl) => {
           const ending = getEnding(resultUrl.url);
 
           return (
-            <SxDownloadButton
+            <DownloadButton
+              className={downloadButton()}
               key={resultUrl.url}
               resultUrl={resultUrl}
               onClick={() => setFileChoice({ label: resultUrl.label, ending })}
@@ -127,21 +117,26 @@ const DownloadResultsDropdownButton = ({
               showColoredIcon
             >
               {truncate(resultUrl.label)}
-            </SxDownloadButton>
+            </DownloadButton>
           );
         })}
-      </List>
+      </div>
     );
   }, [resultUrls]);
 
   return (
-    <Frame noborder={tiny}>
+    <div className={frame({ noborder: tiny })}>
       {!tiny && (
         <>
-          <SxDownloadButton bgHover resultUrl={urlChoice} showColoredIcon>
+          <DownloadButton
+            className={downloadButton()}
+            bgHover
+            resultUrl={urlChoice}
+            showColoredIcon
+          >
             {truncChosenLabel}
-          </SxDownloadButton>
-          <Separator />
+          </DownloadButton>
+          <div className={separator()} />
         </>
       )}
       <WithTooltip text={tooltip} hideOnClick>
@@ -152,10 +147,14 @@ const DownloadResultsDropdownButton = ({
           trigger="click"
           popperOptions={popperOptions}
         >
-          <SxIconButton bgHover icon={tiny ? faDownload : faCaretDown} />
+          <IconButton
+            className={dropdownOpenButton()}
+            bgHover
+            icon={tiny ? faDownload : faCaretDown}
+          />
         </WithTooltip>
       </WithTooltip>
-    </Frame>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-runner/QueryResults.tsx
+++ b/frontend/src/js/query-runner/QueryResults.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
+import { tv } from "tailwind-variants";
 
 import type { ColumnDescription, ResultUrlWithLabel } from "../api/types";
 import type { StateT } from "../app/reducers";
@@ -13,27 +13,17 @@ import FaIcon from "../icon/FaIcon";
 import { canViewEntityPreview, canViewQueryPreview } from "../user/selectors";
 import DownloadResultsDropdownButton from "./DownloadResultsDropdownButton";
 
-const Root = styled("div")`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 7px;
-`;
+const root = tv({
+  base: ["flex items-center justify-end", "gap-[7px]"],
+});
 
-const Text = styled("p")`
-  margin: 0;
-  line-height: 1;
-  font-size: ${({ theme }) => theme.font.sm};
-`;
+const text = tv({
+  base: ["m-0", "leading-none", "text-sm"],
+});
 
-const LgText = styled(Text)`
-  font-size: ${({ theme }) => theme.font.lg};
-  white-space: nowrap;
-`;
-
-const Bold = styled("span")`
-  font-weight: 700;
-`;
+const lgText = tv({
+  base: ["m-0", "leading-none", "text-xl", "whitespace-nowrap"],
+});
 
 const QueryResults = ({
   resultLabel,
@@ -56,19 +46,19 @@ const QueryResults = ({
   const canViewPreview = useSelector<StateT, boolean>(canViewQueryPreview);
 
   return (
-    <Root>
+    <div className={root()}>
       {isEmpty(resultCount) ? (
-        <Text>
+        <p className={text()}>
           <FaIcon icon={faCheck} left />
           {t("queryRunner.endSuccess")}
-        </Text>
+        </p>
       ) : (
-        <LgText>
-          <Bold>{resultCount}</Bold>{" "}
+        <p className={lgText()}>
+          <span className="font-bold">{resultCount}</span>{" "}
           {queryType === "SECONDARY_ID_QUERY"
             ? t("queryRunner.resultCountSecondaryIdQuery")
             : t("queryRunner.resultCount")}
-        </LgText>
+        </p>
       )}
       {canViewPreview && previewAvailable && <PreviewButton />}
       {!!csvUrl && canViewHistory && exists(resultColumns) && (
@@ -81,7 +71,7 @@ const QueryResults = ({
       {resultUrls.length > 0 && (
         <DownloadResultsDropdownButton resultUrls={resultUrls} />
       )}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-runner/QueryRunner.tsx
+++ b/frontend/src/js/query-runner/QueryRunner.tsx
@@ -1,5 +1,5 @@
-import styled from "@emotion/styled";
 import { useHotkeys } from "react-hotkeys-hook";
+import { tv } from "tailwind-variants";
 
 import { exists } from "../common/helpers/exists";
 import WithTooltip from "../tooltip/WithTooltip";
@@ -11,30 +11,16 @@ import QueryRunningProgress from "./QueryRunningProgress";
 import { QueryRunningSpinner } from "./QueryRunningSpinner";
 import type { QueryRunnerStateT } from "./reducer";
 
-const Root = styled("div")`
-  flex-shrink: 0;
-  padding: 10px 20px 10px 10px;
-  border-top: 1px solid ${({ theme }) => theme.col.grayLight};
-  background-color: ${({ theme }) => theme.col.bg};
-  display: flex;
-  align-items: center;
-  width: 100%;
-`;
-
-const Left = styled("div")`
-  flex-grow: 1;
-`;
-const Right = styled("div")`
-  flex-grow: 2;
-  padding-left: 20px;
-`;
-
-const LoadingGroup = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-`;
+const root = tv({
+  base: [
+    "flex items-center",
+    "w-full",
+    "shrink-0",
+    "py-[10px] pr-5 pl-[10px]",
+    "border-t border-gray-100",
+    "bg-bg-50",
+  ],
+});
 
 const QueryRunner = ({
   queryRunner,
@@ -63,8 +49,8 @@ const QueryRunner = ({
   }, [disabled, btnAction]);
 
   return (
-    <Root data-test-id="query-runner">
-      <Left>
+    <div className={root()} data-test-id="query-runner">
+      <div className="grow">
         <WithTooltip text={buttonTooltip}>
           <QueryRunnerButton
             onClick={btnAction}
@@ -73,13 +59,13 @@ const QueryRunner = ({
             disabled={disabled}
           />
         </WithTooltip>
-      </Left>
-      <Right>
-        <LoadingGroup>
+      </div>
+      <div className="grow-[2] pl-5">
+        <div className="flex flex-row items-center justify-end">
           {exists(progress) && <QueryRunningProgress progress={progress} />}
           {isQueryRunning && <QueryRunningSpinner />}
           {!!queryRunner && <QueryRunnerInfo queryRunner={queryRunner} />}
-        </LoadingGroup>
+        </div>
         {!!queryRunner &&
           !!queryRunner.queryResult &&
           !queryRunner.queryResult.error &&
@@ -96,8 +82,8 @@ const QueryRunner = ({
               previewAvailable={queryRunner.queryResult.previewAvailable}
             />
           )}
-      </Right>
-    </Root>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-runner/QueryRunnerButton.tsx
+++ b/frontend/src/js/query-runner/QueryRunnerButton.tsx
@@ -1,52 +1,45 @@
-import styled from "@emotion/styled";
 import { faPlay, faSpinner, faStop } from "@fortawesome/free-solid-svg-icons";
 import type { Ref } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import BasicButton from "../button/BasicButton";
 import FaIcon from "../icon/FaIcon";
 
-const Root = styled("div")`
-  display: flex;
-`;
+const left = tv({
+  base: ["px-[15px]", "transition-[color,background-color] duration-100"],
+  variants: {
+    running: {
+      true: ["bg-white", "border-r border-primary-500"],
+      false: "bg-primary-500",
+    },
+  },
+});
 
-const Left = styled("span")<{ running?: boolean }>`
-  transition: ${({ theme }) =>
-    `color ${theme.transitionTime}, background-color ${theme.transitionTime}`};
-  padding: 0 15px;
-  background-color: ${({ theme, running }) =>
-    running ? "white" : theme.col.blueGrayDark};
-  border-right: ${({ theme, running }) =>
-    running ? `1px solid ${theme.col.blueGrayDark}` : "transparent"};
-`;
+const runnerLabel = tv({
+  base: [
+    "px-[15px]",
+    "bg-white group-hover/runner:bg-gray-50",
+    "text-gray-800",
+    "leading-[2.5]",
+    "whitespace-nowrap",
+    "transition-[background-color] duration-100",
+  ],
+});
 
-const Label = styled("span")`
-  transition: background-color ${({ theme }) => theme.transitionTime};
-  padding: 0 15px;
-  color: ${({ theme }) => theme.col.black};
-  background-color: white;
-  line-height: 2.5;
-  white-space: nowrap;
-`;
-
-const StyledBasicButton = styled(BasicButton)`
-  outline: none;
-  border: 1px solid ${({ theme }) => theme.col.blueGrayDark};
-  border-radius: ${({ theme }) => theme.borderRadius};
-  overflow: hidden;
-  padding: 0;
-  margin: 0;
-  font-size: ${({ theme }) => theme.font.sm};
-  line-height: 2.5;
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
-  &:hover {
-    .query-runner-label {
-      background-color: ${({ theme }) => theme.col.grayVeryLight};
-    }
-  }
-`;
+const button = tv({
+  base: [
+    "group/runner",
+    "inline-flex flex-row items-center",
+    "m-0 p-0",
+    "overflow-hidden",
+    "outline-none",
+    "rounded",
+    "border border-primary-500",
+    "text-sm",
+    "leading-[2.5]",
+  ],
+});
 
 function getIcon(loading: boolean, running: boolean) {
   return loading ? faSpinner : running ? faStop : faPlay;
@@ -73,19 +66,20 @@ const QueryRunnerButton = ({
   const icon = getIcon(isStartStopLoading, isQueryRunning);
 
   return (
-    <Root ref={ref}>
-      <StyledBasicButton
+    <div className="flex" ref={ref}>
+      <BasicButton
         type="button"
+        className={button()}
         onClick={onClick}
         disabled={disabled}
         data-test-id="query-runner-button"
       >
-        <Left running={isQueryRunning}>
+        <span className={left({ running: isQueryRunning })}>
           <FaIcon white={!isQueryRunning} icon={icon} />
-        </Left>
-        <Label className="query-runner-label">{label}</Label>
-      </StyledBasicButton>
-    </Root>
+        </span>
+        <span className={runnerLabel()}>{label}</span>
+      </BasicButton>
+    </div>
   );
 };
 

--- a/frontend/src/js/query-runner/QueryRunnerInfo.tsx
+++ b/frontend/src/js/query-runner/QueryRunnerInfo.tsx
@@ -1,15 +1,15 @@
-import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { QueryRunnerStateT } from "./reducer";
 
-const Status = styled("p")<{ success?: boolean; error?: boolean }>`
-  font-weight: 400;
-  margin: 0 10px;
-  font-size: ${({ theme }) => theme.font.sm};
-  color: ${({ theme, success, error }) =>
-    success ? theme.col.green : error ? theme.col.red : "initial"};
-`;
+const status = tv({
+  base: ["mx-[10px] my-0", "text-sm", "font-normal"],
+  variants: {
+    success: { true: "text-green" },
+    error: { true: "text-red" },
+  },
+});
 
 const useMessage = (queryRunner: QueryRunnerStateT) => {
   const { t } = useTranslation();
@@ -55,13 +55,15 @@ const QueryRunnerInfo = ({
   }
 
   return (
-    <Status
-      className={className}
-      success={message.type === "success"}
-      error={message.type === "error"}
+    <p
+      className={status({
+        success: message.type === "success",
+        error: message.type === "error",
+        className,
+      })}
     >
       {message.value}
-    </Status>
+    </p>
   );
 };
 

--- a/frontend/src/js/query-runner/QueryRunningProgress.tsx
+++ b/frontend/src/js/query-runner/QueryRunningProgress.tsx
@@ -1,16 +1,13 @@
-import styled from "@emotion/styled";
+import { tv } from "tailwind-variants";
 
-const ProgressText = styled("div")`
-  font-size: ${({ theme }) => theme.font.lg};
-  margin-right: 10px;
-  font-weight: 700;
-  color: ${({ theme }) => theme.col.blueGray};
-`;
+const progressText = tv({
+  base: ["mr-[10px]", "text-xl", "font-bold", "text-primary-200"],
+});
 
 // progress is between 0 and 1
 
 const QueryRunningProgress = ({ progress }: { progress: number }) => {
-  return <ProgressText>{Math.round(progress * 100)} %</ProgressText>;
+  return <div className={progressText()}>{Math.round(progress * 100)} %</div>;
 };
 
 export default QueryRunningProgress;

--- a/frontend/src/js/query-runner/QueryRunningSpinner.tsx
+++ b/frontend/src/js/query-runner/QueryRunningSpinner.tsx
@@ -1,21 +1,18 @@
-import { keyframes } from "@emotion/react";
-import styled from "@emotion/styled";
+import { tv } from "tailwind-variants";
 
-const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-`;
+import { useAppTheme } from "../app-theme-context";
 
-export const QueryRunningSpinner = styled("div")`
-  height: 30px;
-  width: 30px;
-  background-image: url("${({ theme }) => theme.img.spinner}");
-  background-repeat: no-repeat;
-  background-size: 30px;
+const spinner = tv({
+  base: ["h-[30px] w-[30px]", "bg-no-repeat", "bg-size-[30px]", "animate-spin"],
+});
 
-  animation: ${spin} 1s linear 0s infinite;
-`;
+export const QueryRunningSpinner = ({ className }: { className?: string }) => {
+  const { img } = useAppTheme();
+
+  return (
+    <div
+      className={spinner({ className })}
+      style={{ backgroundImage: `url("${img.spinner}")` }}
+    />
+  );
+};


### PR DESCRIPTION
**Emotion → tailwind migration, PR 2/6: the query-editing core (31 files).**

(concept-trees, query-runner, query-node-editor — stacked on #3992, stack overview there)

**Main change**

- every `styled()` block → `tv()`; truly dynamic values (tree `depth * 15px` indents, drag preview sizes) stay inline `style`
- `QueryRunningSpinner` reads the spinner image via `useAppTheme()`; built-in `animate-spin` replaces the custom keyframes (identical)

**Worth a closer look**

- `QueryRunnerButton`: descendant hover (`&:hover .query-runner-label`) → named group `group/runner` + `group-hover/runner:`; the marker class is gone
- `DownloadResultsDropdownButton`: nested `button {…}` selector → `[&_button]:` variants
- duplicate styled blocks collapsed into variants (error/success icons in both upload modals, error/not-found text states)
- a11y: two clickable non-buttons keep `onClick` + biome-ignore/TODO instead of invented roles

Checks: biome, tsc, vitest, vite build green; generated css spot-checked (named group-hover, `[&_button]`, `bg-size-[30px]`).
