### PR TITLE
refactor(frontend): external forms and preview on tailwind-variants

### DIFF
--- a/frontend/src/js/external-forms/FormConfigLoader.tsx
+++ b/frontend/src/js/external-forms/FormConfigLoader.tsx
@@ -1,9 +1,8 @@
-import styled from "@emotion/styled";
 import { memo, type ReactNode, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-
+import { tv } from "tailwind-variants";
 import { useGetFormConfig } from "../api/api";
 import type { SelectOptionT } from "../api/types";
 import type { StateT } from "../app/reducers";
@@ -20,16 +19,13 @@ import { collectAllFormFields, getUniqueFieldname } from "./helper";
 import { selectActiveFormType, selectFormConfig } from "./stateSelectors";
 import type { DragItemFormConfig } from "./types";
 
-const Root = styled("div")`
-  display: flex;
-  align-items: center;
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
+const root = tv({
+  base: ["flex items-center", "rounded"],
+});
 
-const SxDropzone = styled(Dropzone)`
-  padding: 10px 20px 20px 10px;
-  color: ${({ theme }) => theme.col.black};
-`;
+const dropzone = tv({
+  base: ["pt-[10px] pr-5 pb-5 pl-[10px]", "text-gray-800"],
+});
 
 const DROP_TYPES = [DNDType.FORM_CONFIG];
 
@@ -183,16 +179,17 @@ const FormConfigLoader = ({
   }
 
   return (
-    <Root className={className}>
-      <SxDropzone
+    <div className={root({ className })}>
+      <Dropzone
+        className={dropzone()}
         onDrop={(item) => onLoad(item as DragItemFormConfig)}
         acceptedDropTypes={DROP_TYPES}
         naked
         transparent
       >
         {children}
-      </SxDropzone>
-    </Root>
+      </Dropzone>
+    </div>
   );
 };
 

--- a/frontend/src/js/external-forms/FormContainer.tsx
+++ b/frontend/src/js/external-forms/FormContainer.tsx
@@ -1,16 +1,9 @@
-import styled from "@emotion/styled";
 import { type ComponentProps, memo } from "react";
 
 import { exists } from "../common/helpers/exists";
 import type { Form as FormType } from "./config-types";
 import FormConfigLoader from "./FormConfigLoader";
 import Form from "./form/Form";
-
-const Root = styled("div")`
-  flex-grow: 1;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-`;
 
 const FormContainer = ({
   config,
@@ -19,13 +12,13 @@ const FormContainer = ({
   config: FormType | null;
 }) => {
   return (
-    <Root>
+    <div className="grow overflow-y-auto [-webkit-overflow-scrolling:touch]">
       {exists(config) && (
         <FormConfigLoader datasetOptions={props.datasetOptions}>
           {() => <Form config={config} {...props} />}
         </FormConfigLoader>
       )}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/external-forms/FormHeader.tsx
+++ b/frontend/src/js/external-forms/FormHeader.tsx
@@ -1,25 +1,16 @@
-import styled from "@emotion/styled";
 import { faBook } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
 
+import { tv } from "tailwind-variants";
 import IconButton from "../button/IconButton";
 
-const Root = styled("div")`
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  gap: 7px;
-`;
+const root = tv({
+  base: ["flex flex-col", "w-full", "gap-[7px]"],
+});
 
-const Description = styled("p")`
-  margin: 0 10px;
-  font-size: ${({ theme }) => theme.font.md};
-`;
-
-const SxIconButton = styled(IconButton)`
-  justify-content: center;
-  width: 100%;
-`;
+const description = tv({
+  base: ["mx-[10px]", "text-base"],
+});
 
 interface Props {
   description: string;
@@ -27,19 +18,23 @@ interface Props {
   manualUrl?: string;
 }
 
-const FormHeader = ({ className, description, manualUrl }: Props) => {
+const FormHeader = ({
+  className,
+  description: descriptionText,
+  manualUrl,
+}: Props) => {
   const { t } = useTranslation();
   return (
-    <Root className={className}>
-      <Description>{description}</Description>
+    <div className={root({ className })}>
+      <p className={description()}>{descriptionText}</p>
       {manualUrl && (
         <a href={manualUrl} target="_blank" rel="noreferrer">
-          <SxIconButton frame icon={faBook}>
+          <IconButton className="w-full justify-center" frame icon={faBook}>
             {t("externalForms.manualButton")}
-          </SxIconButton>
+          </IconButton>
         </a>
       )}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/external-forms/FormsNavigation.tsx
+++ b/frontend/src/js/external-forms/FormsNavigation.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { tv } from "tailwind-variants";
 
 import type { StateT } from "../app/reducers";
 import IconButton from "../button/IconButton";
@@ -14,31 +14,17 @@ import { setExternalForm } from "./actions";
 import type { Form } from "./config-types";
 import { selectActiveFormType, selectAvailableForms } from "./stateSelectors";
 
-const Root = styled("div")`
-  flex-shrink: 0;
-  padding: 8px 20px 10px 10px;
-  box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.3);
-  box-sizing: border-box;
-  background-color: ${({ theme }) => theme.col.bg};
-  position: relative;
-  z-index: 2;
-`;
-
-const Row = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-`;
-
-const SxInputSelect = styled(InputSelect)`
-  flex-grow: 1;
-`;
-
-const SxIconButton = styled(IconButton)`
-  flex-shrink: 0;
-  margin-left: 10px;
-  padding: 7px 10px;
-`;
+const root = tv({
+  base: [
+    "relative",
+    "z-2",
+    "shrink-0",
+    "box-border",
+    "pt-2 pr-5 pb-[10px] pl-[10px]",
+    "bg-bg-50",
+    "shadow-[0_0_3px_0_rgba(0,0,0,0.3)]",
+  ],
+});
 
 const FormsNavigation = ({ onReset }: { onReset: () => void }) => {
   const language = useActiveLang();
@@ -69,9 +55,10 @@ const FormsNavigation = ({ onReset }: { onReset: () => void }) => {
     .sort((a, b) => (a.label < b.label ? -1 : 1));
 
   return (
-    <Root>
-      <Row>
-        <SxInputSelect
+    <div className={root()}>
+      <div className="flex flex-row items-end">
+        <InputSelect
+          className="grow"
           dataTestId="form-select"
           label={t("externalForms.forms")}
           options={options}
@@ -90,11 +77,15 @@ const FormsNavigation = ({ onReset }: { onReset: () => void }) => {
           confirmationText={t("externalForms.common.clearConfirm")}
         >
           <WithTooltip text={t("externalForms.common.clear")}>
-            <SxIconButton frame icon={faTrash} />
+            <IconButton
+              className="ml-[10px] shrink-0 px-[10px] py-[7px]"
+              frame
+              icon={faTrash}
+            />
           </WithTooltip>
         </ConfirmableTooltip>
-      </Row>
-    </Root>
+      </div>
+    </div>
   );
 };
 

--- a/frontend/src/js/external-forms/form-components/Description.tsx
+++ b/frontend/src/js/external-forms/form-components/Description.tsx
@@ -1,9 +1,10 @@
-import styled from "@emotion/styled";
+import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
-export const Description = styled("p")`
-  font-size: 14px;
-  margin: 0 10px 10px;
-  &:last-child {
-    margin-bottom: 0;
-  }
-`;
+const description = tv({
+  base: ["mx-[10px] mb-[10px] last:mb-0", "text-sm"],
+});
+
+export const Description = ({ className, ...props }: ComponentProps<"p">) => (
+  <p className={description({ className })} {...props} />
+);

--- a/frontend/src/js/external-forms/form-components/DropzoneBetweenElements.tsx
+++ b/frontend/src/js/external-forms/form-components/DropzoneBetweenElements.tsx
@@ -1,28 +1,25 @@
-import styled from "@emotion/styled";
 import type { DropTargetMonitor } from "react-dnd";
+import { tv } from "tailwind-variants";
 
 import Dropzone, {
   type PossibleDroppableObject,
 } from "../../ui-components/Dropzone";
 
-const LINE_HEIGHT = 4;
+// line height 4px; the dropzone's translate offsets by half of it (2px) —
+// written literally because tailwind only generates classes it finds in source
+const line = tv({
+  base: ["h-[4px]", "w-full", "rounded", "bg-primary-500"],
+});
 
-const Line = styled("div")`
-  background-color: ${({ theme }) => theme.col.blueGrayDark};
-  height: ${LINE_HEIGHT}px;
-  width: 100%;
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
-
-const SxDropzone = styled(Dropzone)`
-  height: 30px;
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: translateY(calc(-50% - ${LINE_HEIGHT / 2}px));
-  z-index: 1;
-  background-color: transparent;
-`;
+const dropzone = tv({
+  base: [
+    "absolute top-0 left-0",
+    "z-1",
+    "h-[30px]",
+    "translate-y-[calc(-50%_-_2px)]",
+    "bg-transparent",
+  ],
+});
 
 const DropzoneBetweenElements = ({
   acceptedDropTypes,
@@ -34,15 +31,15 @@ const DropzoneBetweenElements = ({
   className?: string;
 }) => {
   return (
-    <SxDropzone
-      className={className}
+    <Dropzone
+      className={dropzone({ className })}
       bare
       naked
       acceptedDropTypes={acceptedDropTypes}
       onDrop={onDrop}
     >
-      {({ isOver }) => isOver && <Line />}
-    </SxDropzone>
+      {({ isOver }) => isOver && <div className={line()} />}
+    </Dropzone>
   );
 };
 

--- a/frontend/src/js/external-forms/form-components/DropzoneList.tsx
+++ b/frontend/src/js/external-forms/form-components/DropzoneList.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import type { ReactNode, Ref } from "react";
 import type { DropTargetMonitor } from "react-dnd";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../../button/IconButton";
 import InfoTooltip from "../../tooltip/InfoTooltip";
@@ -16,40 +16,26 @@ import Label from "../../ui-components/Label";
 
 import DropzoneBetweenElements from "./DropzoneBetweenElements";
 
-const ListItem = styled("div")`
-  position: relative;
-  padding: 5px;
-  box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.1);
-  background-color: white;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  margin-bottom: 5px;
-`;
+const listItem = tv({
+  base: [
+    "relative",
+    "p-[5px]",
+    "mb-[5px]",
+    "bg-white",
+    "rounded",
+    "shadow-[0_0_3px_0_rgba(0,0,0,0.1)]",
+  ],
+});
 
-const StyledIconButton = styled(IconButton)`
-  position: absolute;
-  top: 0;
-  right: 0;
-`;
+const betweenDropzone = tv({
+  variants: {
+    first: { true: "top-[3px]" },
+  },
+});
 
-const Row = styled("div")`
-  display: flex;
-  align-items: center;
-`;
-
-const ConceptContainer = styled("div")`
-  position: relative;
-`;
-
-const SxDropzoneBetweenElements = styled(DropzoneBetweenElements)<{
-  index: number;
-}>`
-  ${({ index }) => (index === 0 ? "top: 3px;" : "")}
-`;
-
-const SxLastDropzoneBetweenElements = styled(DropzoneBetweenElements)`
-  height: 15px;
-  top: -5px;
-`;
+const lastBetweenDropzone = tv({
+  base: ["-top-[5px]", "h-[15px]"],
+});
 
 interface PropsT<DroppableObject> {
   className?: string;
@@ -91,39 +77,41 @@ const DropzoneList = <DroppableObject extends PossibleDroppableObject>({
 
   return (
     <div className={className}>
-      <Row>
+      <div className="flex items-center">
         {label && <Label>{label}</Label>}
         {tooltip && <InfoTooltip text={tooltip} />}
-      </Row>
+      </div>
       {items && items.length > 0 && (
         <>
           {items.map((item, i) => (
-            <ConceptContainer key={i}>
+            <div className="relative" key={i}>
               {!disallowMultipleColumns && (
-                <SxDropzoneBetweenElements
+                <DropzoneBetweenElements
+                  className={betweenDropzone({ first: i === 0 })}
                   acceptedDropTypes={acceptedDropTypes}
                   onDrop={dropBetween(i)}
-                  index={i}
                 />
               )}
-              <ListItem>
-                <StyledIconButton
+              <div className={listItem()}>
+                <IconButton
+                  className="absolute top-0 right-0"
                   bgHover
                   icon={faTimes}
                   onClick={() => onDelete(i)}
                 />
                 {item}
-              </ListItem>
-            </ConceptContainer>
+              </div>
+            </div>
           ))}
-          <ConceptContainer>
+          <div className="relative">
             {!disallowMultipleColumns && (
-              <SxLastDropzoneBetweenElements
+              <DropzoneBetweenElements
+                className={lastBetweenDropzone()}
                 acceptedDropTypes={acceptedDropTypes}
                 onDrop={dropBetween(items.length)}
               />
             )}
-          </ConceptContainer>
+          </div>
         </>
       )}
       <div ref={ref}>

--- a/frontend/src/js/external-forms/form-components/DynamicInputGroup.tsx
+++ b/frontend/src/js/external-forms/form-components/DynamicInputGroup.tsx
@@ -1,6 +1,7 @@
-import styled from "@emotion/styled";
 import { faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
 import type { ReactNode } from "react";
+
+import { tv } from "tailwind-variants";
 
 import IconButton from "../../button/IconButton";
 
@@ -13,27 +14,17 @@ interface PropsT {
   onRemoveClick: (idx: number) => void;
 }
 
-const Container = styled.div`
-  padding: 4px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-`;
+const container = tv({
+  base: ["flex flex-wrap", "gap-2", "p-1"],
+});
 
-const RemoveBtn = styled(IconButton)`
-  position: absolute;
-  top: -7px;
-  right: -7px;
-  opacity: 1;
-  z-index: 1;
-  background-color: white;
-`;
+const removeButton = tv({
+  base: ["absolute -top-[7px] -right-[7px]", "z-1", "bg-white", "opacity-100"],
+});
 
-const GroupItem = styled("div")`
-  padding: 2px 2px 2px 0;
-  position: relative;
-  max-width: 200px;
-`;
+const groupItem = tv({
+  base: ["relative", "max-w-[200px]", "py-[2px] pr-[2px] pl-0"],
+});
 
 const DynamicInputGroup = ({
   className,
@@ -47,10 +38,10 @@ const DynamicInputGroup = ({
   const limitNotReached = limit === 0 || items.length < limit;
 
   return (
-    <Container className={className}>
+    <div className={container({ className })}>
       {label && <span>{label}</span>}
       {items.map((item, idx) => (
-        <GroupItem key={idx}>
+        <div className={groupItem()} key={idx}>
           {item}
           {/*
             No need to display the remove button, when limit is 1.
@@ -61,19 +52,20 @@ const DynamicInputGroup = ({
             you can also just delete the following constraint:
            */}
           {limit !== 1 && (
-            <RemoveBtn
+            <IconButton
+              className={removeButton()}
               bgHover
               tiny
               icon={faTimes}
               onClick={() => onRemoveClick(idx)}
             />
           )}
-        </GroupItem>
+        </div>
       ))}
       {limitNotReached && (
         <IconButton bgHover icon={faPlus} tiny onClick={onAddClick} />
       )}
-    </Container>
+    </div>
   );
 };
 

--- a/frontend/src/js/external-forms/form-components/Headline.tsx
+++ b/frontend/src/js/external-forms/form-components/Headline.tsx
@@ -1,5 +1,5 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
+import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 
 import type { Headline as HeadlineField } from "../config-types";
 
@@ -16,49 +16,49 @@ export const getHeadlineFieldAs = (headline: HeadlineField) => {
   return HEADLINE_DOM[headline.style.size];
 };
 
-export const Headline = styled("h3")<{ size?: "h1" | "h2" | "h3" }>`
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: ${({ theme, size }) =>
-    size === "h3"
-      ? theme.font.sm
-      : size === "h2"
-        ? theme.font.md
-        : theme.font.lg};
-  line-height: 1;
-  color: ${({ theme }) => theme.col.black};
-  font-weight: ${({ size }) => (size === "h3" ? "700" : "400")};
+const headline = tv({
+  base: [
+    "relative",
+    "flex items-center",
+    "gap-[10px]",
+    "leading-none",
+    "text-gray-800",
+    // wins over the size margins: :first-child raises specificity
+    "first:mt-0",
+  ],
+  variants: {
+    size: {
+      h1: ["text-xl", "font-normal", "mt-5 mb-[5px] ml-0"],
+      h2: ["text-base", "font-normal", "mt-[10px] mb-[3px] ml-[10px]"],
+      h3: ["text-sm", "font-bold", "mt-[10px] mb-[3px] ml-[10px]"],
+    },
+  },
+  defaultVariants: { size: "h1" },
+});
 
-  &:first-child {
-    margin-top: 0;
-  }
+export const Headline = ({
+  as: Component = "h3",
+  size,
+  className,
+  ...props
+}: ComponentProps<"h3"> & {
+  as?: "h3" | "h4" | "h5";
+  size?: "h1" | "h2" | "h3";
+}) => <Component className={headline({ size, className })} {...props} />;
 
-  position: relative;
+const headlineIndex = tv({
+  base: [
+    "flex items-center justify-center",
+    "px-[10px]",
+    "text-xl",
+    "border-r-[3px] border-gray-400",
+    "text-gray-400",
+  ],
+});
 
-  ${({ size }) =>
-    (!size || size === "h1") &&
-    css`
-      margin: 20px 0 5px;
-      margin-left: 0;
-    `};
-
-  ${({ size }) =>
-    (size === "h2" || size === "h3") &&
-    css`
-      border-left: 0;
-      padding-left: 0;
-      margin: 10px 0 3px;
-      margin-left: 10px;
-    `};
-`;
-
-export const HeadlineIndex = styled("span")`
-  padding: 0 10px;
-  font-size: ${({ theme }) => theme.font.lg};
-  border-right: 3px solid ${({ theme }) => theme.col.grayMediumLight};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.col.grayMediumLight};
-`;
+export const HeadlineIndex = ({
+  className,
+  ...props
+}: ComponentProps<"span">) => (
+  <span className={headlineIndex({ className })} {...props} />
+);

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptCopyModal.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptCopyModal.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import type { SelectOptionT } from "../../api/types";
 import PrimaryButton from "../../button/PrimaryButton";
@@ -15,28 +15,18 @@ import { useVisibleConceptListFields } from "../stateSelectors";
 
 import type { FormConceptGroupT } from "./formConceptGroupState";
 
-const Buttons = styled("div")`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  margin-top: 20px;
-`;
+const buttons = tv({
+  base: ["flex items-center justify-between", "w-full", "mt-5"],
+});
 
-const Options = styled("div")`
-  padding: 8px 0 0 28px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  max-height: 345px;
-`;
-
-const SelectAllCheckbox = styled(InputCheckbox)`
-  margin: 10px 0 0 8px;
-`;
-
-const SxInputCheckbox = styled(InputCheckbox)`
-  margin: 5px 0;
-`;
+const options = tv({
+  base: [
+    "pt-2 pl-[28px]",
+    "max-h-[345px]",
+    "overflow-y-auto",
+    "[-webkit-overflow-scrolling:touch]",
+  ],
+});
 
 const FormConceptCopyModal = ({
   targetFieldname,
@@ -153,15 +143,17 @@ const FormConceptCopyModal = ({
         }}
         value={selectedOption}
       />
-      <SelectAllCheckbox
+      <InputCheckbox
+        className="mt-[10px] ml-2"
         label={t("externalForms.copyModal.selectAll")}
         value={allConceptsSelected}
         onChange={onToggleAllConcepts}
       />
-      <Options>
+      <div className={options()}>
         {Object.keys(valuesChecked).map((idx) =>
           idxHasConcepts(idx) ? (
-            <SxInputCheckbox
+            <InputCheckbox
+              className="my-[5px]"
               key={idx}
               label={getLabelFromIdx(idx)}
               value={valuesChecked[idx]}
@@ -169,15 +161,15 @@ const FormConceptCopyModal = ({
             />
           ) : null,
         )}
-      </Options>
-      <Buttons>
+      </div>
+      <div className={buttons()}>
         <TransparentButton onClick={onClose}>
           {t("common.cancel")}
         </TransparentButton>
         <PrimaryButton onClick={onSubmit} disabled={isAcceptDisabled}>
           {t("externalForms.copyModal.accept")}
         </PrimaryButton>
-      </Buttons>
+      </div>
     </Modal>
   );
 };

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptGroup.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import { usePostPrefixForSuggestions } from "../../api/api";
 import type { SelectorResultType } from "../../api/types";
@@ -90,25 +90,15 @@ interface Props {
   rowPrefixFieldname?: string;
 }
 
-const Row = styled("div")`
-  display: flex;
-  align-items: center;
-  margin-bottom: 5px;
-`;
+// named to avoid shadowing the `row` map param below
+const connectorRow = tv({
+  base: ["flex items-center", "mb-[5px]"],
+});
 
-const SxTransparentButton = styled(TransparentButton)`
-  margin-left: 10px;
-  flex-shrink: 0;
-`;
-
-const SxDescription = styled(Description)`
-  margin: 0 5px 0 0;
-  font-size: ${({ theme }) => theme.font.xs};
-`;
-
-const SxFormConceptNode = styled(FormConceptNode)`
-  margin-top: 5px;
-`;
+// Description's own margins are overridden here
+const connectorDescription = tv({
+  base: ["m-0 mr-[5px]", "text-xs"],
+});
 
 export interface EditedFormQueryNodePosition {
   valueIdx: number;
@@ -319,12 +309,13 @@ const FormConceptGroup = (props: Props) => {
           <>
             {props.label}
             {allowExtendedCopying && (
-              <SxTransparentButton
+              <TransparentButton
+                className="ml-[10px] shrink-0"
                 tiny
                 onClick={() => setIsCopyModalOpen(true)}
               >
                 {t("externalForms.common.concept.copyFrom")}
-              </SxTransparentButton>
+              </TransparentButton>
             )}
           </>
         }
@@ -366,10 +357,10 @@ const FormConceptGroup = (props: Props) => {
                 })
               : null}
             {row.concepts.length > 1 && (
-              <Row>
-                <SxDescription>
+              <div className={connectorRow()}>
+                <Description className={connectorDescription()}>
                   {t("externalForms.common.connectedWith")}:
-                </SxDescription>
+                </Description>
                 <ToggleButton
                   value={props.value[i].connector}
                   onChange={(val) => {
@@ -384,7 +375,7 @@ const FormConceptGroup = (props: Props) => {
                     { value: "AND", label: t("common.and") },
                   ]}
                 />
-              </Row>
+              </div>
             )}
             <DynamicInputGroup
               key={i}
@@ -397,7 +388,7 @@ const FormConceptGroup = (props: Props) => {
               }
               items={row.concepts.map((concept, j) =>
                 concept ? (
-                  <SxFormConceptNode
+                  <FormConceptNode
                     key={j}
                     valueIdx={i}
                     conceptIdx={j}

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptNode.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptNode.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   faCompressArrowsAlt,
   faExpandArrowsAlt,
@@ -6,6 +5,7 @@ import {
 import { useRef } from "react";
 import { useDrag } from "react-dnd";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 
 import { getWidthAndHeight } from "../../app/DndProvider";
 import IconButton from "../../button/IconButton";
@@ -15,58 +15,50 @@ import { getRootNodeLabel } from "../../standard-query-editor/helper";
 import type { DragItemConceptTreeNode } from "../../standard-query-editor/types";
 import WithTooltip from "../../tooltip/WithTooltip";
 
-const Root = styled("div")<{
-  active?: boolean;
-}>`
-  padding: 5px 10px;
-  cursor: pointer;
-  max-width: 200px;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  transition: background-color ${({ theme }) => theme.transitionTime};
-  border: ${({ theme, active }) =>
-    active
-      ? `2px solid ${theme.col.blueGrayDark}`
-      : `1px solid ${theme.col.grayMediumLight}`};
-  &:hover {
-    background-color: ${({ theme }) => theme.col.bgAlt};
-  }
-  display: grid;
-  grid-template-columns: 1fr auto;
-  font-size: ${({ theme }) => theme.font.sm};
-`;
+const node = tv({
+  base: [
+    "grid grid-cols-[1fr_auto]",
+    "max-w-[200px]",
+    "px-[10px] py-[5px]",
+    "cursor-pointer",
+    "rounded",
+    "hover:bg-bg-100",
+    "transition-[background-color] duration-100",
+    "text-sm",
+  ],
+  variants: {
+    active: {
+      true: "border-2 border-primary-500",
+      false: "border border-gray-400",
+    },
+  },
+});
 
-const Label = styled("p")`
-  margin: 0;
-  word-break: break-word;
-  line-height: 1.2;
-  font-size: ${({ theme }) => theme.font.md};
-`;
+const labelText = tv({
+  base: ["m-0", "[word-break:break-word]", "leading-[1.2]", "text-base"],
+});
 
-const Description = styled("div")`
-  margin: 3px 0 0;
-  word-break: break-word;
-  line-height: 1.2;
-  text-transform: uppercase;
-  font-size: ${({ theme }) => theme.font.xs};
-`;
+const descriptionText = tv({
+  base: [
+    "mt-[3px]",
+    "[word-break:break-word]",
+    "leading-[1.2]",
+    "uppercase",
+    "text-xs",
+  ],
+});
 
-const Right = styled("div")`
-  margin-left: 10px;
-`;
-
-const SxIconButton = styled(IconButton)`
-  padding: 0 6px;
-`;
-
-const RootNode = styled("p")`
-  margin: 0 0 4px;
-  line-height: 1;
-  text-transform: uppercase;
-  font-weight: 700;
-  font-size: ${({ theme }) => theme.font.xs};
-  color: ${({ theme }) => theme.col.blueGrayDark};
-  word-break: break-word;
-`;
+const rootNode = tv({
+  base: [
+    "mb-1",
+    "leading-none",
+    "uppercase",
+    "font-bold",
+    "text-xs",
+    "text-primary-500",
+    "[word-break:break-word]",
+  ],
+});
 
 // generalized node to handle concepts queried in forms
 const FormConceptNode = ({
@@ -137,30 +129,35 @@ const FormConceptNode = ({
       canDrop={(item) => canNodeBeDropped(conceptNode, item)}
       highlightDroppable
     >
-      <Root
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: TODO make this a button */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: see above */}
+      <div
+        className={node({ active: hasNonDefaultSettings || hasFilterValues })}
         ref={(instance) => {
           ref.current = instance;
           drag(instance);
         }}
-        active={hasNonDefaultSettings || hasFilterValues}
         onClick={onClick}
       >
         <div>
           <WithTooltip text={tooltipText}>
             {/* biome-ignore lint/complexity/noUselessFragments: WithTooltip takes a single child */}
             <>
-              {rootNodeLabel && <RootNode>{rootNodeLabel}</RootNode>}
-              <Label>{conceptNode?.label}</Label>
+              {rootNodeLabel && <p className={rootNode()}>{rootNodeLabel}</p>}
+              <p className={labelText()}>{conceptNode?.label}</p>
               {conceptNode && !!conceptNode.description && (
-                <Description>{conceptNode.description}</Description>
+                <div className={descriptionText()}>
+                  {conceptNode.description}
+                </div>
               )}
             </>
           </WithTooltip>
         </div>
-        <Right>
+        <div className="ml-[10px]">
           {expand?.expandable && (
             <WithTooltip text={t("externalForms.common.concept.expand")}>
-              <SxIconButton
+              <IconButton
+                className="px-[6px] py-0"
                 icon={expand.active ? faCompressArrowsAlt : faExpandArrowsAlt}
                 tiny
                 onClick={(e) => {
@@ -170,8 +167,8 @@ const FormConceptNode = ({
               />
             </WithTooltip>
           )}
-        </Right>
-      </Root>
+        </div>
+      </div>
     </HoverNavigatable>
   );
 };

--- a/frontend/src/js/external-forms/form-query-dropzone/FormQueryDropzone.tsx
+++ b/frontend/src/js/external-forms/form-query-dropzone/FormQueryDropzone.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { useCallback, useRef } from "react";
 
 import { DNDType } from "../../common/constants/dndTypes";
@@ -9,10 +8,6 @@ import Dropzone from "../../ui-components/Dropzone";
 import Label from "../../ui-components/Label";
 
 import ValidatedFormQueryResult from "./ValidatedFormQueryResult";
-
-const SxDropzone = styled(Dropzone)`
-  justify-content: flex-start;
-`;
 
 const DROP_TYPES = [
   DNDType.PREVIOUS_QUERY,
@@ -58,7 +53,8 @@ const FormQueryDropzone = ({
         {label}
         {exists(tooltip) && <InfoTooltip text={tooltip} />}
       </Label>
-      <SxDropzone
+      <Dropzone
+        className="justify-start"
         onDrop={(item) => onDrop(item as DragItemQuery)}
         acceptedDropTypes={DROP_TYPES}
       >
@@ -70,7 +66,7 @@ const FormQueryDropzone = ({
             onDelete={onDelete}
           />
         )}
-      </SxDropzone>
+      </Dropzone>
     </div>
   );
 };

--- a/frontend/src/js/external-forms/form-query-dropzone/FormQueryResult.tsx
+++ b/frontend/src/js/external-forms/form-query-dropzone/FormQueryResult.tsx
@@ -1,24 +1,27 @@
-import styled from "@emotion/styled";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { tv } from "tailwind-variants";
 
 import IconButton from "../../button/IconButton";
 import { exists } from "../../common/helpers/exists";
 import type { DragItemQuery } from "../../standard-query-editor/types";
 
-const Root = styled("div")<{ error?: boolean }>`
-  padding: 5px 10px;
-  background-color: white;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  border: 1px solid
-    ${({ theme, error }) => (error ? theme.col.red : theme.col.grayLight)};
-  font-size: ${({ theme }) => theme.font.md};
-  color: ${({ theme }) => theme.col.black};
-`;
+const root = tv({
+  base: [
+    "px-[10px] py-[5px]",
+    "bg-white",
+    "rounded",
+    "text-base",
+    "text-gray-800",
+  ],
+  variants: {
+    error: {
+      true: "border border-red",
+      false: "border border-gray-100",
+    },
+  },
+});
 
-const ErrorMessage = styled.span`
-  color: ${({ theme }) => theme.col.red};
-  font-weight: 400;
-`;
+const errorMessage = tv({ base: ["text-red", "font-normal"] });
 
 interface PropsT {
   queryResult?: DragItemQuery;
@@ -34,14 +37,14 @@ const FormQueryResult = ({
   onDelete,
 }: PropsT) => {
   return (
-    <Root className={className} error={exists(error)}>
+    <div className={root({ error: exists(error), className })}>
       {error ? (
-        <ErrorMessage>{error}</ErrorMessage>
+        <span className={errorMessage()}>{error}</span>
       ) : queryResult ? (
         queryResult.label || queryResult.id
       ) : null}
       {onDelete && <IconButton tiny icon={faTimes} onClick={onDelete} />}
-    </Root>
+    </div>
   );
 };
 

--- a/frontend/src/js/external-forms/form-query-dropzone/ValidatedFormQueryResult.tsx
+++ b/frontend/src/js/external-forms/form-query-dropzone/ValidatedFormQueryResult.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -7,10 +6,6 @@ import type { DragItemQuery } from "../../standard-query-editor/types";
 
 import FormQueryResult from "./FormQueryResult";
 
-const FullWidthCentered = styled("div")`
-  width: 100%;
-  text-align: center;
-`;
 interface PropsT {
   queryResult?: DragItemQuery;
   placeholder: string;
@@ -52,7 +47,7 @@ const ValidatedFormQueryResult = ({
   const error = localError ? t("previousQuery.loadError") : undefined;
 
   return !queryResult && !error ? (
-    <FullWidthCentered>{placeholder}</FullWidthCentered>
+    <div className="w-full text-center">{placeholder}</div>
   ) : (
     <FormQueryResult
       {...props}

--- a/frontend/src/js/external-forms/form-tab-navigation/FormTabNavigation.tsx
+++ b/frontend/src/js/external-forms/form-tab-navigation/FormTabNavigation.tsx
@@ -1,17 +1,18 @@
-import styled from "@emotion/styled";
 import type { ComponentProps } from "react";
 
 import SmallTabNavigation from "../../small-tab-navigation/SmallTabNavigation";
 
-const SxSmallTabNavigation = styled(SmallTabNavigation)`
-  padding-top: 3px;
-  padding-left: 10px;
-`;
-
 const FormTavNavigation = (
   props: ComponentProps<typeof SmallTabNavigation>,
 ) => {
-  return <SxSmallTabNavigation size="L" variant="primary" {...props} />;
+  return (
+    <SmallTabNavigation
+      className="pt-[3px] pl-[10px]"
+      size="L"
+      variant="primary"
+      {...props}
+    />
+  );
 };
 
 export default FormTavNavigation;

--- a/frontend/src/js/external-forms/form/ConnectedField.tsx
+++ b/frontend/src/js/external-forms/form/ConnectedField.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import type { ReactNode } from "react";
 import {
   type Control,
@@ -6,6 +5,7 @@ import {
   useController,
 } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { tv } from "tailwind-variants";
 import { exists } from "../../common/helpers/exists";
 import type { Field, Tabs } from "../config-types";
 import { getErrorForField } from "../validators";
@@ -41,31 +41,37 @@ type Props<T> = T & {
   noContainer?: boolean;
   noLabel?: boolean;
 };
-const FieldContainer = styled("div")<{
-  noLabel?: boolean;
-  hasError?: boolean;
-  red?: boolean;
-}>`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  padding: ${({ noLabel }) => (noLabel ? "7px 10px" : "2px 10px 7px")};
-  background-color: white;
-  border-radius: ${({ theme }) => theme.borderRadius};
-  border: 1px solid
-    ${({ theme, hasError, red }) =>
-      hasError
-        ? red
-          ? theme.col.red
-          : theme.col.blueGrayDark
-        : theme.col.grayLight};
-`;
+const fieldContainer = tv({
+  base: [
+    "flex flex-col",
+    "gap-[5px]",
+    "bg-white",
+    "rounded",
+    "border border-gray-100",
+  ],
+  variants: {
+    noLabel: {
+      true: "px-[10px] py-[7px]",
+      false: "pt-[2px] px-[10px] pb-[7px]",
+    },
+    hasError: { true: "", false: "" },
+    red: { true: "", false: "" },
+  },
+  compoundVariants: [
+    { hasError: true, red: false, class: "border-primary-500" },
+    { hasError: true, red: true, class: "border-red" },
+  ],
+});
 
-const ErrorContainer = styled("div")<{ red?: boolean }>`
-  color: ${({ theme, red }) => (red ? theme.col.red : theme.col.blueGrayDark)};
-  font-weight: 700;
-  font-size: ${({ theme }) => theme.font.sm};
-`;
+const errorContainer = tv({
+  base: ["font-bold", "text-sm"],
+  variants: {
+    red: {
+      true: "text-red",
+      false: "text-primary-500",
+    },
+  },
+});
 
 export const setValueConfig = {
   shouldValidate: true,
@@ -102,15 +108,17 @@ export const ConnectedField = <T extends object>({
   return noContainer ? (
     <div>{children({ ...field, ...props })}</div>
   ) : (
-    <FieldContainer
-      noLabel={noLabel}
-      hasError={exists(fieldState.error)}
-      red={isRedError}
+    <div
+      className={fieldContainer({
+        noLabel: !!noLabel,
+        hasError: exists(fieldState.error),
+        red: isRedError,
+      })}
     >
       {children({ ...field, ...props })}
-      <ErrorContainer red={isRedError}>
+      <div className={errorContainer({ red: isRedError })}>
         {fieldState.error?.message}
-      </ErrorContainer>
-    </FieldContainer>
+      </div>
+    </div>
   );
 };

--- a/frontend/src/js/external-forms/form/Form.tsx
+++ b/frontend/src/js/external-forms/form/Form.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { memo } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
@@ -9,10 +8,6 @@ import FormHeader from "../FormHeader";
 import { getFieldKey, getH1Index } from "../helper";
 
 import Field from "./Field";
-
-const SxFormHeader = styled(FormHeader)`
-  margin: 5px 0 15px;
-`;
 
 interface Props {
   config: FormType;
@@ -30,7 +25,8 @@ const Form = memo(({ config, datasetOptions, methods }: Props) => {
   return (
     <div className="w-full flex flex-col gap-2">
       {config.description?.[activeLang] && (
-        <SxFormHeader
+        <FormHeader
+          className="mt-[5px] mb-[15px]"
           description={config.description[activeLang]!}
           manualUrl={config.manualUrl}
         />

--- a/frontend/src/js/external-forms/form/fields/ConceptListField.tsx
+++ b/frontend/src/js/external-forms/form/fields/ConceptListField.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import type { ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
 import { exists } from "../../../common/helpers/exists";
@@ -9,10 +8,6 @@ import FormConceptGroup from "../../form-concept-group/FormConceptGroup";
 import type { FormConceptGroupT } from "../../form-concept-group/formConceptGroupState";
 import { ConnectedField, setValueConfig } from "../ConnectedField";
 import type Field from "../Field";
-
-const SxToggleButton = styled(ToggleButton)`
-  margin-bottom: 5px;
-`;
 
 export const ConceptListField = ({
   field,
@@ -82,7 +77,8 @@ export const ConceptListField = ({
           renderRowPrefix={
             exists(field.rowPrefixField)
               ? ({ value: fieldValue, onChange, row, i }) => (
-                  <SxToggleButton
+                  <ToggleButton
+                    className="mb-[5px]"
                     options={field.rowPrefixField!.options.map((option) => ({
                       label: option.label[locale] || "",
                       value: option.value,

--- a/frontend/src/js/external-forms/form/fields/GroupField.tsx
+++ b/frontend/src/js/external-forms/form/fields/GroupField.tsx
@@ -1,16 +1,9 @@
-import styled from "@emotion/styled";
 import type { ComponentProps } from "react";
 import type { Group } from "../../config-types";
 import { Description } from "../../form-components/Description";
 import { Headline } from "../../form-components/Headline";
 import { getFieldKey } from "../../helper";
 import Field from "../Field";
-
-const GroupContainer = styled("div")`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-`;
 
 export const GroupField = ({
   field,
@@ -25,7 +18,8 @@ export const GroupField = ({
       {field.description && (
         <Description>{field.description[commonProps.locale]}</Description>
       )}
-      <GroupContainer
+      <div
+        className="flex flex-row flex-wrap"
         style={{
           display: field.style?.display || "flex",
           gap: field.style?.display === "grid" ? "7px 12px" : "7px 8px",
@@ -37,7 +31,7 @@ export const GroupField = ({
 
           return <Field key={key} field={f} {...commonProps} />;
         })}
-      </GroupContainer>
+      </div>
     </>
   );
 };

--- a/frontend/src/js/external-forms/form/fields/TabsField.tsx
+++ b/frontend/src/js/external-forms/form/fields/TabsField.tsx
@@ -1,24 +1,21 @@
-import styled from "@emotion/styled";
 import type { ComponentProps } from "react";
+import { tv } from "tailwind-variants";
 import type { Tabs } from "../../config-types";
 import FormTabNavigation from "../../form-tab-navigation/FormTabNavigation";
 import { getFieldKey } from "../../helper";
 import { ConnectedField, setValueConfig } from "../ConnectedField";
 import Field from "../Field";
 
-const Spacer = styled("div")`
-  height: 14px;
-`;
-
-const NestedFields = styled("div")`
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  background-color: ${({ theme }) => theme.col.bg};
-  padding: 12px 10px 12px;
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
+const nestedFields = tv({
+  base: [
+    "flex flex-col",
+    "gap-[7px]",
+    "bg-bg-50",
+    "px-[10px] py-3",
+    "border border-gray-500",
+    "rounded",
+  ],
+});
 
 export const TabsField = ({
   field,
@@ -60,15 +57,15 @@ export const TabsField = ({
               }))}
             />
             {tabToShow && tabToShow.fields.length > 0 ? (
-              <NestedFields>
+              <div className={nestedFields()}>
                 {tabToShow.fields.map((f, i) => {
                   const key = getFieldKey(commonProps.formType, f, i);
 
                   return <Field key={key} field={f} {...commonProps} />;
                 })}
-              </NestedFields>
+              </div>
             ) : (
-              <Spacer />
+              <div className="h-[14px]" />
             )}
           </>
         );

--- a/frontend/src/js/preview/Charts.tsx
+++ b/frontend/src/js/preview/Charts.tsx
@@ -1,41 +1,29 @@
-import styled from "@emotion/styled";
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { t } from "i18next";
 import { useHotkeys } from "react-hotkeys-hook";
+import { tv } from "tailwind-variants";
 import type { PreviewStatistics } from "../api/types";
 import IconButton from "../button/IconButton";
 import Diagram from "./Diagram";
 
-const Root = styled("div")``;
+const diagram = tv({
+  base: ["h-[27vh]", "mr-[15px]", "p-[5px]"],
+});
 
-const SxDiagram = styled(Diagram)`
-  padding: 5px;
-  margin-right: 15px;
-  height: 27vh;
-`;
+// the old styles also declared `font-size: 24` on the buttons — a unitless
+// value, invalid css, never applied
+const directionSelector = tv({
+  base: [
+    "col-start-1 col-end-3 row-start-3",
+    "flex flex-row items-center justify-center",
+    "mb-[5px]",
+    "px-[100px]",
+  ],
+});
 
-const DirectionSelector = styled("div")`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 5px;
-  grid-column: 1 / 3;
-  grid-row: 3;
-  padding-left: 100px;
-  padding-right: 100px;
-`;
-
-const SxIconButton = styled(IconButton)`
-  font-size: 24;
-`;
-
-const DiagramContainer = styled("div")`
-  overflow-x: hidden;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-gap: 5px;
-`;
+const diagramContainer = tv({
+  base: ["grid grid-cols-2", "gap-[5px]", "overflow-x-hidden"],
+});
 
 type ChartProps = {
   statistics: PreviewStatistics[];
@@ -71,21 +59,22 @@ export default function Charts({
   useHotkeys("right", () => updatePage(1), [page]);
 
   return (
-    <Root className={className}>
-      <DiagramContainer>
+    <div className={className}>
+      <div className={diagramContainer()}>
         {diagramsOnPage.map((statistic) => {
           return (
             <div key={statistic.label}>
-              <SxDiagram
+              <Diagram
+                className={diagram()}
                 stat={statistic}
                 onClick={() => showPopup(statistic)}
               />
             </div>
           );
         })}
-      </DiagramContainer>
-      <DirectionSelector>
-        <SxIconButton
+      </div>
+      <div className={directionSelector()}>
+        <IconButton
           icon={faArrowLeft}
           onClick={() => updatePage(-1)}
           disabled={page === 0}
@@ -94,12 +83,12 @@ export default function Charts({
           {t("preview.page")} {page + 1}/
           {Math.ceil(statistics.length / DIAGRAMS_PER_PAGE)}
         </span>
-        <SxIconButton
+        <IconButton
           icon={faArrowRight}
           onClick={() => updatePage(1)}
           disabled={page === maxPage - 1}
         />
-      </DirectionSelector>
-    </Root>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/js/preview/Diagram.tsx
+++ b/frontend/src/js/preview/Diagram.tsx
@@ -1,4 +1,3 @@
-import { type Theme, useTheme } from "@emotion/react";
 import type { ChartData, ChartOptions } from "chart.js";
 import { addMonths, format } from "date-fns";
 import { useMemo } from "react";
@@ -11,6 +10,7 @@ import type {
 } from "../api/types";
 import { parseDate, parseStdDate } from "../common/helpers/dateHelper";
 import { hexToRgbA } from "../entity-history/TimeStratifiedChart";
+import { getCssVarColor } from "./getThemeColor";
 import {
   formatNumber,
   previewStatsIsBarStats,
@@ -27,14 +27,14 @@ type DiagramProps = {
 };
 function transformBarStatsToData(
   stats: BarStatistics,
-  theme: Theme,
+  color: string,
 ): ChartData<"bar"> {
   return {
     labels: stats.entries.map((entry) => entry.label),
     datasets: [
       {
         data: stats.entries.map((entry) => entry.value),
-        backgroundColor: `rgba(${hexToRgbA(theme.col.blueGrayDark)}, 1)`,
+        backgroundColor: color,
         borderWidth: 1,
       },
     ],
@@ -43,7 +43,7 @@ function transformBarStatsToData(
 
 function transformDateStatsToData(
   stats: DateStatistics,
-  theme: Theme,
+  color: string,
 ): ChartData<"line"> {
   const labels: string[] = [];
   const values: number[] = [];
@@ -58,7 +58,7 @@ function transformDateStatsToData(
       datasets: [
         {
           data: values,
-          borderColor: `rgba(${hexToRgbA(theme.col.blueGrayDark)}, 1)`,
+          borderColor: color,
           borderWidth: 1,
           fill: false,
         },
@@ -81,7 +81,7 @@ function transformDateStatsToData(
     datasets: [
       {
         data: values,
-        borderColor: `rgba(${hexToRgbA(theme.col.blueGrayDark)}, 1)`,
+        borderColor: color,
         borderWidth: 1,
         fill: false,
       },
@@ -96,15 +96,15 @@ export default function Diagram({
   height,
   width,
 }: DiagramProps) {
-  const theme = useTheme();
   const data = useMemo(() => {
+    const color = `rgba(${hexToRgbA(getCssVarColor("--color-primary-500"))}, 1)`;
     if (previewStatsIsBarStats(stat)) {
-      return transformBarStatsToData(stat, theme);
+      return transformBarStatsToData(stat, color);
     }
     if (previewStatsIsDateStats(stat)) {
-      return transformDateStatsToData(stat, theme);
+      return transformDateStatsToData(stat, color);
     }
-  }, [stat, theme]);
+  }, [stat]);
   const { t } = useTranslation();
   const { shouldTickRender } = useDateTickHandler(stat);
 

--- a/frontend/src/js/preview/DiagramModal.tsx
+++ b/frontend/src/js/preview/DiagramModal.tsx
@@ -1,7 +1,7 @@
-import styled from "@emotion/styled";
 import { t } from "i18next";
 import RcTable from "rc-table";
 import { useHotkeys } from "react-hotkeys-hook";
+import { tv } from "tailwind-variants";
 import type { PreviewStatistics } from "../api/types";
 import Modal from "../modal/Modal";
 import Diagram from "./Diagram";
@@ -13,19 +13,9 @@ interface DiagramModalProps {
   onClose: () => void;
 }
 
-const Horizontal = styled("div")`
-  display: inline-flex;
-`;
-
-const SxDiagram = styled(Diagram)`
-  width: 70vw;
-  height: 70vh;
-  margin-right: 15px;
-`;
-
-const StyledRcTable = styled(RcTable)`
-  margin: auto;
-`;
+const diagram = tv({
+  base: ["h-[70vh] w-[70vw]", "mr-[15px]"],
+});
 
 export default function DiagramModal({
   statistic,
@@ -39,11 +29,12 @@ export default function DiagramModal({
 
   return (
     <Modal onClose={onClose}>
-      <Horizontal>
-        <SxDiagram stat={statistic} />
+      <div className="inline-flex">
+        <Diagram className={diagram()} stat={statistic} />
         {previewStatsIsBarStats(statistic) &&
           Object.keys(statistic.extras).length > 0 && (
-            <StyledRcTable
+            <RcTable
+              className="m-auto"
               columns={[
                 {
                   title: t("preview.name"),
@@ -63,7 +54,7 @@ export default function DiagramModal({
               components={components}
             />
           )}
-      </Horizontal>
+      </div>
     </Modal>
   );
 }

--- a/frontend/src/js/preview/HeadlineStats.tsx
+++ b/frontend/src/js/preview/HeadlineStats.tsx
@@ -1,19 +1,13 @@
-import styled from "@emotion/styled";
+import { tv } from "tailwind-variants";
 import type { PreviewStatisticsResponse } from "../api/types";
 import TooltipEntries from "../tooltip/TooltipEntries";
 
-const Root = styled("div")`
-  padding: 10px;
-  align-self: right;
-  margin-left: auto;
-`;
+// the old styles also declared `align-self: right` — an invalid value, never applied
+const root = tv({ base: ["ml-auto", "p-[10px]"] });
 
-const SxTooltipEntries = styled(TooltipEntries)`
-  display: flex;
-  flex-direction: row;
-  gap: 12px 12px;
-  margin: auto;
-`;
+const tooltipEntries = tv({
+  base: ["flex flex-row", "gap-3", "m-auto"],
+});
 
 export type HeadlineStatsProps = {
   statistics: PreviewStatisticsResponse | null;
@@ -25,13 +19,14 @@ export default function HeadlineStats({
   idLabel,
 }: HeadlineStatsProps) {
   return (
-    <Root>
-      <SxTooltipEntries
+    <div className={root()}>
+      <TooltipEntries
+        className={tooltipEntries()}
         matchingEntities={statistics?.entities}
         matchingEntries={statistics?.total}
         dateRange={statistics?.dateRange}
         idLabel={idLabel}
       />
-    </Root>
+    </div>
   );
 }

--- a/frontend/src/js/preview/Preview.tsx
+++ b/frontend/src/js/preview/Preview.tsx
@@ -1,9 +1,9 @@
-import styled from "@emotion/styled";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { tv } from "tailwind-variants";
 
 import type { PreviewStatistics, SecondaryId } from "../api/types";
 import type { StateT } from "../app/reducers";
@@ -18,62 +18,51 @@ import ScrollBox from "./ScrollBox";
 import SelectBox from "./SelectBox";
 import Table from "./Table";
 
-const FullScreen = styled("div")`
-  height: 100%;
-  width: 100%;
-  position: fixed;
-  top: 0;
-  left: 0;
-  background-color: ${({ theme }) => theme.col.bgAlt};
-  z-index: 2;
-  display: flex;
-  flex-direction: column;
-  gap: 15px;
-`;
+const fullScreen = tv({
+  base: [
+    "fixed top-0 left-0",
+    "z-2",
+    "flex flex-col",
+    "gap-[15px]",
+    "h-full w-full",
+    "bg-bg-100",
+  ],
+});
 
-const Headline = styled("div")`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 30px;
-`;
+const headline = tv({
+  base: ["flex flex-row items-center", "gap-[30px]"],
+});
 
-const SxScrollBox = styled(ScrollBox)`
-  padding: 60px 20px 20px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-`;
+const scrollBox = tv({
+  base: ["flex flex-col", "gap-5", "pt-[60px] px-5 pb-5"],
+});
 
-const SxCharts = styled(Charts)`
-  width: 100%;
-  background-color: white;
-  padding: 10px;
-  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
-`;
+const charts = tv({
+  base: [
+    "w-full",
+    "bg-white",
+    "p-[10px]",
+    "shadow-[0_0_5px_0_rgba(0,0,0,0.2)]",
+  ],
+});
 
-const SxChartLoadingBlocker = styled("div")`
-  width: 100%;
-  background-color: white;
-  padding: 10px;
-  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
-  align-items: center;
-  height: 65vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
+const chartLoadingBlocker = tv({
+  base: [
+    "flex items-center justify-center",
+    "h-[65vh] w-full",
+    "bg-white",
+    "p-[10px]",
+    "shadow-[0_0_5px_0_rgba(0,0,0,0.2)]",
+  ],
+});
 
-const SxFaIcon = styled(FaIcon)`
-  width: 30px;
-  height: 30px;
-`;
+// the old styles also set `width: 30px`, but FaIcon forces `width: initial
+// !important`, so it never applied — only the height did
+const spinnerIcon = tv({ base: "h-[30px]" });
 
-const SxSelectBox = styled(SelectBox)`
-  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
-  background-color: white;
-  border-radius: ${({ theme }) => theme.borderRadius};
-`;
+const selectBox = tv({
+  base: ["rounded", "bg-white", "shadow-[0_0_5px_0_rgba(0,0,0,0.2)]"],
+});
 
 export default function Preview() {
   const preview = useSelector<StateT, PreviewStateT>((state) => state.preview);
@@ -104,14 +93,15 @@ export default function Preview() {
   });
 
   return (
-    <FullScreen>
-      <SxScrollBox>
-        <Headline>
+    <div className={fullScreen()}>
+      <ScrollBox className={scrollBox()}>
+        <div className={headline()}>
           <TransparentButton small onClick={onClose}>
             {t("common.back")}
           </TransparentButton>
           Ergebnisvorschau
-          <SxSelectBox
+          <SelectBox
+            className={selectBox()}
             items={statistics?.statistics ?? ([] as PreviewStatistics[])}
             onChange={(res) => {
               const stat = statistics?.statistics.find(
@@ -123,9 +113,10 @@ export default function Preview() {
             setIsOpen={setSelectBoxOpen}
           />
           <HeadlineStats statistics={statistics} idLabel={idLabel} />
-        </Headline>
+        </div>
         {statistics ? (
-          <SxCharts
+          <Charts
+            className={charts()}
             statistics={statistics.statistics}
             showPopup={(statistic: PreviewStatistics) => {
               setPopOver(statistic);
@@ -134,9 +125,9 @@ export default function Preview() {
             setPage={setPage}
           />
         ) : (
-          <SxChartLoadingBlocker>
-            <SxFaIcon icon={faSpinner} />
-          </SxChartLoadingBlocker>
+          <div className={chartLoadingBlocker()}>
+            <FaIcon className={spinnerIcon()} icon={faSpinner} />
+          </div>
         )}
         {popOver && (
           <DiagramModal statistic={popOver} onClose={() => setPopOver(null)} />
@@ -150,7 +141,7 @@ export default function Preview() {
               queryData={preview.queryData}
             />
           )}
-      </SxScrollBox>
-    </FullScreen>
+      </ScrollBox>
+    </div>
   );
 }

--- a/frontend/src/js/preview/ScrollBox.tsx
+++ b/frontend/src/js/preview/ScrollBox.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { faArrowUp } from "@fortawesome/free-solid-svg-icons";
 import {
   type HTMLAttributes,
@@ -7,29 +6,28 @@ import {
   useRef,
   useState,
 } from "react";
+import { tv } from "tailwind-variants";
 import IconButton from "../button/IconButton";
 
-const Root = styled("div")`
-  overflow: auto;
-`;
-const ScrollTopButton = styled(IconButton)`
-  position: absolute;
-  right: 30px;
-  bottom: 30px;
-  width: 50px;
-  height: 50px;
-  display: flex;
-  justify-content: center;
-  border-radius: 50%;
-  border: 1px solid ${({ theme }) => theme.col.gray};
-  background: white;
-  box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.2);
-  z-index: 3;
-`;
+const root = tv({ base: "overflow-auto" });
+
+const scrollTopButton = tv({
+  base: [
+    "absolute right-[30px] bottom-[30px]",
+    "z-3",
+    "flex justify-center",
+    "h-[50px] w-[50px]",
+    "rounded-full",
+    "border border-gray-500",
+    "bg-white",
+    "shadow-[0_0_5px_0_rgba(0,0,0,0.2)]",
+  ],
+});
 
 export default function ScrollBox({
   threshold = 0,
   children,
+  className,
   ...props
 }: PropsWithChildren<{ threshold?: number }> & HTMLAttributes<HTMLDivElement>) {
   const scrollBoxRef = useRef<HTMLDivElement>(null);
@@ -49,9 +47,10 @@ export default function ScrollBox({
   }, [threshold]);
 
   return (
-    <Root ref={scrollBoxRef} {...props}>
+    <div ref={scrollBoxRef} className={root({ className })} {...props}>
       {showButton && (
-        <ScrollTopButton
+        <IconButton
+          className={scrollTopButton()}
           icon={faArrowUp}
           bgHover={true}
           onClick={() =>
@@ -60,6 +59,6 @@ export default function ScrollBox({
         />
       )}
       {children}
-    </Root>
+    </div>
   );
 }

--- a/frontend/src/js/preview/SelectBox.tsx
+++ b/frontend/src/js/preview/SelectBox.tsx
@@ -1,6 +1,6 @@
-import styled from "@emotion/styled";
 import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons";
 import { type SetStateAction, useMemo, useRef, useState } from "react";
+import { tv } from "tailwind-variants";
 import { useClickOutside } from "../common/helpers/useClickOutside";
 import FaIcon from "../icon/FaIcon";
 import { Input } from "../ui-components/InputSelect/InputSelectComponents";
@@ -17,56 +17,33 @@ interface SelectBoxProps<T extends SelectItem> {
   setIsOpen: (open: boolean) => void;
 }
 
-const Root = styled("div")`
-  display: flex;
-  min-height: 30px;
-  flex-direction: column;
-  width: 20vw;
-`;
+const root = tv({
+  base: ["flex flex-col", "min-h-[30px]", "w-[20vw]"],
+});
 
-const InputContainer = styled("div")`
-  display: flex;
-  flex-direction: row;
-`;
+const list = tv({
+  base: [
+    "absolute",
+    "z-1",
+    "mt-[35px]",
+    "flex flex-col",
+    "gap-[5px]",
+    "max-h-[40vh] w-[20vw]",
+    "overflow-y-auto",
+    "rounded",
+    "bg-white",
+    "shadow-[0_0_5px_rgba(0,0,0,0.2)]",
+    "[clip-path:inset(0px_-8px_-8px_-8px)]",
+  ],
+});
 
-const List = styled("div")`
-  position: absolute;
-  z-index: 1;
-  margin-top: 35px;
-  background-color: white;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
-  border-radius: ${({ theme }) => theme.borderRadius};
-  clip-path: inset(0px -8px -8px -8px);
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  max-height: 40vh;
-  overflow-y: auto;
-  width: 20vw;
-`;
+const listItem = tv({
+  base: ["px-[5px]", "cursor-pointer", "hover:bg-gray-50"],
+});
 
-const ListItem = styled("div")`
-  padding: 0 5px;
-  cursor: pointer;
-  cursor: pointer;
-  &:hover {
-    background-color: ${({ theme }) => theme.col.grayVeryLight};
-  }
-`;
-
-const SxInput = styled(Input)`
-  margin-top: 5px;
-  width: 190px;
-`;
-const ArrowContainer = styled("div")`
-  margin-right: 5px;
-`;
-const SxArrow = styled(FaIcon)`
-  margin-top: 5px;
-  color: ${({ theme }) => theme.col.gray};
-  font-size: 17px;
-  cursor: pointer;
-`;
+const arrow = tv({
+  base: ["mt-[5px]", "text-[17px]", "text-gray-500", "cursor-pointer"],
+});
 
 export default function SelectBox<T extends SelectItem>({
   items,
@@ -92,9 +69,12 @@ export default function SelectBox<T extends SelectItem>({
   }, [items, searchTerm]);
 
   return (
-    <Root className={className} onClick={() => setIsOpen(!isOpen)}>
-      <InputContainer>
-        <SxInput
+    // biome-ignore lint/a11y/noStaticElementInteractions: TODO make this a real combobox
+    // biome-ignore lint/a11y/useKeyWithClickEvents: see above
+    <div className={root({ className })} onClick={() => setIsOpen(!isOpen)}>
+      <div className="flex flex-row">
+        <Input
+          className="mt-[5px] w-[190px]"
           type="text"
           placeholder=""
           value={searchTerm}
@@ -108,20 +88,26 @@ export default function SelectBox<T extends SelectItem>({
           }}
           spellCheck={false}
         />
-        <ArrowContainer>
-          <SxArrow icon={isOpen ? faCaretUp : faCaretDown} />
-        </ArrowContainer>
-      </InputContainer>
-      <List ref={clickOutsideRef}>
+        <div className="mr-[5px]">
+          <FaIcon className={arrow()} icon={isOpen ? faCaretUp : faCaretDown} />
+        </div>
+      </div>
+      <div className={list()} ref={clickOutsideRef}>
         {isOpen &&
           displayedItems.map((item) => {
             return (
-              <ListItem key={item.label} onClick={() => onChange(item)}>
+              // biome-ignore lint/a11y/noStaticElementInteractions: TODO make this a real listbox option
+              // biome-ignore lint/a11y/useKeyWithClickEvents: see above
+              <div
+                className={listItem()}
+                key={item.label}
+                onClick={() => onChange(item)}
+              >
                 {item.label}
-              </ListItem>
+              </div>
             );
           })}
-      </List>
-    </Root>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/js/preview/Table.tsx
+++ b/frontend/src/js/preview/Table.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import {
   Table as ArrowTable,
   type AsyncRecordBatchStreamReader,
@@ -6,7 +5,8 @@ import {
   type Vector,
 } from "apache-arrow";
 import RcTable from "rc-table";
-import { memo, useMemo, useRef } from "react";
+import { type ComponentProps, memo, useMemo, useRef } from "react";
+import { tv } from "tailwind-variants";
 import type { GetQueryResponseDoneT, GetQueryResponseT } from "../api/types";
 import { useCustomTableRenderers } from "./tableUtils";
 
@@ -16,58 +16,38 @@ interface Props {
   queryData: GetQueryResponseT;
 }
 
-const Root = styled("div")`
-  flex-grow: 1;
-  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
-  transform: rotateX(180deg);
+// flipped so the horizontal scrollbar sits on top; the inner table flips back
+const root = tv({
+  base: [
+    "grow",
+    "shadow-[0_0_10px_0_rgba(0,0,0,0.2)]",
+    "[transform:rotateX(180deg)]",
+    "[&_table]:[transform:rotateX(-180deg)]",
+  ],
+});
 
-  table {
-    transform: rotateX(-180deg);
-  }
-`;
+const table = tv({
+  base: [
+    "w-full",
+    "border-spacing-0",
+    "[&_th]:bg-gray-50 [&_th]:text-left [&_th]:font-normal",
+    "[&_td]:max-w-[25ch] [&_td]:overflow-hidden [&_td]:text-ellipsis [&_td]:whitespace-nowrap",
+    "[&_th]:p-[10px] [&_td]:p-[10px]",
+    "[&_th]:border-r [&_th]:border-b [&_th]:border-gray-400",
+    "[&_td]:border-r [&_td]:border-b [&_td]:border-gray-400",
+    "[&_th:last-of-type]:border-r-0 [&_td:last-of-type]:border-r-0",
+    "[&_.rc-table-measure-cell]:py-0 [&_.rc-table-measure-cell]:border-y-0",
+    "[&_.rc-table-measure-cell-content]:invisible [&_.rc-table-measure-cell-content]:pointer-events-none",
+    "[&_.rc-table-measure-cell-content]:h-0 [&_.rc-table-measure-cell-content]:overflow-hidden",
+  ],
+});
 
-export const StyledTable = styled("table")`
-  width: 100%;
-  border-spacing: 0;
-
-  th {
-    background: ${({ theme }) => theme.col.grayVeryLight};
-    font-weight: normal;
-    text-align: left;
-  }
-
-  td {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 25ch;
-  }
-
-  th,
-  td {
-    padding: 10px;
-    border-bottom: 1px solid ${({ theme }) => theme.col.grayMediumLight};
-    border-right: 1px solid ${({ theme }) => theme.col.grayMediumLight};
-  }
-
-  th:last-of-type,
-  td:last-of-type {
-    border-right: none;
-  }
-
-  .rc-table-measure-cell {
-    padding-top: 0;
-    padding-bottom: 0;
-    border-top: 0;
-    border-bottom: 0;
-  }
-  .rc-table-measure-cell-content {
-    height: 0;
-    overflow: hidden;
-    visibility: hidden;
-    pointer-events: none;
-  }
-`;
+export const StyledTable = ({
+  className,
+  ...props
+}: ComponentProps<"table">) => (
+  <table className={table({ className })} {...props} />
+);
 
 export default memo(function Table({
   arrowReader,
@@ -103,7 +83,7 @@ export default memo(function Table({
   );
 
   return (
-    <Root ref={rootRef}>
+    <div ref={rootRef} className={root()}>
       <RcTable
         columns={columns}
         data={loadedTableData}
@@ -113,6 +93,6 @@ export default memo(function Table({
         }}
         scroll={{ x: true }}
       />
-    </Root>
+    </div>
   );
 });

--- a/frontend/src/js/preview/getThemeColor.ts
+++ b/frontend/src/js/preview/getThemeColor.ts
@@ -1,0 +1,6 @@
+/**
+ * Chart.js needs resolved colour strings at runtime, so read the css theme
+ * tokens from the root element — downstream `:root` overrides keep working.
+ */
+export const getCssVarColor = (name: string): string =>
+  getComputedStyle(document.documentElement).getPropertyValue(name).trim();


### PR DESCRIPTION
**Emotion → tailwind migration, PR 4/6: external forms and preview (29 files).**

(external-forms, preview — stacked on #3995, stack overview in #3992)

**Main change**

- every `styled()` block → `tv()`; form-config-driven layout values stay inline `style`
- charts: new `getCssVarColor()` resolves theme tokens via `getComputedStyle` for chart.js, and palette colours come from `useAppTheme()` — downstream `:root` overrides keep affecting charts

**Worth a closer look**

- `Headline` keeps its polymorphic `as` prop; the `size` axis is a variant with `defaultVariants`
- `Table` (preview): all nested rc-table selectors → `[&_…]:` variants; the rotateX scrollbar-on-top trick kept as exact arbitrary transforms
- behaviour-identical removals: `SxFormConceptNode` wrapper (its className was never accepted, the margin never rendered) and `DropzoneList`'s `index` prop (only fed the styled wrapper)
- dead/invalid css dropped with comments: unitless `font-size: 24`, `align-self: right`, inert grid placements in `Charts`
- one more tv-const shadowing caught (`row` vs a `.map((row, …)` param)

Checks: biome, tsc, vitest, vite build green.
