### PR TITLE
refactor(frontend): hover tooltips on react-aria-components

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,5 +1,7 @@
 import type { Decorator, Preview } from "@storybook/react";
 
+import "../src/index.css";
+
 import { theme } from "../src/app-theme";
 import DndProvider from "../src/js/app/DndProvider";
 import { AppThemeContext } from "../src/js/app-theme-context";

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     "mustache": "^4.2.0",
     "rc-table": "^7.55.1",
     "react": "^19.2.8",
-    "react-aria": "^3.51.0",
+    "react-aria": "3.51.0",
     "react-aria-components": "^1.20.0",
     "react-chartjs-2": "^5.3.1",
     "react-datepicker": "^9.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,8 @@
     "mustache": "^4.2.0",
     "rc-table": "^7.55.1",
     "react": "^19.2.8",
+    "react-aria": "^3.51.0",
+    "react-aria-components": "^1.20.0",
     "react-chartjs-2": "^5.3.1",
     "react-datepicker": "^9.1.0",
     "react-dnd": "^16.0.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       react:
         specifier: ^19.2.8
         version: 19.2.8
+      react-aria:
+        specifier: ^3.51.0
+        version: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-aria-components:
+        specifier: ^1.20.0
+        version: 1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-chartjs-2:
         specifier: ^5.3.1
         version: 5.3.1(chart.js@4.5.1)(react@19.2.8)
@@ -584,6 +590,15 @@ packages:
       '@fortawesome/fontawesome-svg-core': ~6 || ~7
       react: ^18.0.0 || ^19.0.0
 
+  '@internationalized/date@3.12.3':
+    resolution: {integrity: sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==}
+
+  '@internationalized/number@3.6.7':
+    resolution: {integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==}
+
+  '@internationalized/string@3.2.10':
+    resolution: {integrity: sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==}
+
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
     peerDependencies:
@@ -905,6 +920,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@react-types/shared@3.36.1':
+    resolution: {integrity: sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   '@redux-devtools/extension@4.0.0':
     resolution: {integrity: sha512-pLIzgo5MvqdDLe5D1pzHLgmr8THra/DOyRf5MvOEPZnKKDn6RhFbNSS5oXZ3Cal0cpx08kx7sR6zD8QgoXEnZA==}
@@ -1228,6 +1248,9 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
@@ -1671,6 +1694,10 @@ packages:
   apache-arrow@21.2.0:
     resolution: {integrity: sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1784,6 +1811,9 @@ packages:
 
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2777,6 +2807,18 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  react-aria-components@1.20.0:
+    resolution: {integrity: sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-aria@3.51.0:
+    resolution: {integrity: sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-chartjs-2@5.3.1:
     resolution: {integrity: sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==}
     peerDependencies:
@@ -2938,6 +2980,11 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
+
+  react-stately@3.49.0:
+    resolution: {integrity: sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   react-window@2.3.0:
     resolution: {integrity: sha512-FW6TIpaOH646k51X7yE+LSCWGkt5Pfsnc1fVyq/sCI9h0pTqmMiBXM04pzFKg3Bt7NGkeV6kqbU8d/QjmFS7Ug==}
@@ -3713,6 +3760,18 @@ snapshots:
       '@fortawesome/fontawesome-svg-core': 7.3.1
       react: 19.2.8
 
+  '@internationalized/date@3.12.3':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.7':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/string@3.2.10':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.44.0)(tsx@4.23.12))':
     dependencies:
       glob: 13.0.6
@@ -3933,6 +3992,10 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
+  '@react-types/shared@3.36.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+
   '@redux-devtools/extension@4.0.0(redux@5.0.1)':
     dependencies:
       redux: 5.0.1
@@ -4141,6 +4204,10 @@ snapshots:
       typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.3.3':
     dependencies:
@@ -4544,6 +4611,10 @@ snapshots:
       json-with-bigint: 3.5.12
       tslib: 2.8.1
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -4668,6 +4739,8 @@ snapshots:
       fsevents: 2.3.3
 
   classnames@2.5.1: {}
+
+  client-only@0.0.1: {}
 
   clsx@2.1.1: {}
 
@@ -5847,6 +5920,32 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  react-aria-components@1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      client-only: 0.0.1
+      react: 19.2.8
+      react-aria: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+
+  react-aria@3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   react-chartjs-2@5.3.1(chart.js@4.5.1)(react@19.2.8):
     dependencies:
       chart.js: 4.5.1
@@ -6001,6 +6100,16 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
+
+  react-stately@3.49.0(react@19.2.8):
+    dependencies:
+      '@internationalized/date': 3.12.3
+      '@internationalized/number': 3.6.7
+      '@internationalized/string': 3.2.10
+      '@react-types/shared': 3.36.1(react@19.2.8)
+      '@swc/helpers': 0.5.23
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   react-window@2.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -84,7 +84,7 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8
       react-aria:
-        specifier: ^3.51.0
+        specifier: 3.51.0
         version: 3.51.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-aria-components:
         specifier: ^1.20.0

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,18 @@
 
   --animate-spin-fast: spin 0.5s linear infinite;
   --animate-blink: blink 1s linear infinite;
+  --animate-fade-in: fade-in 0.1s ease-out;
+  --animate-fade-out: fade-out 0.1s ease-in forwards;
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+  }
+  @keyframes fade-out {
+    to {
+      opacity: 0;
+    }
+  }
   @keyframes blink {
     50% {
       color: transparent;

--- a/frontend/src/js/button/BasicButton.tsx
+++ b/frontend/src/js/button/BasicButton.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes, Ref } from "react";
-
+import { mergeProps, useFocusable, useObjectRef } from "react-aria";
 import { tv } from "tailwind-variants";
 
 export interface BasicButtonProps
@@ -42,22 +42,31 @@ const BasicButton = ({
   large,
   active,
   secondary,
+  disabled,
   ...props
-}: BasicButtonProps & { ref?: Ref<HTMLButtonElement> }) => (
-  <button
-    type="button"
-    className={button({
-      bare,
-      tiny,
-      small,
-      large,
-      active,
-      secondary,
-      className,
-    })}
-    {...props}
-    ref={ref}
-  />
-);
+}: BasicButtonProps & { ref?: Ref<HTMLButtonElement> }) => {
+  const domRef = useObjectRef(ref);
+  // A surrounding TooltipTrigger hands its hover/focus props to the
+  // nearest focusable element: this makes every button a tooltip trigger.
+  const { focusableProps } = useFocusable({ isDisabled: disabled }, domRef);
+
+  return (
+    <button
+      type="button"
+      className={button({
+        bare,
+        tiny,
+        small,
+        large,
+        active,
+        secondary,
+        className,
+      })}
+      disabled={disabled}
+      {...mergeProps(focusableProps, props)}
+      ref={domRef}
+    />
+  );
+};
 
 export default BasicButton;

--- a/frontend/src/js/button/HistoryButton.tsx
+++ b/frontend/src/js/button/HistoryButton.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 
 import { openHistory } from "../entity-history/actions";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import IconButton from "./IconButton";
 
@@ -17,8 +17,9 @@ export const HistoryButton = () => {
   }, [dispatch]);
 
   return (
-    <WithTooltip text={t("history.history")}>
+    <TooltipTrigger>
       <IconButton small frame icon={faListUl} onClick={onClick} />
-    </WithTooltip>
+      <Tooltip>{t("history.history")}</Tooltip>
+    </TooltipTrigger>
   );
 };

--- a/frontend/src/js/concept-trees-open/ConceptTreesOpenButtons.tsx
+++ b/frontend/src/js/concept-trees-open/ConceptTreesOpenButtons.tsx
@@ -8,7 +8,7 @@ import type { StateT } from "../app/reducers";
 import IconButton from "../button/IconButton";
 import { clearSearchQuery } from "../concept-trees/actions";
 import { useRootConceptIds } from "../concept-trees/useRootConceptIds";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import { closeAllConceptOpen, resetAllConceptOpen } from "./actions";
 import type { ConceptTreesOpenStateT } from "./reducer";
@@ -71,15 +71,16 @@ const ConceptTreesOpenButtonsView = memo(
 
     return (
       <div className={row({ className })}>
-        <WithTooltip text={t("conceptTreesOpen.resetAll")}>
+        <TooltipTrigger>
           <IconButton
             className="px-[6px] py-[9px]"
             frame
             icon={faHome}
             onClick={onResetAllConceptOpen}
           />
-        </WithTooltip>
-        <WithTooltip text={t("conceptTreesOpen.closeAll")}>
+          <Tooltip>{t("conceptTreesOpen.resetAll")}</Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger>
           <IconButton
             className="px-[6px] py-[9px]"
             disabled={isCloseAllDisabled}
@@ -87,7 +88,8 @@ const ConceptTreesOpenButtonsView = memo(
             icon={faFolderMinus}
             onClick={onCloseAllConceptOpen}
           />
-        </WithTooltip>
+          <Tooltip>{t("conceptTreesOpen.closeAll")}</Tooltip>
+        </TooltipTrigger>
       </div>
     );
   },

--- a/frontend/src/js/dataset/DatasetSelector.tsx
+++ b/frontend/src/js/dataset/DatasetSelector.tsx
@@ -11,6 +11,7 @@ import {
   Tooltip,
   TooltipTarget,
   TooltipTrigger,
+  tooltipDelay,
 } from "../ui-components/Tooltip";
 
 import { useSelectDataset } from "./actions";
@@ -100,7 +101,7 @@ const DatasetSelectorUI = memo(
     const { t } = useTranslation();
 
     return (
-      <TooltipTrigger>
+      <TooltipTrigger delay={tooltipDelay.info}>
         <TooltipTarget
           as="div"
           excludeFromTabOrder

--- a/frontend/src/js/dataset/DatasetSelector.tsx
+++ b/frontend/src/js/dataset/DatasetSelector.tsx
@@ -101,7 +101,7 @@ const DatasetSelectorUI = memo(
     const { t } = useTranslation();
 
     return (
-      <TooltipTrigger delay={tooltipDelay.info}>
+      <TooltipTrigger delay={tooltipDelay.long}>
         <TooltipTarget
           as="div"
           excludeFromTabOrder

--- a/frontend/src/js/dataset/DatasetSelector.tsx
+++ b/frontend/src/js/dataset/DatasetSelector.tsx
@@ -7,7 +7,11 @@ import type { DatasetT, SelectOptionT } from "../api/types";
 import type { StateT } from "../app/reducers";
 import { exists } from "../common/helpers/exists";
 import InputSelect from "../ui-components/InputSelect/InputSelect";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 
 import { useSelectDataset } from "./actions";
 
@@ -96,13 +100,13 @@ const DatasetSelectorUI = memo(
     const { t } = useTranslation();
 
     return (
-      <WithTooltip
-        text={
-          disabled ? t("datasetSelector.disabled") : t("help.datasetSelector")
-        }
-        lazy
-      >
-        <div className={root()} data-test-id="dataset-selector">
+      <TooltipTrigger delay={1500}>
+        <TooltipTarget
+          as="div"
+          excludeFromTabOrder
+          className={root()}
+          data-test-id="dataset-selector"
+        >
           <span className={headline()}>{t("datasetSelector.label")}</span>
           <InputSelect
             className="min-w-[300px]"
@@ -114,8 +118,11 @@ const DatasetSelectorUI = memo(
             disabled={disabled || exists(error)}
             options={options}
           />
-        </div>
-      </WithTooltip>
+        </TooltipTarget>
+        <Tooltip>
+          {disabled ? t("datasetSelector.disabled") : t("help.datasetSelector")}
+        </Tooltip>
+      </TooltipTrigger>
     );
   },
 );

--- a/frontend/src/js/dataset/DatasetSelector.tsx
+++ b/frontend/src/js/dataset/DatasetSelector.tsx
@@ -100,7 +100,7 @@ const DatasetSelectorUI = memo(
     const { t } = useTranslation();
 
     return (
-      <TooltipTrigger delay={1500}>
+      <TooltipTrigger>
         <TooltipTarget
           as="div"
           excludeFromTabOrder

--- a/frontend/src/js/editor-v2/EditorV2.tsx
+++ b/frontend/src/js/editor-v2/EditorV2.tsx
@@ -431,18 +431,18 @@ export function EditorV2({
                   </IconButton>
                 </KeyboardShortcutTooltip>
               )}
-              <ConfirmableTooltip
-                onConfirm={onReset}
-                confirmationText={t("editorV2.clearConfirm")}
-              >
-                <TooltipTrigger>
+              <TooltipTrigger>
+                <ConfirmableTooltip
+                  onConfirm={onReset}
+                  confirmationText={t("editorV2.clearConfirm")}
+                >
                   <IconButton
                     style={{ marginLeft: "20px", height: "32.5px" }}
                     icon={faTrash}
                   />
-                  <Tooltip>{t("editorV2.clear")}</Tooltip>
-                </TooltipTrigger>
-              </ConfirmableTooltip>
+                </ConfirmableTooltip>
+                <Tooltip>{t("editorV2.clear")}</Tooltip>
+              </TooltipTrigger>
             </div>
           </div>
         )}

--- a/frontend/src/js/editor-v2/EditorV2.tsx
+++ b/frontend/src/js/editor-v2/EditorV2.tsx
@@ -24,7 +24,7 @@ import type {
 } from "../standard-query-editor/types";
 import { ConfirmableTooltip } from "../ui-components/ConfirmableTooltip";
 import Dropzone from "../ui-components/Dropzone";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 import { EDITOR_DROP_TYPES, HOTKEYS } from "./config";
 import { useConnectorEditing } from "./connector-update/useConnectorRotation";
 import { DateModal } from "./date-restriction/DateModal";
@@ -435,12 +435,13 @@ export function EditorV2({
                 onConfirm={onReset}
                 confirmationText={t("editorV2.clearConfirm")}
               >
-                <WithTooltip text={t("editorV2.clear")}>
+                <TooltipTrigger>
                   <IconButton
                     style={{ marginLeft: "20px", height: "32.5px" }}
                     icon={faTrash}
                   />
-                </WithTooltip>
+                  <Tooltip>{t("editorV2.clear")}</Tooltip>
+                </TooltipTrigger>
               </ConfirmableTooltip>
             </div>
           </div>

--- a/frontend/src/js/editor-v2/KeyboardShortcutTooltip.tsx
+++ b/frontend/src/js/editor-v2/KeyboardShortcutTooltip.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 
 import { KeyboardKey } from "../common/components/KeyboardKey";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const keyTooltip = tv({
-  base: ["flex items-center", "gap-[5px]", "px-[15px] py-2"],
+  base: ["flex items-center", "gap-[5px]"],
 });
 
 export const KeyboardShortcutTooltip = ({
@@ -20,8 +20,9 @@ export const KeyboardShortcutTooltip = ({
   const keynames = keyname.split("+");
 
   return (
-    <WithTooltip
-      html={
+    <TooltipTrigger>
+      {children}
+      <Tooltip>
         <div className={keyTooltip()}>
           {t("common.shortcut")}:{" "}
           <div className="flex items-center gap-[2px]">
@@ -33,9 +34,7 @@ export const KeyboardShortcutTooltip = ({
             ))}
           </div>
         </div>
-      }
-    >
-      {children}
-    </WithTooltip>
+      </Tooltip>
+    </TooltipTrigger>
   );
 };

--- a/frontend/src/js/editor-v2/TreeNode.tsx
+++ b/frontend/src/js/editor-v2/TreeNode.tsx
@@ -16,7 +16,11 @@ import Dropzone, {
   type DropzoneProps,
   type PossibleDroppableObject,
 } from "../ui-components/Dropzone";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 import { EDITOR_DROP_TYPES } from "./config";
 import { DateRange } from "./date-restriction/DateRange";
 import { Connector, Grid } from "./EditorLayout";
@@ -259,10 +263,10 @@ export function TreeNode({
           onDrop={() => {}}
         >
           {({ canDrop }) => (
-            <WithTooltip text={tooltipText}>
-              {/* biome-ignore lint/a11y/noStaticElementInteractions: TODO node selection area, emotion had hidden this */}
-              {/* biome-ignore lint/a11y/useKeyWithClickEvents: see above */}
-              <div
+            <TooltipTrigger>
+              <TooltipTarget
+                as="div"
+                excludeFromTabOrder
                 className={node({
                   isDragging: canDrop,
                   active,
@@ -399,8 +403,9 @@ export function TreeNode({
                     </InvisibleDropzone>
                   </Grid>
                 )}
-              </div>
-            </WithTooltip>
+              </TooltipTarget>
+              <Tooltip>{tooltipText}</Tooltip>
+            </TooltipTrigger>
           )}
         </Dropzone>
         {droppable.h && (

--- a/frontend/src/js/entity-history/ContentControl.tsx
+++ b/frontend/src/js/entity-history/ContentControl.tsx
@@ -8,7 +8,7 @@ import { memo, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import IconButton from "../button/IconButton";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 export type ContentType =
   | "groupId"
@@ -58,7 +58,7 @@ const ContentControl = ({ value, onChange }: Props) => {
       {options.map((option) => {
         const active = value[option.key];
         return (
-          <WithTooltip key={option.key} text={option.tooltip}>
+          <TooltipTrigger key={option.key}>
             <IconButton
               icon={option.icon}
               active={active}
@@ -67,7 +67,8 @@ const ContentControl = ({ value, onChange }: Props) => {
                 onChange({ ...value, [option.key]: !value[option.key] });
               }}
             />
-          </WithTooltip>
+            <Tooltip>{option.tooltip}</Tooltip>
+          </TooltipTrigger>
         );
       })}
     </div>

--- a/frontend/src/js/entity-history/ContentControl.tsx
+++ b/frontend/src/js/entity-history/ContentControl.tsx
@@ -67,7 +67,7 @@ const ContentControl = ({ value, onChange }: Props) => {
                 onChange({ ...value, [option.key]: !value[option.key] });
               }}
             />
-            <Tooltip>{option.tooltip}</Tooltip>
+            <Tooltip placement="right">{option.tooltip}</Tooltip>
           </TooltipTrigger>
         );
       })}

--- a/frontend/src/js/entity-history/DetailControl.tsx
+++ b/frontend/src/js/entity-history/DetailControl.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const root = tv({ base: "flex flex-col items-center" });
 export type DetailLevel = "summary" | "detail" | "full";
@@ -58,14 +58,15 @@ export const DetailControl = memo(
           const selected = value === detailLevel;
 
           return (
-            <WithTooltip key={value} text={tooltip}>
+            <TooltipTrigger key={value}>
               <IconButton
                 key={value}
                 onClick={() => setDetailLevel(value as DetailLevel)}
                 icon={icon}
                 active={selected}
               />
-            </WithTooltip>
+              <Tooltip>{tooltip}</Tooltip>
+            </TooltipTrigger>
           );
         })}
       </div>

--- a/frontend/src/js/entity-history/DetailControl.tsx
+++ b/frontend/src/js/entity-history/DetailControl.tsx
@@ -65,7 +65,7 @@ export const DetailControl = memo(
                 icon={icon}
                 active={selected}
               />
-              <Tooltip>{tooltip}</Tooltip>
+              <Tooltip placement="right">{tooltip}</Tooltip>
             </TooltipTrigger>
           );
         })}

--- a/frontend/src/js/entity-history/InteractionControl.tsx
+++ b/frontend/src/js/entity-history/InteractionControl.tsx
@@ -18,11 +18,11 @@ const InteractionControl = ({
     <div className="flex flex-col items-center">
       <TooltipTrigger>
         <IconButton onClick={onCloseAll} icon={faHome} />
-        <Tooltip>{t("history.closeAll")}</Tooltip>
+        <Tooltip placement="right">{t("history.closeAll")}</Tooltip>
       </TooltipTrigger>
       <TooltipTrigger>
         <IconButton onClick={onOpenAll} icon={faChevronRight} />
-        <Tooltip>{t("history.openAll")}</Tooltip>
+        <Tooltip placement="right">{t("history.openAll")}</Tooltip>
       </TooltipTrigger>
     </div>
   );

--- a/frontend/src/js/entity-history/InteractionControl.tsx
+++ b/frontend/src/js/entity-history/InteractionControl.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import IconButton from "../button/IconButton";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const InteractionControl = ({
   onCloseAll,
@@ -16,12 +16,14 @@ const InteractionControl = ({
 
   return (
     <div className="flex flex-col items-center">
-      <WithTooltip text={t("history.closeAll")}>
+      <TooltipTrigger>
         <IconButton onClick={onCloseAll} icon={faHome} />
-      </WithTooltip>
-      <WithTooltip text={t("history.openAll")}>
+        <Tooltip>{t("history.closeAll")}</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
         <IconButton onClick={onOpenAll} icon={faChevronRight} />
-      </WithTooltip>
+        <Tooltip>{t("history.openAll")}</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 };

--- a/frontend/src/js/entity-history/Navigation.tsx
+++ b/frontend/src/js/entity-history/Navigation.tsx
@@ -21,7 +21,11 @@ import type { SelectOptionT } from "../api/types";
 import type { StateT } from "../app/reducers";
 import IconButton from "../button/IconButton";
 import { ConfirmableTooltip } from "../ui-components/ConfirmableTooltip";
-import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  tooltipDelay,
+} from "../ui-components/Tooltip";
 import { closeHistory, resetHistory, useUpdateHistorySession } from "./actions";
 import { EntityIdsList } from "./EntityIdsList";
 import type { EntityIdsStatus } from "./History";
@@ -180,7 +184,7 @@ export const Navigation = memo(
         <div className={entityIdNav()}>
           {!empty && (
             <div className="flex">
-              <TooltipTrigger>
+              <TooltipTrigger delay={tooltipDelay.info}>
                 <IconButton
                   className={fullWidthIconButton()}
                   icon={faArrowUp}
@@ -209,7 +213,7 @@ export const Navigation = memo(
           {!empty && (
             <>
               <div className="flex">
-                <TooltipTrigger>
+                <TooltipTrigger delay={tooltipDelay.info}>
                   <IconButton
                     className={fullWidthIconButton()}
                     icon={faArrowDown}

--- a/frontend/src/js/entity-history/Navigation.tsx
+++ b/frontend/src/js/entity-history/Navigation.tsx
@@ -21,7 +21,7 @@ import type { SelectOptionT } from "../api/types";
 import type { StateT } from "../app/reducers";
 import IconButton from "../button/IconButton";
 import { ConfirmableTooltip } from "../ui-components/ConfirmableTooltip";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 import { closeHistory, resetHistory, useUpdateHistorySession } from "./actions";
 import { EntityIdsList } from "./EntityIdsList";
 import type { EntityIdsStatus } from "./History";
@@ -63,10 +63,6 @@ const containedIconButton = tv({
 
 const fullWidthIconButton = tv({
   base: ["w-full", "justify-center"],
-});
-
-const buttonWithTooltip = tv({
-  base: ["w-full", "shrink-0", "text-black"],
 });
 
 export const Navigation = memo(
@@ -145,7 +141,7 @@ export const Navigation = memo(
         }}
       >
         <div className={row()}>
-          <WithTooltip text={backButtonWarning}>
+          <TooltipTrigger>
             <IconButton
               className={containedIconButton()}
               frame
@@ -154,7 +150,8 @@ export const Navigation = memo(
             >
               {t("common.back")}
             </IconButton>
-          </WithTooltip>
+            <Tooltip>{backButtonWarning}</Tooltip>
+          </TooltipTrigger>
           {!empty && (
             <ConfirmableTooltip
               onConfirm={onReset}
@@ -183,17 +180,14 @@ export const Navigation = memo(
         <div className={entityIdNav()}>
           {!empty && (
             <div className="flex">
-              <WithTooltip
-                className={buttonWithTooltip()}
-                text={`${t("history.prevButtonLabel")} (shift + ⬆)`}
-                lazy
-              >
+              <TooltipTrigger delay={1500}>
                 <IconButton
                   className={fullWidthIconButton()}
                   icon={faArrowUp}
                   onClick={goToPrev}
                 />
-              </WithTooltip>
+                <Tooltip>{`${t("history.prevButtonLabel")} (shift + ⬆)`}</Tooltip>
+              </TooltipTrigger>
             </div>
           )}
           <LoadHistoryDropzone
@@ -215,23 +209,17 @@ export const Navigation = memo(
           {!empty && (
             <>
               <div className="flex">
-                <WithTooltip
-                  className={buttonWithTooltip()}
-                  text={`${t("history.nextButtonLabel")} (shift + ⬇)`}
-                  lazy
-                >
+                <TooltipTrigger delay={1500}>
                   <IconButton
                     className={fullWidthIconButton()}
                     icon={faArrowDown}
                     onClick={goToNext}
                   />
-                </WithTooltip>
+                  <Tooltip>{`${t("history.nextButtonLabel")} (shift + ⬇)`}</Tooltip>
+                </TooltipTrigger>
               </div>
               <div className="flex" style={{ marginTop: "10px" }}>
-                <WithTooltip
-                  className={buttonWithTooltip()}
-                  text={t("history.downloadButtonLabel")}
-                >
+                <TooltipTrigger>
                   <IconButton
                     className={fullWidthIconButton()}
                     style={{ backgroundColor: "white" }}
@@ -241,7 +229,8 @@ export const Navigation = memo(
                   >
                     CSV
                   </IconButton>
-                </WithTooltip>
+                  <Tooltip>{t("history.downloadButtonLabel")}</Tooltip>
+                </TooltipTrigger>
               </div>
             </>
           )}

--- a/frontend/src/js/entity-history/Navigation.tsx
+++ b/frontend/src/js/entity-history/Navigation.tsx
@@ -180,7 +180,7 @@ export const Navigation = memo(
         <div className={entityIdNav()}>
           {!empty && (
             <div className="flex">
-              <TooltipTrigger delay={1500}>
+              <TooltipTrigger>
                 <IconButton
                   className={fullWidthIconButton()}
                   icon={faArrowUp}
@@ -209,7 +209,7 @@ export const Navigation = memo(
           {!empty && (
             <>
               <div className="flex">
-                <TooltipTrigger delay={1500}>
+                <TooltipTrigger>
                   <IconButton
                     className={fullWidthIconButton()}
                     icon={faArrowDown}

--- a/frontend/src/js/entity-history/Navigation.tsx
+++ b/frontend/src/js/entity-history/Navigation.tsx
@@ -184,7 +184,7 @@ export const Navigation = memo(
         <div className={entityIdNav()}>
           {!empty && (
             <div className="flex">
-              <TooltipTrigger delay={tooltipDelay.info}>
+              <TooltipTrigger delay={tooltipDelay.long}>
                 <IconButton
                   className={fullWidthIconButton()}
                   icon={faArrowUp}
@@ -213,7 +213,7 @@ export const Navigation = memo(
           {!empty && (
             <>
               <div className="flex">
-                <TooltipTrigger delay={tooltipDelay.info}>
+                <TooltipTrigger delay={tooltipDelay.long}>
                   <IconButton
                     className={fullWidthIconButton()}
                     icon={faArrowDown}

--- a/frontend/src/js/entity-history/NavigationHeader.tsx
+++ b/frontend/src/js/entity-history/NavigationHeader.tsx
@@ -9,7 +9,7 @@ import type { StateT } from "../app/reducers";
 import IconButton from "../button/IconButton";
 import ProgressBar from "../common/components/ProgressBar";
 import { Heading3 } from "../headings/Headings";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import { SettingsModal } from "./SettingsModal";
 
@@ -87,12 +87,13 @@ export const NavigationHeader = memo(
             </Heading3>
             <p className={specialText()}>{t("history.history")}</p>
           </div>
-          <WithTooltip text={t("history.settings.headline")}>
+          <TooltipTrigger>
             <IconButton
               icon={faSliders}
               onClick={() => setSettingsModalOpen(true)}
             />
-          </WithTooltip>
+            <Tooltip>{t("history.settings.headline")}</Tooltip>
+          </TooltipTrigger>
         </div>
         <div className="grid gap-x-2 grid-cols-[auto_1fr] items-center">
           <Heading3 className={heading({ end: true })}>{idsCount}</Heading3>

--- a/frontend/src/js/entity-history/TimeStratifiedConceptChart.tsx
+++ b/frontend/src/js/entity-history/TimeStratifiedConceptChart.tsx
@@ -9,7 +9,11 @@ import type {
 } from "../api/types";
 import { getConceptById } from "../concept-trees/globalTreeStoreHelper";
 import FaIcon from "../icon/FaIcon";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 
 import { ConceptBubble } from "./ConceptBubble";
 
@@ -101,9 +105,12 @@ export const TimeStratifiedConceptChart = ({
     >
       <div />
       {allValues.map((val) => (
-        <WithTooltip key={val.label} text={val.description}>
-          <ConceptBubble>{val.label}</ConceptBubble>
-        </WithTooltip>
+        <TooltipTrigger key={val.label}>
+          <TooltipTarget as={ConceptBubble} excludeFromTabOrder>
+            {val.label}
+          </TooltipTarget>
+          <Tooltip>{val.description}</Tooltip>
+        </TooltipTrigger>
       ))}
       {years.map((year, i) => (
         <Fragment key={year}>

--- a/frontend/src/js/entity-history/VisibilityControl.tsx
+++ b/frontend/src/js/entity-history/VisibilityControl.tsx
@@ -22,7 +22,7 @@ const VisibilityControl = ({
           onClick={toggleBlurred}
           icon={blurred ? faEyeSlash : faEye}
         />
-        <Tooltip>{t("history.blurred")}</Tooltip>
+        <Tooltip placement="right">{t("history.blurred")}</Tooltip>
       </TooltipTrigger>
     </div>
   );

--- a/frontend/src/js/entity-history/VisibilityControl.tsx
+++ b/frontend/src/js/entity-history/VisibilityControl.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import IconButton from "../button/IconButton";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const VisibilityControl = ({
   blurred,
@@ -16,13 +16,14 @@ const VisibilityControl = ({
 
   return (
     <div className="flex flex-col items-center">
-      <WithTooltip text={t("history.blurred")}>
+      <TooltipTrigger>
         <IconButton
           className="px-[10px] py-2"
           onClick={toggleBlurred}
           icon={blurred ? faEyeSlash : faEye}
         />
-      </WithTooltip>
+        <Tooltip>{t("history.blurred")}</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 };

--- a/frontend/src/js/entity-history/timeline-search/SearchControl.tsx
+++ b/frontend/src/js/entity-history/timeline-search/SearchControl.tsx
@@ -20,7 +20,7 @@ const SearchControl = () => {
           onClick={toggleSearchVisible}
           icon={faSearch}
         />
-        <Tooltip>{t("history.search")}</Tooltip>
+        <Tooltip placement="right">{t("history.search")}</Tooltip>
       </TooltipTrigger>
     </div>
   );

--- a/frontend/src/js/entity-history/timeline-search/SearchControl.tsx
+++ b/frontend/src/js/entity-history/timeline-search/SearchControl.tsx
@@ -2,7 +2,7 @@ import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import IconButton from "../../button/IconButton";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 import { useTimelineSearch } from "./timelineSearchState";
 
 const SearchControl = () => {
@@ -13,14 +13,15 @@ const SearchControl = () => {
 
   return (
     <div className="flex flex-col items-center">
-      <WithTooltip text={t("history.search")}>
+      <TooltipTrigger>
         <IconButton
           className="px-[10px] py-2"
           active={searchVisible}
           onClick={toggleSearchVisible}
           icon={faSearch}
         />
-      </WithTooltip>
+        <Tooltip>{t("history.search")}</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 };

--- a/frontend/src/js/entity-history/timeline/EventCard.tsx
+++ b/frontend/src/js/entity-history/timeline/EventCard.tsx
@@ -14,7 +14,11 @@ import type {
 import { Highlighter } from "../../common/components/Highlighter";
 import { exists } from "../../common/helpers/exists";
 import FaIcon from "../../icon/FaIcon";
-import WithTooltip from "../../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../../ui-components/Tooltip";
 import type { ContentFilterValue } from "../ContentControl";
 import { RowDates } from "../RowDates";
 import type { DateRow, EntityEvent } from "../reducer";
@@ -140,16 +144,21 @@ const EventCard = ({
       <div className={eventItemContent()}>
         {contentFilter.money && applicableMoney.length > 0 && (
           <div className={flex()}>
-            <WithTooltip text={moneyTooltip}>
-              <span>
+            <TooltipTrigger>
+              <TooltipTarget
+                role="img"
+                aria-label={moneyTooltip}
+                excludeFromTabOrder
+              >
                 <FaIcon
                   className={bucketIcon()}
                   icon={faEuroSign}
                   active
                   large
                 />
-              </span>
-            </WithTooltip>
+              </TooltipTarget>
+              <Tooltip>{moneyTooltip}</Tooltip>
+            </TooltipTrigger>
             <div className={colBucket()}>
               {applicableMoney.map((column) => (
                 <div key={column.label}>
@@ -183,11 +192,16 @@ const EventCard = ({
         )}
         {contentFilter.rest && applicableRest.length > 0 && (
           <div className={flex()}>
-            <WithTooltip text={restTooltip}>
-              <span>
+            <TooltipTrigger>
+              <TooltipTarget
+                role="img"
+                aria-label={restTooltip}
+                excludeFromTabOrder
+              >
                 <FaIcon className={bucketIcon()} icon={faInfo} active large />
-              </span>
-            </WithTooltip>
+              </TooltipTarget>
+              <Tooltip>{restTooltip}</Tooltip>
+            </TooltipTrigger>
             <div className={colBucket()}>
               {applicableRest.map((column) => (
                 <div key={column.label}>
@@ -209,16 +223,21 @@ const EventCard = ({
         )}
         {contentFilter.groupId && applicableGroupableIds.length > 0 && (
           <div className={flex()}>
-            <WithTooltip text={groupableIdsTooltip}>
-              <span>
+            <TooltipTrigger>
+              <TooltipTarget
+                role="img"
+                aria-label={groupableIdsTooltip}
+                excludeFromTabOrder
+              >
                 <FaIcon
                   className={bucketIcon()}
                   icon={faFingerprint}
                   active
                   large
                 />
-              </span>
-            </WithTooltip>
+              </TooltipTarget>
+              <Tooltip>{groupableIdsTooltip}</Tooltip>
+            </TooltipTrigger>
             <div className={colBucket()}>
               {applicableGroupableIds.map((column) => (
                 <div key={column.label}>

--- a/frontend/src/js/entity-history/timeline/YearHead.tsx
+++ b/frontend/src/js/entity-history/timeline/YearHead.tsx
@@ -10,7 +10,11 @@ import type {
 import { exists } from "../../common/helpers/exists";
 import { getConceptById } from "../../concept-trees/globalTreeStoreHelper";
 import FaIcon from "../../icon/FaIcon";
-import WithTooltip from "../../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../../ui-components/Tooltip";
 import { ConceptBubble } from "../ConceptBubble";
 
 import { SmallHeading } from "./SmallHeading";
@@ -104,9 +108,12 @@ const ConceptValues = ({
       </div>
       <div className={conceptRow()}>
         {concepts.map((concept) => (
-          <WithTooltip key={concept.label} text={concept.description}>
-            <ConceptBubble>{concept.label}</ConceptBubble>
-          </WithTooltip>
+          <TooltipTrigger key={concept.label}>
+            <TooltipTarget as={ConceptBubble} excludeFromTabOrder>
+              {concept.label}
+            </TooltipTarget>
+            <Tooltip>{concept.description}</Tooltip>
+          </TooltipTrigger>
         ))}
       </div>
     </>

--- a/frontend/src/js/external-forms/FormsNavigation.tsx
+++ b/frontend/src/js/external-forms/FormsNavigation.tsx
@@ -72,19 +72,19 @@ const FormsNavigation = ({ onReset }: { onReset: () => void }) => {
             }
           }}
         />
-        <ConfirmableTooltip
-          onConfirm={onReset}
-          confirmationText={t("externalForms.common.clearConfirm")}
-        >
-          <TooltipTrigger>
+        <TooltipTrigger>
+          <ConfirmableTooltip
+            onConfirm={onReset}
+            confirmationText={t("externalForms.common.clearConfirm")}
+          >
             <IconButton
               className="ml-[10px] shrink-0 px-[10px] py-[7px]"
               frame
               icon={faTrash}
             />
-            <Tooltip>{t("externalForms.common.clear")}</Tooltip>
-          </TooltipTrigger>
-        </ConfirmableTooltip>
+          </ConfirmableTooltip>
+          <Tooltip>{t("externalForms.common.clear")}</Tooltip>
+        </TooltipTrigger>
       </div>
     </div>
   );

--- a/frontend/src/js/external-forms/FormsNavigation.tsx
+++ b/frontend/src/js/external-forms/FormsNavigation.tsx
@@ -8,7 +8,7 @@ import IconButton from "../button/IconButton";
 import { useActiveLang } from "../localization/useActiveLang";
 import { ConfirmableTooltip } from "../ui-components/ConfirmableTooltip";
 import InputSelect from "../ui-components/InputSelect/InputSelect";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import { setExternalForm } from "./actions";
 import type { Form } from "./config-types";
@@ -76,13 +76,14 @@ const FormsNavigation = ({ onReset }: { onReset: () => void }) => {
           onConfirm={onReset}
           confirmationText={t("externalForms.common.clearConfirm")}
         >
-          <WithTooltip text={t("externalForms.common.clear")}>
+          <TooltipTrigger>
             <IconButton
               className="ml-[10px] shrink-0 px-[10px] py-[7px]"
               frame
               icon={faTrash}
             />
-          </WithTooltip>
+            <Tooltip>{t("externalForms.common.clear")}</Tooltip>
+          </TooltipTrigger>
         </ConfirmableTooltip>
       </div>
     </div>

--- a/frontend/src/js/external-forms/form-concept-group/FormConceptNode.tsx
+++ b/frontend/src/js/external-forms/form-concept-group/FormConceptNode.tsx
@@ -13,7 +13,11 @@ import { canNodeBeDropped } from "../../model/node";
 import { HoverNavigatable } from "../../small-tab-navigation/HoverNavigatable";
 import { getRootNodeLabel } from "../../standard-query-editor/helper";
 import type { DragItemConceptTreeNode } from "../../standard-query-editor/types";
-import WithTooltip from "../../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../../ui-components/Tooltip";
 
 const node = tv({
   base: [
@@ -140,9 +144,8 @@ const FormConceptNode = ({
         onClick={onClick}
       >
         <div>
-          <WithTooltip text={tooltipText}>
-            {/* biome-ignore lint/complexity/noUselessFragments: WithTooltip takes a single child */}
-            <>
+          <TooltipTrigger>
+            <TooltipTarget as="div" excludeFromTabOrder>
               {rootNodeLabel && <p className={rootNode()}>{rootNodeLabel}</p>}
               <p className={labelText()}>{conceptNode?.label}</p>
               {conceptNode && !!conceptNode.description && (
@@ -150,12 +153,13 @@ const FormConceptNode = ({
                   {conceptNode.description}
                 </div>
               )}
-            </>
-          </WithTooltip>
+            </TooltipTarget>
+            <Tooltip>{tooltipText}</Tooltip>
+          </TooltipTrigger>
         </div>
         <div className="ml-[10px]">
           {expand?.expandable && (
-            <WithTooltip text={t("externalForms.common.concept.expand")}>
+            <TooltipTrigger>
               <IconButton
                 className="px-[6px] py-0"
                 icon={expand.active ? faCompressArrowsAlt : faExpandArrowsAlt}
@@ -165,7 +169,8 @@ const FormConceptNode = ({
                   expand.onClick();
                 }}
               />
-            </WithTooltip>
+              <Tooltip>{t("externalForms.common.concept.expand")}</Tooltip>
+            </TooltipTrigger>
           )}
         </div>
       </div>

--- a/frontend/src/js/header/LogoutButton.tsx
+++ b/frontend/src/js/header/LogoutButton.tsx
@@ -7,9 +7,9 @@ import { deleteStoredAuthToken } from "../authorization/helper";
 import IconButton from "../button/IconButton";
 import { clearIndexedDBCache } from "../common/helpers/indexedDBCache";
 import { isIDPEnabled } from "../environment";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
-const LogoutButton = ({ className }: { className?: string }) => {
+const LogoutButton = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { keycloak } = useKeycloak();
@@ -35,9 +35,10 @@ const LogoutButton = ({ className }: { className?: string }) => {
   };
 
   return (
-    <WithTooltip className={className} text={t("common.logout")}>
+    <TooltipTrigger>
       <IconButton small frame icon={faSignOutAlt} onClick={onLogout} />
-    </WithTooltip>
+      <Tooltip>{t("common.logout")}</Tooltip>
+    </TooltipTrigger>
   );
 };
 

--- a/frontend/src/js/modal/Modal.tsx
+++ b/frontend/src/js/modal/Modal.tsx
@@ -6,7 +6,7 @@ import { tv } from "tailwind-variants";
 import { TransparentButton } from "../button/TransparentButton";
 import { useClickOutside } from "../common/helpers/useClickOutside";
 import { Heading3 } from "../headings/Headings";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const root = tv({
   base: [
@@ -94,11 +94,12 @@ const Modal = ({
         <div className="flex items-start justify-between">
           <Heading3>{headline}</Heading3>
           {doneButton && (
-            <WithTooltip text={t("common.closeEsc")}>
+            <TooltipTrigger>
               <TransparentButton small onClick={onClose}>
                 {t("common.done")}
               </TransparentButton>
-            </WithTooltip>
+              <Tooltip>{t("common.closeEsc")}</Tooltip>
+            </TooltipTrigger>
           )}
         </div>
         {subtitleProp && <p className={subtitle()}>{subtitleProp}</p>}

--- a/frontend/src/js/pane/TabNavigation.tsx
+++ b/frontend/src/js/pane/TabNavigation.tsx
@@ -1,8 +1,9 @@
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { Focusable } from "react-aria-components";
 import { tv } from "tailwind-variants";
 import FaIcon from "../icon/FaIcon";
 import { HoverNavigatable } from "../small-tab-navigation/HoverNavigatable";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const root = tv({
   base: ["flex items-start", "border-b border-gray-100", "bg-white", "px-5"],
@@ -62,16 +63,19 @@ const TabNavigation = ({
       {tabs.map(({ key, label, tooltip, loading }) => {
         return (
           <HoverNavigatable key={key} triggerNavigate={createClickHandler(key)}>
-            <WithTooltip className="shrink-0" text={tooltip} lazy>
-              <button
-                type="button"
-                className={headline({ active: activeTab === key })}
-                onClick={createClickHandler(key)}
-              >
-                {label}
-                {loading && <FaIcon className="ml-[5px]" icon={faSpinner} />}
-              </button>
-            </WithTooltip>
+            <TooltipTrigger delay={1500}>
+              <Focusable>
+                <button
+                  type="button"
+                  className={headline({ active: activeTab === key })}
+                  onClick={createClickHandler(key)}
+                >
+                  {label}
+                  {loading && <FaIcon className="ml-[5px]" icon={faSpinner} />}
+                </button>
+              </Focusable>
+              <Tooltip>{tooltip}</Tooltip>
+            </TooltipTrigger>
           </HoverNavigatable>
         );
       })}

--- a/frontend/src/js/pane/TabNavigation.tsx
+++ b/frontend/src/js/pane/TabNavigation.tsx
@@ -3,7 +3,11 @@ import { Focusable } from "react-aria-components";
 import { tv } from "tailwind-variants";
 import FaIcon from "../icon/FaIcon";
 import { HoverNavigatable } from "../small-tab-navigation/HoverNavigatable";
-import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  tooltipDelay,
+} from "../ui-components/Tooltip";
 
 const root = tv({
   base: ["flex items-start", "border-b border-gray-100", "bg-white", "px-5"],
@@ -63,7 +67,7 @@ const TabNavigation = ({
       {tabs.map(({ key, label, tooltip, loading }) => {
         return (
           <HoverNavigatable key={key} triggerNavigate={createClickHandler(key)}>
-            <TooltipTrigger>
+            <TooltipTrigger delay={tooltipDelay.info}>
               <Focusable>
                 <button
                   type="button"

--- a/frontend/src/js/pane/TabNavigation.tsx
+++ b/frontend/src/js/pane/TabNavigation.tsx
@@ -63,7 +63,7 @@ const TabNavigation = ({
       {tabs.map(({ key, label, tooltip, loading }) => {
         return (
           <HoverNavigatable key={key} triggerNavigate={createClickHandler(key)}>
-            <TooltipTrigger delay={1500}>
+            <TooltipTrigger>
               <Focusable>
                 <button
                   type="button"

--- a/frontend/src/js/pane/TabNavigation.tsx
+++ b/frontend/src/js/pane/TabNavigation.tsx
@@ -67,7 +67,7 @@ const TabNavigation = ({
       {tabs.map(({ key, label, tooltip, loading }) => {
         return (
           <HoverNavigatable key={key} triggerNavigate={createClickHandler(key)}>
-            <TooltipTrigger delay={tooltipDelay.info}>
+            <TooltipTrigger delay={tooltipDelay.long}>
               <Focusable>
                 <button
                   type="button"

--- a/frontend/src/js/preview/getThemeColor.ts
+++ b/frontend/src/js/preview/getThemeColor.ts
@@ -1,5 +1,5 @@
 /**
- * Chart.js needs resolved colour strings at runtime, so read the css theme
+ * Chart.js needs resolved color strings at runtime, so read the css theme
  * tokens from the root element — downstream `:root` overrides keep working.
  */
 export const getCssVarColor = (name: string): string =>

--- a/frontend/src/js/previous-queries/list/DeleteProjectItemButton.tsx
+++ b/frontend/src/js/previous-queries/list/DeleteProjectItemButton.tsx
@@ -31,20 +31,20 @@ export const DeleteProjectItemButton = ({ item }: { item: ProjectItemT }) => {
   );
 
   return (
-    <ConfirmableTooltip
-      red
-      onConfirm={onDelete}
-      confirmationText={confirmationText}
-    >
-      <TooltipTrigger>
+    <TooltipTrigger>
+      <ConfirmableTooltip
+        red
+        onConfirm={onDelete}
+        confirmationText={confirmationText}
+      >
         <IconButton
           icon={faTimes}
           bare
           title="delete"
           data-test-id="project-item-delete-button"
         />
-        <Tooltip>{t("common.delete")}</Tooltip>
-      </TooltipTrigger>
-    </ConfirmableTooltip>
+      </ConfirmableTooltip>
+      <Tooltip>{t("common.delete")}</Tooltip>
+    </TooltipTrigger>
   );
 };

--- a/frontend/src/js/previous-queries/list/DeleteProjectItemButton.tsx
+++ b/frontend/src/js/previous-queries/list/DeleteProjectItemButton.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import IconButton from "../../button/IconButton";
 import { ConfirmableTooltip } from "../../ui-components/ConfirmableTooltip";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 import { useRemoveFormConfig, useRemoveQuery } from "./actions";
 import { isFormConfig } from "./helpers";
 import type { ProjectItemT } from "./ProjectItem";
@@ -36,14 +36,15 @@ export const DeleteProjectItemButton = ({ item }: { item: ProjectItemT }) => {
       onConfirm={onDelete}
       confirmationText={confirmationText}
     >
-      <WithTooltip text={t("common.delete")}>
+      <TooltipTrigger>
         <IconButton
           icon={faTimes}
           bare
           title="delete"
           data-test-id="project-item-delete-button"
         />
-      </WithTooltip>
+        <Tooltip>{t("common.delete")}</Tooltip>
+      </TooltipTrigger>
     </ConfirmableTooltip>
   );
 };

--- a/frontend/src/js/previous-queries/list/Folders.tsx
+++ b/frontend/src/js/previous-queries/list/Folders.tsx
@@ -11,7 +11,7 @@ import { useResizeObserver } from "../../common/helpers/useResizeObserver";
 import type { DragItemFormConfig } from "../../external-forms/types";
 import type { DragItemQuery } from "../../standard-query-editor/types";
 import Dropzone from "../../ui-components/Dropzone";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 import {
   removeFolderFromFilter,
   setFolderFilter,
@@ -264,7 +264,7 @@ const Folders = ({ className }: { className?: string }) => {
                     resultCount={searchResult ? searchResult[folder] : null}
                     resultWords={searchResultWords}
                   />
-                  <WithTooltip text={t("common.delete")}>
+                  <TooltipTrigger>
                     <IconButton
                       className={deleteButton()}
                       icon={faTimes}
@@ -273,7 +273,8 @@ const Folders = ({ className }: { className?: string }) => {
                         e.stopPropagation();
                       }}
                     />
-                  </WithTooltip>
+                    <Tooltip>{t("common.delete")}</Tooltip>
+                  </TooltipTrigger>
                 </>
               )}
             </Dropzone>

--- a/frontend/src/js/previous-queries/list/Folders.tsx
+++ b/frontend/src/js/previous-queries/list/Folders.tsx
@@ -39,11 +39,12 @@ const root = tv({
   base: ["flex flex-col items-start", "shrink-0", "h-full", "overflow-hidden"],
 });
 
-// hidden until the surrounding folder dropzone (group/folder) is hovered
+// shown while the surrounding folder dropzone (group/folder) is hovered;
+// invisible rather than hidden, so it keeps its layout and its tooltip stays anchored
 const deleteButton = tv({
   base: [
     "absolute top-0 right-0",
-    "hidden group-hover/folder:block",
+    "invisible group-hover/folder:visible",
     "bg-bg-50",
     "px-2 py-[2px]",
     "opacity-100",

--- a/frontend/src/js/previous-queries/list/FoldersToggleButton.tsx
+++ b/frontend/src/js/previous-queries/list/FoldersToggleButton.tsx
@@ -2,24 +2,19 @@ import { faFolder } from "@fortawesome/free-solid-svg-icons";
 import { useTranslation } from "react-i18next";
 
 import IconButton from "../../button/IconButton";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 
 const FoldersToggleButton = ({
-  className,
   active,
   onClick,
 }: {
-  className?: string;
   active?: boolean;
   onClick: () => void;
 }) => {
   const { t } = useTranslation();
 
   return (
-    <WithTooltip
-      text={t("previousQueriesFolderButton.tooltip")}
-      className={className}
-    >
+    <TooltipTrigger>
       <IconButton
         className="mr-[5px] px-[6px] py-[9px]"
         onClick={onClick}
@@ -27,7 +22,8 @@ const FoldersToggleButton = ({
         active={active}
         frame
       />
-    </WithTooltip>
+      <Tooltip>{t("previousQueriesFolderButton.tooltip")}</Tooltip>
+    </TooltipTrigger>
   );
 };
 export default FoldersToggleButton;

--- a/frontend/src/js/previous-queries/list/ProjectItem.tsx
+++ b/frontend/src/js/previous-queries/list/ProjectItem.tsx
@@ -25,7 +25,11 @@ import { useFormLabelByType } from "../../external-forms/stateSelectors";
 import FaIcon from "../../icon/FaIcon";
 import FormSymbol from "../../symbols/FormSymbol";
 import QuerySymbol from "../../symbols/QuerySymbol";
-import WithTooltip from "../../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../../ui-components/Tooltip";
 import { useUpdateFormConfig, useUpdateQuery } from "./actions";
 import { DeleteProjectItemButton } from "./DeleteProjectItemButton";
 import { isFormConfig } from "./helpers";
@@ -60,14 +64,7 @@ const ownerName = tv({
   base: ["shrink-0", "pl-[5px]", "text-gray-500", "text-xs"],
 });
 
-const tooltipText = tv({
-  base: [
-    "flex flex-col items-start",
-    "px-[14px] py-2",
-    "font-normal",
-    "text-base",
-  ],
-});
+const tooltipText = tv({ base: ["flex flex-col items-start", "font-normal"] });
 
 const labelRow = tv({
   base: ["flex justify-between", "w-full", "leading-6", "my-[2px]"],
@@ -141,13 +138,7 @@ const ShareButton = ({
 }) => {
   const { t } = useTranslation();
   return (
-    <WithTooltip
-      html={
-        <div className={tooltipText()}>
-          {isShared ? t("common.shared") : t("common.share")}
-        </div>
-      }
-    >
+    <TooltipTrigger>
       <IconButton
         icon={isShared ? faUser : faUserRegular}
         bare
@@ -155,7 +146,14 @@ const ShareButton = ({
         data-test-id="share"
         onClick={onClick}
       />
-    </WithTooltip>
+      <Tooltip>
+        {
+          <div className={tooltipText()}>
+            {isShared ? t("common.shared") : t("common.share")}
+          </div>
+        }
+      </Tooltip>
+    </TooltipTrigger>
   );
 };
 
@@ -183,7 +181,7 @@ const ResultsLabel = ({
   const { t } = useTranslation();
   if (!resultUrl) return <span className="whitespace-nowrap">{label}</span>;
   return (
-    <WithTooltip text={t("previousQuery.downloadResults")}>
+    <TooltipTrigger>
       <DownloadButton
         className={downloadButton()}
         tight
@@ -194,7 +192,8 @@ const ResultsLabel = ({
       >
         {label}
       </DownloadButton>
-    </WithTooltip>
+      <Tooltip>{t("previousQuery.downloadResults")}</Tooltip>
+    </TooltipTrigger>
   );
 };
 
@@ -266,7 +265,7 @@ const ProjectItem = ({
       <div className={content({ own: !!item.own, system: isSystem })}>
         <div className={topInfos()}>
           <div className="flex items-center">
-            <WithTooltip html={<FoldersTooltip folders={folders} />}>
+            <TooltipTrigger>
               <IconButton
                 className="mr-[10px]"
                 icon={folders.length === 0 ? faFolderRegular : faFolder}
@@ -276,24 +275,31 @@ const ProjectItem = ({
                 onClick={onIndicateEditFolders}
                 disabled={!mayEdit}
               />
-            </WithTooltip>
+              <Tooltip>{<FoldersTooltip folders={folders} />}</Tooltip>
+            </TooltipTrigger>
             <div className="flex items-center gap-2">
               <ResultsLabel label={topLeftLabel} resultUrl={resultUrl} />
               {hasNoDates && (
-                <WithTooltip text={t("previousQuery.hasNoDates")}>
-                  <FaIcon className="opacity-70" red icon={faCalendar} />
-                </WithTooltip>
+                <TooltipTrigger>
+                  <TooltipTarget
+                    role="img"
+                    aria-label={t("previousQuery.hasNoDates")}
+                    excludeFromTabOrder
+                  >
+                    <FaIcon className="opacity-70" red icon={faCalendar} />
+                  </TooltipTarget>
+                  <Tooltip>{t("previousQuery.hasNoDates")}</Tooltip>
+                </TooltipTrigger>
               )}
             </div>
           </div>
           <div className="ml-[5px] flex shrink-0 items-center gap-[10px]">
             {executedAt}
             {secondaryId && (
-              <WithTooltip
-                text={`${t("queryEditor.secondaryId")}: ${secondaryId.label}`}
-              >
+              <TooltipTrigger>
                 <IconButton icon={faMicroscope} bare onClick={() => {}} />
-              </WithTooltip>
+                <Tooltip>{`${t("queryEditor.secondaryId")}: ${secondaryId.label}`}</Tooltip>
+              </TooltipTrigger>
             )}
             {item.own && (
               <ShareButton isShared={!!isShared} onClick={onIndicateShare} />

--- a/frontend/src/js/previous-queries/list/ShareProjectItemModal.tsx
+++ b/frontend/src/js/previous-queries/list/ShareProjectItemModal.tsx
@@ -8,7 +8,7 @@ import type { StateT } from "../../app/reducers";
 import IconButton from "../../button/IconButton";
 import Modal from "../../modal/Modal";
 import InputMultiSelect from "../../ui-components/InputMultiSelect/InputMultiSelect";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 import {
   useLoadFormConfig,
   useLoadQuery,
@@ -146,7 +146,7 @@ const ShareProjectItemModal = ({ item, onClose }: PropsT) => {
             label={groupsLabel}
             options={userGroupOptions}
           />
-          <WithTooltip text={shareLabel}>
+          <TooltipTrigger>
             <IconButton
               className="ml-[3px] px-[10px] py-[7px]"
               type="submit"
@@ -154,7 +154,8 @@ const ShareProjectItemModal = ({ item, onClose }: PropsT) => {
               disabled={buttonDisabled}
               icon={loading ? faSpinner : faCheck}
             />
-          </WithTooltip>
+            <Tooltip>{shareLabel}</Tooltip>
+          </TooltipTrigger>
         </div>
       </form>
     </Modal>

--- a/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
+++ b/frontend/src/js/previous-queries/upload/CSVColumnPicker.tsx
@@ -21,7 +21,7 @@ import FaIcon from "../../icon/FaIcon";
 import { useActiveLang } from "../../localization/useActiveLang";
 import ScrollableList from "../../scrollable-list/ScrollableList";
 import InputSelect from "../../ui-components/InputSelect/InputSelect";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 
 const td = tv({
   base: "min-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap text-xs",
@@ -259,9 +259,10 @@ const CSVColumnPicker = ({
             <code className="font-bold">{file.name}</code>
             <code>{csv.length} Zeilen</code>
           </div>
-          <WithTooltip text={t("common.clear")}>
+          <TooltipTrigger>
             <IconButton frame icon={faTrash} onClick={onReset} />
-          </WithTooltip>
+            <Tooltip>{t("common.clear")}</Tooltip>
+          </TooltipTrigger>
         </div>
         {csv.length > 0 && (
           <InputSelect

--- a/frontend/src/js/previous-queries/upload/UploadQueryResults.tsx
+++ b/frontend/src/js/previous-queries/upload/UploadQueryResults.tsx
@@ -12,7 +12,7 @@ import type {
 import type { StateT } from "../../app/reducers";
 import IconButton from "../../button/IconButton";
 import { setMessage } from "../../snack-message/actions";
-import WithTooltip from "../../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../../ui-components/Tooltip";
 import { useLoadQueries } from "../list/actions";
 
 import type { QueryToUploadT } from "./CSVColumnPicker";
@@ -76,14 +76,15 @@ const UploadQueryResults = ({
 
   return (
     <div className={className}>
-      <WithTooltip text={t("uploadQueryResults.uploadResults")}>
+      <TooltipTrigger>
         <IconButton
           className="px-[6px] py-[9px]"
           frame
           icon={faUpload}
           onClick={() => setIsModalOpen(true)}
         />
-      </WithTooltip>
+        <Tooltip>{t("uploadQueryResults.uploadResults")}</Tooltip>
+      </TooltipTrigger>
       {isModalOpen && (
         <UploadQueryResultsModal
           loading={loading}

--- a/frontend/src/js/query-node-editor/CommonNodeSettings.tsx
+++ b/frontend/src/js/query-node-editor/CommonNodeSettings.tsx
@@ -25,7 +25,6 @@ const CommonNodeSettings = ({
           <InputCheckbox
             label={t("queryNodeEditor.excludeTimestamps")}
             tooltip={t("help.excludeTimestamps")}
-            tooltipLazy
             value={excludeTimestamps}
             onChange={onToggleTimestamps}
           />
@@ -36,7 +35,6 @@ const CommonNodeSettings = ({
           <InputCheckbox
             label={t("queryNodeEditor.excludeFromSecondaryId")}
             tooltip={t("help.excludeFromSecondaryId")}
-            tooltipLazy
             value={excludeFromSecondaryId}
             onChange={onToggleSecondaryIdExclude}
           />

--- a/frontend/src/js/query-node-editor/MenuColumnItem.tsx
+++ b/frontend/src/js/query-node-editor/MenuColumnItem.tsx
@@ -7,7 +7,7 @@ import IconButton from "../button/IconButton";
 import type { NodeResetConfig } from "../model/node";
 import { tableHasFilterValues, tableIsDisabled } from "../model/table";
 import type { TableWithFilterValueT } from "../standard-query-editor/types";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const container = tv({
   base: [
@@ -94,10 +94,7 @@ const MenuColumnItem = ({
         <span className="pl-[10px] leading-[20px]">{table.label}</span>
       </div>
       {isFilterActive && (
-        <WithTooltip
-          className="flex!"
-          text={t("queryNodeEditor.clearSettings")}
-        >
+        <TooltipTrigger>
           <IconButton
             className="p-0"
             icon={faFilter}
@@ -113,7 +110,8 @@ const MenuColumnItem = ({
               onResetTable({ useDefaults: false });
             }}
           />
-        </WithTooltip>
+          <Tooltip>{t("queryNodeEditor.clearSettings")}</Tooltip>
+        </TooltipTrigger>
       )}
     </div>
   );

--- a/frontend/src/js/query-node-editor/ResetAllSettingsButton.tsx
+++ b/frontend/src/js/query-node-editor/ResetAllSettingsButton.tsx
@@ -1,5 +1,4 @@
 import { faTrash } from "@fortawesome/free-solid-svg-icons";
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import IconButton from "../button/IconButton";
@@ -17,22 +16,26 @@ const ResetAllSettingsButton = ({
   const text = t("queryNodeEditor.clearAllSettings");
   const confirmationText = t("queryNodeEditor.clearAllSettingsConfirm");
 
-  const button = useMemo(() => {
-    return compact ? (
-      <TooltipTrigger>
-        <IconButton icon={faTrash} active />
-        <Tooltip className="whitespace-nowrap">{text}</Tooltip>
-      </TooltipTrigger>
-    ) : (
-      <IconButton icon={faTrash} active>
-        {text}
-      </IconButton>
-    );
-  }, [compact, text]);
+  const trigger = (
+    <IconButton icon={faTrash} active>
+      {compact ? null : text}
+    </IconButton>
+  );
 
-  return (
+  // tippy needs the button itself as its child, the tooltip goes around both
+  return compact ? (
+    <TooltipTrigger>
+      <ConfirmableTooltip
+        onConfirm={onClick}
+        confirmationText={confirmationText}
+      >
+        {trigger}
+      </ConfirmableTooltip>
+      <Tooltip className="whitespace-nowrap">{text}</Tooltip>
+    </TooltipTrigger>
+  ) : (
     <ConfirmableTooltip onConfirm={onClick} confirmationText={confirmationText}>
-      {button}
+      {trigger}
     </ConfirmableTooltip>
   );
 };

--- a/frontend/src/js/query-node-editor/ResetAllSettingsButton.tsx
+++ b/frontend/src/js/query-node-editor/ResetAllSettingsButton.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import IconButton from "../button/IconButton";
 import { ConfirmableTooltip } from "../ui-components/ConfirmableTooltip";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 const ResetAllSettingsButton = ({
   compact,
@@ -19,9 +19,10 @@ const ResetAllSettingsButton = ({
 
   const button = useMemo(() => {
     return compact ? (
-      <WithTooltip className="whitespace-nowrap" text={text}>
+      <TooltipTrigger>
         <IconButton icon={faTrash} active />
-      </WithTooltip>
+        <Tooltip className="whitespace-nowrap">{text}</Tooltip>
+      </TooltipTrigger>
     ) : (
       <IconButton icon={faTrash} active>
         {text}

--- a/frontend/src/js/query-node-editor/ResetAndClose.tsx
+++ b/frontend/src/js/query-node-editor/ResetAndClose.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import { TransparentButton } from "../button/TransparentButton";
 import type { NodeResetConfig } from "../model/node";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import ResetAllSettingsButton from "./ResetAllSettingsButton";
 
@@ -30,11 +30,12 @@ const ResetAndClose = ({
           compact={isCompact}
         />
       )}
-      <WithTooltip text={t("common.saveAndCloseEsc")}>
+      <TooltipTrigger>
         <TransparentButton small onClick={onClose}>
           {t("common.save")}
         </TransparentButton>
-      </WithTooltip>
+        <Tooltip>{t("common.saveAndCloseEsc")}</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 };

--- a/frontend/src/js/query-runner/QueryRunner.tsx
+++ b/frontend/src/js/query-runner/QueryRunner.tsx
@@ -2,7 +2,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { tv } from "tailwind-variants";
 
 import { exists } from "../common/helpers/exists";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import QueryResults from "./QueryResults";
 import QueryRunnerButton from "./QueryRunnerButton";
@@ -51,14 +51,15 @@ const QueryRunner = ({
   return (
     <div className={root()} data-test-id="query-runner">
       <div className="grow">
-        <WithTooltip text={buttonTooltip}>
+        <TooltipTrigger>
           <QueryRunnerButton
             onClick={btnAction}
             isStartStopLoading={isStartStopLoading}
             isQueryRunning={isQueryRunning}
             disabled={disabled}
           />
-        </WithTooltip>
+          <Tooltip>{buttonTooltip}</Tooltip>
+        </TooltipTrigger>
       </div>
       <div className="grow-[2] pl-5">
         <div className="flex flex-row items-center justify-end">

--- a/frontend/src/js/small-tab-navigation/SmallTabNavigation.tsx
+++ b/frontend/src/js/small-tab-navigation/SmallTabNavigation.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
+import { Focusable } from "react-aria-components";
 
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import SmallTabNavigationButton from "./SmallTabNavigationButton";
 
@@ -31,18 +32,21 @@ const SmallTabNavigation = ({
         const selected = option.value === selectedTab;
 
         return (
-          <WithTooltip key={option.value} text={option.tooltip}>
-            <SmallTabNavigationButton
-              variant={variant}
-              key={option.value}
-              value={option.value}
-              size={size}
-              isSelected={selected}
-              onClick={() => onSelectTab(option.value)}
-            >
-              {option.label({ selected })}
-            </SmallTabNavigationButton>
-          </WithTooltip>
+          <TooltipTrigger key={option.value}>
+            <Focusable>
+              <SmallTabNavigationButton
+                variant={variant}
+                key={option.value}
+                value={option.value}
+                size={size}
+                isSelected={selected}
+                onClick={() => onSelectTab(option.value)}
+              >
+                {option.label({ selected })}
+              </SmallTabNavigationButton>
+            </Focusable>
+            <Tooltip>{option.tooltip}</Tooltip>
+          </TooltipTrigger>
         );
       })}
     </div>

--- a/frontend/src/js/small-tab-navigation/SmallTabNavigationButton.tsx
+++ b/frontend/src/js/small-tab-navigation/SmallTabNavigationButton.tsx
@@ -1,4 +1,4 @@
-import type { Ref } from "react";
+import type { ButtonHTMLAttributes, Ref } from "react";
 import { tv } from "tailwind-variants";
 
 import { HoverNavigatable } from "./HoverNavigatable";
@@ -94,6 +94,7 @@ const SmallTabNavigationButton = ({
   isSelected,
   onClick,
   variant,
+  ...props
 }: {
   ref?: Ref<HTMLButtonElement>;
 
@@ -103,7 +104,10 @@ const SmallTabNavigationButton = ({
   onClick: () => void;
   children?: React.ReactNode;
   variant: "primary" | "secondary";
-}) => {
+} & Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "onClick" | "value" | "children"
+>) => {
   const highlight =
     value === "own" ? "own" : value === "system" ? "system" : "default";
 
@@ -111,6 +115,7 @@ const SmallTabNavigationButton = ({
     <HoverNavigatable triggerNavigate={onClick}>
       <button
         ref={ref}
+        {...props}
         className={button({
           size,
           primary: variant === "primary",

--- a/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
+++ b/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
@@ -2,7 +2,11 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { PreviousQueryT } from "../previous-queries/list/reducer";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 
 import QueryEditorDropzone from "./QueryEditorDropzone";
 import type { DragItemConceptTreeNode, DragItemQuery } from "./types";
@@ -24,15 +28,18 @@ const QueryAndDropzone = ({
 
   return (
     <div className="pt-[70px]">
-      <WithTooltip className="block!" text={t("help.editorDropzoneAnd")} lazy>
-        <QueryEditorDropzone
-          isAnd
-          onDropNode={onDropAndNode}
-          onDropFile={onDropFile}
-          onImportLines={onImportLines}
-          onLoadPreviousQuery={onLoadQuery}
-        />
-      </WithTooltip>
+      <TooltipTrigger delay={1500}>
+        <TooltipTarget as="div" excludeFromTabOrder>
+          <QueryEditorDropzone
+            isAnd
+            onDropNode={onDropAndNode}
+            onDropFile={onDropFile}
+            onImportLines={onImportLines}
+            onLoadPreviousQuery={onLoadQuery}
+          />
+        </TooltipTarget>
+        <Tooltip>{t("help.editorDropzoneAnd")}</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 };

--- a/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
+++ b/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
@@ -6,6 +6,7 @@ import {
   Tooltip,
   TooltipTarget,
   TooltipTrigger,
+  tooltipDelay,
 } from "../ui-components/Tooltip";
 
 import QueryEditorDropzone from "./QueryEditorDropzone";
@@ -28,7 +29,7 @@ const QueryAndDropzone = ({
 
   return (
     <div className="pt-[70px]">
-      <TooltipTrigger>
+      <TooltipTrigger delay={tooltipDelay.info}>
         <TooltipTarget as="div" excludeFromTabOrder>
           <QueryEditorDropzone
             isAnd

--- a/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
+++ b/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
@@ -29,7 +29,7 @@ const QueryAndDropzone = ({
 
   return (
     <div className="pt-[70px]">
-      <TooltipTrigger delay={tooltipDelay.info}>
+      <TooltipTrigger delay={tooltipDelay.long}>
         <TooltipTarget as="div" excludeFromTabOrder>
           <QueryEditorDropzone
             isAnd

--- a/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
+++ b/frontend/src/js/standard-query-editor/QueryAndDropzone.tsx
@@ -28,7 +28,7 @@ const QueryAndDropzone = ({
 
   return (
     <div className="pt-[70px]">
-      <TooltipTrigger delay={1500}>
+      <TooltipTrigger>
         <TooltipTarget as="div" excludeFromTabOrder>
           <QueryEditorDropzone
             isAnd

--- a/frontend/src/js/standard-query-editor/QueryClearButton.tsx
+++ b/frontend/src/js/standard-query-editor/QueryClearButton.tsx
@@ -15,15 +15,15 @@ const QueryClearButton = ({ className }: { className?: string }) => {
 
   return (
     <div className={className}>
-      <ConfirmableTooltip
-        confirmationText={t(`queryEditor.clearConfirm`)}
-        onConfirm={onClearQuery}
-      >
-        <TooltipTrigger>
+      <TooltipTrigger>
+        <ConfirmableTooltip
+          confirmationText={t(`queryEditor.clearConfirm`)}
+          onConfirm={onClearQuery}
+        >
           <IconButton tiny icon={faTrash} tabIndex={-1} />
-          <Tooltip>{t("queryEditor.clear")}</Tooltip>
-        </TooltipTrigger>
-      </ConfirmableTooltip>
+        </ConfirmableTooltip>
+        <Tooltip>{t("queryEditor.clear")}</Tooltip>
+      </TooltipTrigger>
     </div>
   );
 };

--- a/frontend/src/js/standard-query-editor/QueryClearButton.tsx
+++ b/frontend/src/js/standard-query-editor/QueryClearButton.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 
 import IconButton from "../button/IconButton";
 import { ConfirmableTooltip } from "../ui-components/ConfirmableTooltip";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 import { clearQuery } from "./actions";
 
@@ -19,9 +19,10 @@ const QueryClearButton = ({ className }: { className?: string }) => {
         confirmationText={t(`queryEditor.clearConfirm`)}
         onConfirm={onClearQuery}
       >
-        <WithTooltip text={t("queryEditor.clear")}>
+        <TooltipTrigger>
           <IconButton tiny icon={faTrash} tabIndex={-1} />
-        </WithTooltip>
+          <Tooltip>{t("queryEditor.clear")}</Tooltip>
+        </TooltipTrigger>
       </ConfirmableTooltip>
     </div>
   );

--- a/frontend/src/js/standard-query-editor/QueryGroup.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroup.tsx
@@ -107,7 +107,7 @@ const QueryGroup = ({
   return (
     <div className="max-w-[250px] text-sm">
       {/* block! overrides tippy's inline-block wrapper */}
-      <TooltipTrigger delay={1500}>
+      <TooltipTrigger>
         <TooltipTarget as="div" excludeFromTabOrder>
           <QueryEditorDropzone
             key={group.elements.length + 1}

--- a/frontend/src/js/standard-query-editor/QueryGroup.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroup.tsx
@@ -107,8 +107,7 @@ const QueryGroup = ({
 
   return (
     <div className="max-w-[250px] text-sm">
-      {/* block! overrides tippy's inline-block wrapper */}
-      <TooltipTrigger delay={tooltipDelay.info}>
+      <TooltipTrigger delay={tooltipDelay.long}>
         <TooltipTarget as="div" excludeFromTabOrder>
           <QueryEditorDropzone
             key={group.elements.length + 1}

--- a/frontend/src/js/standard-query-editor/QueryGroup.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroup.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   TooltipTarget,
   TooltipTrigger,
+  tooltipDelay,
 } from "../ui-components/Tooltip";
 
 import QueryEditorDropzone from "./QueryEditorDropzone";
@@ -107,7 +108,7 @@ const QueryGroup = ({
   return (
     <div className="max-w-[250px] text-sm">
       {/* block! overrides tippy's inline-block wrapper */}
-      <TooltipTrigger>
+      <TooltipTrigger delay={tooltipDelay.info}>
         <TooltipTarget as="div" excludeFromTabOrder>
           <QueryEditorDropzone
             key={group.elements.length + 1}

--- a/frontend/src/js/standard-query-editor/QueryGroup.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroup.tsx
@@ -4,7 +4,11 @@ import { tv } from "tailwind-variants";
 
 import type { DateRangeT, QueryT } from "../api/types";
 import type { PreviousQueryT } from "../previous-queries/list/reducer";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 
 import QueryEditorDropzone from "./QueryEditorDropzone";
 import QueryGroupActions from "./QueryGroupActions";
@@ -103,15 +107,18 @@ const QueryGroup = ({
   return (
     <div className="max-w-[250px] text-sm">
       {/* block! overrides tippy's inline-block wrapper */}
-      <WithTooltip className="block!" text={t("help.editorDropzoneOr")} lazy>
-        <QueryEditorDropzone
-          key={group.elements.length + 1}
-          onDropNode={onDropNode}
-          onDropFile={dropFile}
-          onLoadPreviousQuery={onLoadPreviousQuery}
-          onImportLines={importLines}
-        />
-      </WithTooltip>
+      <TooltipTrigger delay={1500}>
+        <TooltipTarget as="div" excludeFromTabOrder>
+          <QueryEditorDropzone
+            key={group.elements.length + 1}
+            onDropNode={onDropNode}
+            onDropFile={dropFile}
+            onLoadPreviousQuery={onLoadPreviousQuery}
+            onImportLines={importLines}
+          />
+        </TooltipTarget>
+        <Tooltip>{t("help.editorDropzoneOr")}</Tooltip>
+      </TooltipTrigger>
       <p className={queryOrConnector()}>{t("common.or")}</p>
       <div
         className={groupBox({ excluded: !!group.exclude })}

--- a/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
@@ -53,7 +53,7 @@ const QueryGroupActions = ({
   return (
     <div className={actions()}>
       <div>
-        <TooltipTrigger delay={1500}>
+        <TooltipTrigger>
           <IconButton
             className={excludeButton({ active: excludeActive })}
             red
@@ -66,7 +66,7 @@ const QueryGroupActions = ({
           </IconButton>
           <Tooltip>{t("help.queryEditorExclude")}</Tooltip>
         </TooltipTrigger>
-        <TooltipTrigger delay={1500}>
+        <TooltipTrigger>
           <IconButton
             className={dateButton({ active: dateActive })}
             active={dateActive}

--- a/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
-import WithTooltip from "../ui-components/WithTooltip";
+import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
 
 // h-[18px]: to provide enough space when only the right side is rendered
 const actions = tv({
@@ -53,7 +53,7 @@ const QueryGroupActions = ({
   return (
     <div className={actions()}>
       <div>
-        <WithTooltip text={t("help.queryEditorExclude")} lazy>
+        <TooltipTrigger delay={1500}>
           <IconButton
             className={excludeButton({ active: excludeActive })}
             red
@@ -64,8 +64,9 @@ const QueryGroupActions = ({
           >
             {t("queryEditor.exclude")}
           </IconButton>
-        </WithTooltip>
-        <WithTooltip text={t("help.queryEditorDate")} lazy>
+          <Tooltip>{t("help.queryEditorExclude")}</Tooltip>
+        </TooltipTrigger>
+        <TooltipTrigger delay={1500}>
           <IconButton
             className={dateButton({ active: dateActive })}
             active={dateActive}
@@ -75,12 +76,14 @@ const QueryGroupActions = ({
           >
             {t("queryEditor.date")}
           </IconButton>
-        </WithTooltip>
+          <Tooltip>{t("help.queryEditorDate")}</Tooltip>
+        </TooltipTrigger>
       </div>
       <div className="absolute top-[5px] right-[7px]">
-        <WithTooltip text={t("queryEditor.removeColumn")}>
+        <TooltipTrigger>
           <IconButton tiny icon={faTimes} onClick={onDeleteGroup} />
-        </WithTooltip>
+          <Tooltip>{t("queryEditor.removeColumn")}</Tooltip>
+        </TooltipTrigger>
       </div>
     </div>
   );

--- a/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
@@ -5,7 +5,11 @@ import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
-import { Tooltip, TooltipTrigger } from "../ui-components/Tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  tooltipDelay,
+} from "../ui-components/Tooltip";
 
 // h-[18px]: to provide enough space when only the right side is rendered
 const actions = tv({
@@ -53,7 +57,7 @@ const QueryGroupActions = ({
   return (
     <div className={actions()}>
       <div>
-        <TooltipTrigger>
+        <TooltipTrigger delay={tooltipDelay.info}>
           <IconButton
             className={excludeButton({ active: excludeActive })}
             red
@@ -66,7 +70,7 @@ const QueryGroupActions = ({
           </IconButton>
           <Tooltip>{t("help.queryEditorExclude")}</Tooltip>
         </TooltipTrigger>
-        <TooltipTrigger>
+        <TooltipTrigger delay={tooltipDelay.info}>
           <IconButton
             className={dateButton({ active: dateActive })}
             active={dateActive}

--- a/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
+++ b/frontend/src/js/standard-query-editor/QueryGroupActions.tsx
@@ -57,7 +57,7 @@ const QueryGroupActions = ({
   return (
     <div className={actions()}>
       <div>
-        <TooltipTrigger delay={tooltipDelay.info}>
+        <TooltipTrigger delay={tooltipDelay.long}>
           <IconButton
             className={excludeButton({ active: excludeActive })}
             red
@@ -70,7 +70,7 @@ const QueryGroupActions = ({
           </IconButton>
           <Tooltip>{t("help.queryEditorExclude")}</Tooltip>
         </TooltipTrigger>
-        <TooltipTrigger delay={tooltipDelay.info}>
+        <TooltipTrigger delay={tooltipDelay.long}>
           <IconButton
             className={dateButton({ active: dateActive })}
             active={dateActive}

--- a/frontend/src/js/standard-query-editor/QueryNodeActions.tsx
+++ b/frontend/src/js/standard-query-editor/QueryNodeActions.tsx
@@ -11,7 +11,11 @@ import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
 import FaIcon from "../icon/FaIcon";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 
 const actionButton = tv({
   base: "px-[6px] py-1",
@@ -49,7 +53,7 @@ const QueryNodeActions = (props: Props) => {
 
   return (
     <div className="flex flex-col items-center justify-start">
-      <WithTooltip text={t("queryEditor.removeNode")}>
+      <TooltipTrigger>
         <IconButton
           className={actionButton()}
           icon={faTimes}
@@ -58,9 +62,10 @@ const QueryNodeActions = (props: Props) => {
             props.onDeleteNode(props.andIdx, props.orIdx);
           }}
         />
-      </WithTooltip>
+        <Tooltip>{t("queryEditor.removeNode")}</Tooltip>
+      </TooltipTrigger>
       {props.excludeTimestamps && (
-        <WithTooltip text={t("queryNodeEditor.excludingTimestamps")}>
+        <TooltipTrigger>
           <IconButton
             className={actionButton()}
             red
@@ -70,15 +75,23 @@ const QueryNodeActions = (props: Props) => {
               props.onToggleTimestamps(props.andIdx, props.orIdx);
             }}
           />
-        </WithTooltip>
+          <Tooltip>{t("queryNodeEditor.excludingTimestamps")}</Tooltip>
+        </TooltipTrigger>
       )}
       {!props.error && !!props.previousQueryLoading && (
-        <WithTooltip text={t("queryEditor.loadingPreviousQuery")}>
-          <FaIcon className="mt-[7px] mb-1 mx-[6px]" icon={faSpinner} />
-        </WithTooltip>
+        <TooltipTrigger>
+          <TooltipTarget
+            role="img"
+            aria-label={t("queryEditor.loadingPreviousQuery")}
+            excludeFromTabOrder
+          >
+            <FaIcon className="mt-[7px] mb-1 mx-[6px]" icon={faSpinner} />
+          </TooltipTarget>
+          <Tooltip>{t("queryEditor.loadingPreviousQuery")}</Tooltip>
+        </TooltipTrigger>
       )}
       {!props.error && props.isExpandable && !props.previousQueryLoading && (
-        <WithTooltip text={t("queryEditor.expand")}>
+        <TooltipTrigger>
           <IconButton
             className={actionButton()}
             icon={faExpandArrowsAlt}
@@ -87,16 +100,11 @@ const QueryNodeActions = (props: Props) => {
               props.onExpandClick();
             }}
           />
-        </WithTooltip>
+          <Tooltip>{t("queryEditor.expand")}</Tooltip>
+        </TooltipTrigger>
       )}
       {props.hasActiveSecondaryId && (
-        <WithTooltip
-          text={
-            props.excludeFromSecondaryId
-              ? t("queryNodeEditor.excludingFromSecondaryId")
-              : t("queryEditor.hasSecondaryId")
-          }
-        >
+        <TooltipTrigger>
           <div className="relative">
             <IconButton
               className={actionButton()}
@@ -109,7 +117,12 @@ const QueryNodeActions = (props: Props) => {
             />
             {props.excludeFromSecondaryId && <div className={crossedOut()} />}
           </div>
-        </WithTooltip>
+          <Tooltip>
+            {props.excludeFromSecondaryId
+              ? t("queryNodeEditor.excludingFromSecondaryId")
+              : t("queryEditor.hasSecondaryId")}
+          </Tooltip>
+        </TooltipTrigger>
       )}
     </div>
   );

--- a/frontend/src/js/standard-query-editor/QueryNodeContent.tsx
+++ b/frontend/src/js/standard-query-editor/QueryNodeContent.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 
 import ErrorMessage from "../error-message/ErrorMessage";
-import WithTooltip from "../ui-components/WithTooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+} from "../ui-components/Tooltip";
 
 // tv consts named *Text to not shadow the label/description props
 const labelText = tv({
@@ -63,8 +67,8 @@ const QueryNodeContent = ({
   const { t } = useTranslation();
 
   return (
-    <WithTooltip text={tooltipText}>
-      <div className="grow pt-[2px]">
+    <TooltipTrigger>
+      <TooltipTarget as="div" excludeFromTabOrder className="grow pt-[2px]">
         {!isConceptQueryNode && (
           <p className={previousQueryLabel()}>
             {t("queryEditor.previousQuery")}
@@ -79,8 +83,9 @@ const QueryNodeContent = ({
             {description && <p className={descriptionText()}>{description}</p>}
           </>
         )}
-      </div>
-    </WithTooltip>
+      </TooltipTarget>
+      <Tooltip>{tooltipText}</Tooltip>
+    </TooltipTrigger>
   );
 };
 

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -18,7 +18,12 @@ import { isEmpty } from "../common/helpers/commonHelper";
 import { exists } from "../common/helpers/exists";
 import FaIcon from "../icon/FaIcon";
 import CurrencyInput from "./CurrencyInput";
-import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+  tooltipDelay,
+} from "./Tooltip";
 
 const root = tv({ base: "relative" });
 
@@ -189,7 +194,7 @@ const BaseInput = ({
             <FaIcon icon={faCheck} large={large} className={greenIcon()} />
           )}
           {invalid && (
-            <TooltipTrigger delay={0}>
+            <TooltipTrigger delay={tooltipDelay.help}>
               <TooltipTarget
                 as="div"
                 role="img"

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -189,7 +189,7 @@ const BaseInput = ({
             <FaIcon icon={faCheck} large={large} className={greenIcon()} />
           )}
           {invalid && (
-            <TooltipTrigger>
+            <TooltipTrigger delay={0}>
               <TooltipTarget
                 as="div"
                 role="img"

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -194,7 +194,7 @@ const BaseInput = ({
             <FaIcon icon={faCheck} large={large} className={greenIcon()} />
           )}
           {invalid && (
-            <TooltipTrigger delay={tooltipDelay.help}>
+            <TooltipTrigger delay={tooltipDelay.immediate}>
               <TooltipTarget
                 as="div"
                 role="img"

--- a/frontend/src/js/ui-components/BaseInput.tsx
+++ b/frontend/src/js/ui-components/BaseInput.tsx
@@ -18,7 +18,7 @@ import { isEmpty } from "../common/helpers/commonHelper";
 import { exists } from "../common/helpers/exists";
 import FaIcon from "../icon/FaIcon";
 import CurrencyInput from "./CurrencyInput";
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
 
 const root = tv({ base: "relative" });
 
@@ -189,15 +189,22 @@ const BaseInput = ({
             <FaIcon icon={faCheck} large={large} className={greenIcon()} />
           )}
           {invalid && (
-            <WithTooltip text={invalidText}>
-              <div className={absoluteWrap()}>
+            <TooltipTrigger>
+              <TooltipTarget
+                as="div"
+                role="img"
+                aria-label={invalidText}
+                excludeFromTabOrder
+                className={absoluteWrap()}
+              >
                 <FaIcon
                   icon={faExclamationTriangle}
                   large={large}
                   className={redIcon()}
                 />
-              </div>
-            </WithTooltip>
+              </TooltipTarget>
+              <Tooltip>{invalidText}</Tooltip>
+            </TooltipTrigger>
           )}
           <IconButton
             className={clearZoneIconButton()}

--- a/frontend/src/js/ui-components/EditableTagsForm.tsx
+++ b/frontend/src/js/ui-components/EditableTagsForm.tsx
@@ -7,7 +7,7 @@ import type { SelectOptionT } from "../api/types";
 import IconButton from "../button/IconButton";
 import { useClickOutside } from "../common/helpers/useClickOutside";
 import InputMultiSelect from "./InputMultiSelect/InputMultiSelect";
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTrigger } from "./Tooltip";
 
 const form = tv({
   base: "flex items-start",
@@ -70,7 +70,7 @@ const EditableTagsForm = ({
         onChange={setValues}
         placeholder={t("inputMultiSelect.tagPlaceholder")}
       />
-      <WithTooltip text={t("common.save")}>
+      <TooltipTrigger>
         <IconButton
           className={saveButton()}
           type="submit"
@@ -78,7 +78,8 @@ const EditableTagsForm = ({
           disabled={!!loading}
           icon={loading ? faSpinner : faCheck}
         />
-      </WithTooltip>
+        <Tooltip>{t("common.save")}</Tooltip>
+      </TooltipTrigger>
     </form>
   );
 };

--- a/frontend/src/js/ui-components/EditableText.tsx
+++ b/frontend/src/js/ui-components/EditableText.tsx
@@ -5,7 +5,7 @@ import IconButton from "../button/IconButton";
 import { Highlighter } from "../common/components/Highlighter";
 import HighlightableLabel from "../highlightable-label/HighlightableLabel";
 import EditableTextForm from "./EditableTextForm";
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTrigger } from "./Tooltip";
 
 const editButton = tv({
   base: ["px-0 py-[2px]"],
@@ -64,7 +64,7 @@ const EditableText = ({
     />
   ) : (
     <div className={text({ className })}>
-      <WithTooltip text={tooltip}>
+      <TooltipTrigger>
         <IconButton
           className={editButton({ large: !!large })}
           bare
@@ -73,7 +73,8 @@ const EditableText = ({
           small
           large={large}
         />
-      </WithTooltip>
+        <Tooltip>{tooltip}</Tooltip>
+      </TooltipTrigger>
       <HighlightableLabel className={label()} isHighlighted={isHighlighted}>
         {highlightedWords && highlightedWords.length > 0 ? (
           <Highlighter

--- a/frontend/src/js/ui-components/EditableTextForm.tsx
+++ b/frontend/src/js/ui-components/EditableTextForm.tsx
@@ -5,7 +5,7 @@ import { tv } from "tailwind-variants";
 
 import IconButton from "../button/IconButton";
 import { useClickOutside } from "../common/helpers/useClickOutside";
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTrigger } from "./Tooltip";
 
 const input = tv({
   base: ["h-[28px]", "px-2", "rounded", "border border-gray-500", "text-sm"],
@@ -67,7 +67,7 @@ const EditableTextForm = ({
         }}
       />
       {!saveOnClickoutside && (
-        <WithTooltip text={t("common.save")}>
+        <TooltipTrigger>
           <IconButton
             className={saveButton()}
             type="submit"
@@ -75,7 +75,8 @@ const EditableTextForm = ({
             disabled={loading}
             icon={loading ? faSpinner : faCheck}
           />
-        </WithTooltip>
+          <Tooltip>{t("common.save")}</Tooltip>
+        </TooltipTrigger>
       )}
     </form>
   );

--- a/frontend/src/js/ui-components/InfoTooltip.tsx
+++ b/frontend/src/js/ui-components/InfoTooltip.tsx
@@ -4,7 +4,12 @@ import { tv } from "tailwind-variants";
 
 import FaIcon from "../icon/FaIcon";
 
-import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+  tooltipDelay,
+} from "./Tooltip";
 
 const icon = tv({
   base: ["transition-all duration-100", "hover:text-gray-800"],
@@ -24,7 +29,7 @@ const InfoTooltip = ({
   wide?: boolean;
 }) => {
   return (
-    <TooltipTrigger delay={0}>
+    <TooltipTrigger delay={tooltipDelay.help}>
       <TooltipTarget
         role="img"
         aria-label="Info"

--- a/frontend/src/js/ui-components/InfoTooltip.tsx
+++ b/frontend/src/js/ui-components/InfoTooltip.tsx
@@ -29,7 +29,7 @@ const InfoTooltip = ({
   wide?: boolean;
 }) => {
   return (
-    <TooltipTrigger delay={tooltipDelay.help}>
+    <TooltipTrigger delay={tooltipDelay.immediate}>
       <TooltipTarget
         role="img"
         aria-label="Info"

--- a/frontend/src/js/ui-components/InfoTooltip.tsx
+++ b/frontend/src/js/ui-components/InfoTooltip.tsx
@@ -24,7 +24,7 @@ const InfoTooltip = ({
   wide?: boolean;
 }) => {
   return (
-    <TooltipTrigger>
+    <TooltipTrigger delay={0}>
       <TooltipTarget
         role="img"
         aria-label="Info"

--- a/frontend/src/js/ui-components/InfoTooltip.tsx
+++ b/frontend/src/js/ui-components/InfoTooltip.tsx
@@ -4,7 +4,7 @@ import { tv } from "tailwind-variants";
 
 import FaIcon from "../icon/FaIcon";
 
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
 
 const icon = tv({
   base: ["transition-all duration-100", "hover:text-gray-800"],
@@ -24,11 +24,25 @@ const InfoTooltip = ({
   wide?: boolean;
 }) => {
   return (
-    <WithTooltip text={text} html={html} wide={wide}>
-      <span className={spanContainer({ className })}>
+    <TooltipTrigger>
+      <TooltipTarget
+        role="img"
+        aria-label="Info"
+        className={spanContainer({ className })}
+      >
         <FaIcon className={icon()} gray icon={faQuestionCircle} />
-      </span>
-    </WithTooltip>
+      </TooltipTarget>
+      <Tooltip wide={wide}>
+        {text ? (
+          <span
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: help texts come from form configs and the backend, which may use markup
+            dangerouslySetInnerHTML={{ __html: text }}
+          />
+        ) : (
+          html
+        )}
+      </Tooltip>
+    </TooltipTrigger>
   );
 };
 

--- a/frontend/src/js/ui-components/InputCheckbox.tsx
+++ b/frontend/src/js/ui-components/InputCheckbox.tsx
@@ -45,7 +45,6 @@ const InputCheckbox = ({
   label: labelText,
   className,
   tooltip,
-  tooltipLazy,
   infoTooltip,
   value,
   onChange,
@@ -54,7 +53,6 @@ const InputCheckbox = ({
   label: string;
   className?: string;
   tooltip?: string;
-  tooltipLazy?: boolean;
   infoTooltip?: string;
   value?: boolean;
   onChange: (checked: boolean) => void;
@@ -68,7 +66,7 @@ const InputCheckbox = ({
       if (!disabled) onChange(!value);
     }}
   >
-    <TooltipTrigger delay={tooltipLazy ? 1500 : undefined}>
+    <TooltipTrigger>
       <TooltipTarget
         as="div"
         excludeFromTabOrder

--- a/frontend/src/js/ui-components/InputCheckbox.tsx
+++ b/frontend/src/js/ui-components/InputCheckbox.tsx
@@ -3,7 +3,7 @@ import { tv } from "tailwind-variants";
 import { exists } from "../common/helpers/exists";
 import FaIcon from "../icon/FaIcon";
 import InfoTooltip from "./InfoTooltip";
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
 
 const row = tv({
   base: ["flex flex-row items-center", "cursor-pointer"],
@@ -68,15 +68,20 @@ const InputCheckbox = ({
       if (!disabled) onChange(!value);
     }}
   >
-    <WithTooltip text={tooltip} lazy={tooltipLazy}>
-      <div className={container({ disabled })}>
+    <TooltipTrigger delay={tooltipLazy ? 1500 : undefined}>
+      <TooltipTarget
+        as="div"
+        excludeFromTabOrder
+        className={container({ disabled })}
+      >
         {!!value && (
           <div className={checkmark()}>
             <FaIcon icon={faCheck} className={checkmarkIcon()} />
           </div>
         )}
-      </div>
-    </WithTooltip>
+      </TooltipTarget>
+      <Tooltip>{tooltip}</Tooltip>
+    </TooltipTrigger>
     <span className={label()}>{labelText}</span>
     {exists(infoTooltip) && <InfoTooltip text={infoTooltip} />}
   </div>

--- a/frontend/src/js/ui-components/InputCheckbox.tsx
+++ b/frontend/src/js/ui-components/InputCheckbox.tsx
@@ -3,7 +3,12 @@ import { tv } from "tailwind-variants";
 import { exists } from "../common/helpers/exists";
 import FaIcon from "../icon/FaIcon";
 import InfoTooltip from "./InfoTooltip";
-import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+  tooltipDelay,
+} from "./Tooltip";
 
 const row = tv({
   base: ["flex flex-row items-center", "cursor-pointer"],
@@ -66,7 +71,7 @@ const InputCheckbox = ({
       if (!disabled) onChange(!value);
     }}
   >
-    <TooltipTrigger>
+    <TooltipTrigger delay={tooltipDelay.info}>
       <TooltipTarget
         as="div"
         excludeFromTabOrder

--- a/frontend/src/js/ui-components/InputCheckbox.tsx
+++ b/frontend/src/js/ui-components/InputCheckbox.tsx
@@ -71,7 +71,7 @@ const InputCheckbox = ({
       if (!disabled) onChange(!value);
     }}
   >
-    <TooltipTrigger delay={tooltipDelay.info}>
+    <TooltipTrigger delay={tooltipDelay.long}>
       <TooltipTarget
         as="div"
         excludeFromTabOrder

--- a/frontend/src/js/ui-components/ToggleButton.tsx
+++ b/frontend/src/js/ui-components/ToggleButton.tsx
@@ -1,6 +1,7 @@
+import { Focusable } from "react-aria-components";
 import { tv } from "tailwind-variants";
 
-import WithTooltip from "./WithTooltip";
+import { Tooltip, TooltipTrigger } from "./Tooltip";
 
 const root = tv({ base: ["m-0", "flex flex-wrap items-center"] });
 
@@ -44,21 +45,24 @@ const ToggleButton = ({
   return (
     <div className={root({ className })}>
       {options.map(({ value, label, description }, i) => (
-        <WithTooltip key={value} text={description}>
-          <button
-            type="button"
-            className={option({
-              isFirst: i === 0,
-              isLast: i === options.length - 1,
-              active: inputValue === value,
-            })}
-            onClick={() => {
-              if (value !== inputValue) onChange(value);
-            }}
-          >
-            {label}
-          </button>
-        </WithTooltip>
+        <TooltipTrigger key={value}>
+          <Focusable>
+            <button
+              type="button"
+              className={option({
+                isFirst: i === 0,
+                isLast: i === options.length - 1,
+                active: inputValue === value,
+              })}
+              onClick={() => {
+                if (value !== inputValue) onChange(value);
+              }}
+            >
+              {label}
+            </button>
+          </Focusable>
+          <Tooltip>{description}</Tooltip>
+        </TooltipTrigger>
       ))}
     </div>
   );

--- a/frontend/src/js/ui-components/Tooltip.stories.tsx
+++ b/frontend/src/js/ui-components/Tooltip.stories.tsx
@@ -66,11 +66,11 @@ export const Timing: Story = {
           Names a control: short warm-up, neighbours open instantly
         </Tooltip>
       </TooltipTrigger>
-      <TooltipTrigger delay={tooltipDelay.info}>
+      <TooltipTrigger delay={tooltipDelay.long}>
         <TransparentButton>Further info</TransparentButton>
         <Tooltip>Explains a larger surface: long warm-up</Tooltip>
       </TooltipTrigger>
-      <TooltipTrigger delay={tooltipDelay.help}>
+      <TooltipTrigger delay={tooltipDelay.immediate}>
         <TooltipTarget role="img" aria-label="Info">
           <FaIcon gray icon={faInfoCircle} />
         </TooltipTarget>
@@ -102,7 +102,7 @@ export const RichContent: Story = {
 export const OnStaticContent: Story = {
   render: () => (
     <div className="flex items-center gap-4 text-sm">
-      <TooltipTrigger delay={tooltipDelay.help}>
+      <TooltipTrigger delay={tooltipDelay.immediate}>
         <TooltipTarget role="img" aria-label="Info">
           <FaIcon gray icon={faInfoCircle} />
         </TooltipTarget>

--- a/frontend/src/js/ui-components/Tooltip.stories.tsx
+++ b/frontend/src/js/ui-components/Tooltip.stories.tsx
@@ -52,12 +52,24 @@ export const Placements: Story = {
   ),
 };
 
-export const Delayed: Story = {
+export const Timing: Story = {
   render: () => (
-    <TooltipTrigger delay={1500}>
-      <TransparentButton>Hover and wait</TransparentButton>
-      <Tooltip>Appears after 1.5 seconds</Tooltip>
-    </TooltipTrigger>
+    <div className="flex items-center gap-4 text-sm">
+      <TooltipTrigger>
+        <TransparentButton>Warm-up</TransparentButton>
+        <Tooltip>Waits for the warm-up, then neighbours open instantly</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <IconButton frame icon={faTrash} />
+        <Tooltip>Icon-only buttons wait too</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger delay={0}>
+        <TooltipTarget role="img" aria-label="Info">
+          <FaIcon gray icon={faInfoCircle} />
+        </TooltipTarget>
+        <Tooltip>Help icons open immediately</Tooltip>
+      </TooltipTrigger>
+    </div>
   ),
 };
 
@@ -83,7 +95,7 @@ export const RichContent: Story = {
 export const OnStaticContent: Story = {
   render: () => (
     <div className="flex items-center gap-4 text-sm">
-      <TooltipTrigger>
+      <TooltipTrigger delay={0}>
         <TooltipTarget role="img" aria-label="Info">
           <FaIcon gray icon={faInfoCircle} />
         </TooltipTarget>

--- a/frontend/src/js/ui-components/Tooltip.stories.tsx
+++ b/frontend/src/js/ui-components/Tooltip.stories.tsx
@@ -63,7 +63,7 @@ export const Timing: Story = {
       <TooltipTrigger>
         <IconButton frame icon={faTrash} />
         <Tooltip>
-          Names a control: short warm-up, neighbours open instantly
+          Names a control: short warm-up, neighbors open instantly
         </Tooltip>
       </TooltipTrigger>
       <TooltipTrigger delay={tooltipDelay.long}>

--- a/frontend/src/js/ui-components/Tooltip.stories.tsx
+++ b/frontend/src/js/ui-components/Tooltip.stories.tsx
@@ -1,0 +1,103 @@
+import { faInfoCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import IconButton from "../button/IconButton";
+import PrimaryButton from "../button/PrimaryButton";
+import { TransparentButton } from "../button/TransparentButton";
+import FaIcon from "../icon/FaIcon";
+
+import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
+
+export default {
+  title: "UiComponents/Tooltip",
+  component: Tooltip,
+  parameters: { layout: "centered" },
+} as Meta<typeof Tooltip>;
+
+type Story = StoryObj<typeof Tooltip>;
+
+export const OnButtons: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <TooltipTrigger>
+        <IconButton frame icon={faTrash} />
+        <Tooltip>Delete</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <TransparentButton>Cancel</TransparentButton>
+        <Tooltip>Discards your changes</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <PrimaryButton>Save</PrimaryButton>
+        <Tooltip>Saves and closes the editor</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <PrimaryButton disabled>Disabled</PrimaryButton>
+        <Tooltip>Disabled buttons show no tooltip</Tooltip>
+      </TooltipTrigger>
+    </div>
+  ),
+};
+
+export const Placements: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      {(["top", "bottom", "left", "right"] as const).map((placement) => (
+        <TooltipTrigger key={placement}>
+          <TransparentButton small>{placement}</TransparentButton>
+          <Tooltip placement={placement}>Placed at {placement}</Tooltip>
+        </TooltipTrigger>
+      ))}
+    </div>
+  ),
+};
+
+export const Delayed: Story = {
+  render: () => (
+    <TooltipTrigger delay={1500}>
+      <TransparentButton>Hover and wait</TransparentButton>
+      <Tooltip>Appears after 1.5 seconds</Tooltip>
+    </TooltipTrigger>
+  ),
+};
+
+export const RichContent: Story = {
+  render: () => (
+    <TooltipTrigger>
+      <TransparentButton>Rich content</TransparentButton>
+      <Tooltip wide>
+        <h3>Headline</h3>
+        <p>
+          A wide tooltip can hold formatted content: paragraphs, headlines and
+          lists.
+        </p>
+        <ul>
+          <li>First point</li>
+          <li>Second point</li>
+        </ul>
+      </Tooltip>
+    </TooltipTrigger>
+  ),
+};
+
+export const OnStaticContent: Story = {
+  render: () => (
+    <div className="flex items-center gap-4 text-sm">
+      <TooltipTrigger>
+        <TooltipTarget role="img" aria-label="Info">
+          <FaIcon gray icon={faInfoCircle} />
+        </TooltipTarget>
+        <Tooltip>An icon that is reachable with the keyboard</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger>
+        <TooltipTarget
+          excludeFromTabOrder
+          className="underline decoration-dotted"
+        >
+          Static text
+        </TooltipTarget>
+        <Tooltip>Hover only, stays out of the tab order</Tooltip>
+      </TooltipTrigger>
+    </div>
+  ),
+};

--- a/frontend/src/js/ui-components/Tooltip.stories.tsx
+++ b/frontend/src/js/ui-components/Tooltip.stories.tsx
@@ -6,7 +6,12 @@ import PrimaryButton from "../button/PrimaryButton";
 import { TransparentButton } from "../button/TransparentButton";
 import FaIcon from "../icon/FaIcon";
 
-import { Tooltip, TooltipTarget, TooltipTrigger } from "./Tooltip";
+import {
+  Tooltip,
+  TooltipTarget,
+  TooltipTrigger,
+  tooltipDelay,
+} from "./Tooltip";
 
 export default {
   title: "UiComponents/Tooltip",
@@ -56,14 +61,16 @@ export const Timing: Story = {
   render: () => (
     <div className="flex items-center gap-4 text-sm">
       <TooltipTrigger>
-        <TransparentButton>Warm-up</TransparentButton>
-        <Tooltip>Waits for the warm-up, then neighbours open instantly</Tooltip>
-      </TooltipTrigger>
-      <TooltipTrigger>
         <IconButton frame icon={faTrash} />
-        <Tooltip>Icon-only buttons wait too</Tooltip>
+        <Tooltip>
+          Names a control: short warm-up, neighbours open instantly
+        </Tooltip>
       </TooltipTrigger>
-      <TooltipTrigger delay={0}>
+      <TooltipTrigger delay={tooltipDelay.info}>
+        <TransparentButton>Further info</TransparentButton>
+        <Tooltip>Explains a larger surface: long warm-up</Tooltip>
+      </TooltipTrigger>
+      <TooltipTrigger delay={tooltipDelay.help}>
         <TooltipTarget role="img" aria-label="Info">
           <FaIcon gray icon={faInfoCircle} />
         </TooltipTarget>
@@ -95,7 +102,7 @@ export const RichContent: Story = {
 export const OnStaticContent: Story = {
   render: () => (
     <div className="flex items-center gap-4 text-sm">
-      <TooltipTrigger delay={0}>
+      <TooltipTrigger delay={tooltipDelay.help}>
         <TooltipTarget role="img" aria-label="Info">
           <FaIcon gray icon={faInfoCircle} />
         </TooltipTarget>

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -67,18 +67,24 @@ const arrow = tv({
  * Other elements need a TooltipTarget (or react-aria's Focusable for native buttons).
  *
  * Timing follows Spectrum's tooltip guideline: tooltips wait for a global
- * warm-up, after which neighbouring tooltips open immediately. Pick the
- * delay from `tooltipDelay`.
+ * warm-up, after which neighboring tooltips open immediately. Pick the
+ * delay from `tooltipDelay`. A tooltip closes 300 ms after the pointer has
+ * left, enough to move onto the tooltip itself.
+ *
+ * The tooltip is anchored to the trigger and follows it while open; a trigger
+ * that leaves the layout (`hidden`) sends it to the page's corner, so hide a
+ * hover-revealed trigger with `invisible`.
  *
  * A tooltip stays open while the pointer is over it (react-aria keeps it
  * hoverable, WCAG 1.4.13). In a vertical stack of triggers a tooltip on top
- * would cover the neighbour above, so place those to the side.
+ * would cover the neighbor above, so place those to the side.
  */
 export const TooltipTrigger = ({
   delay = tooltipDelay.short,
+  closeDelay = 300,
   ...props
 }: TooltipTriggerComponentProps) => (
-  <RacTooltipTrigger delay={delay} {...props} />
+  <RacTooltipTrigger delay={delay} closeDelay={closeDelay} {...props} />
 );
 
 export const Tooltip = ({

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -55,12 +55,14 @@ const arrow = tv({
  *
  * Buttons based on BasicButton attach themselves to the trigger.
  * Other elements need a TooltipTarget (or react-aria's Focusable for native buttons).
+ *
+ * Timing follows Spectrum's tooltip guideline: tooltips wait for a global
+ * warm-up (react-aria's default), after which neighbouring tooltips open
+ * immediately. Only help icons, where the tooltip is the sole affordance,
+ * open right away with `delay={0}`.
  */
-export const TooltipTrigger = ({
-  delay = 500,
-  ...props
-}: TooltipTriggerComponentProps) => (
-  <RacTooltipTrigger delay={delay} {...props} />
+export const TooltipTrigger = (props: TooltipTriggerComponentProps) => (
+  <RacTooltipTrigger {...props} />
 );
 
 export const Tooltip = ({

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -57,12 +57,15 @@ const arrow = tv({
  * Other elements need a TooltipTarget (or react-aria's Focusable for native buttons).
  *
  * Timing follows Spectrum's tooltip guideline: tooltips wait for a global
- * warm-up (react-aria's default), after which neighbouring tooltips open
- * immediately. Only help icons, where the tooltip is the sole affordance,
- * open right away with `delay={0}`.
+ * warm-up, after which neighbouring tooltips open immediately. The warm-up
+ * is short because most triggers are icon-only buttons. Help icons, where
+ * the tooltip is the sole affordance, open right away with `delay={0}`.
  */
-export const TooltipTrigger = (props: TooltipTriggerComponentProps) => (
-  <RacTooltipTrigger {...props} />
+export const TooltipTrigger = ({
+  delay = 300,
+  ...props
+}: TooltipTriggerComponentProps) => (
+  <RacTooltipTrigger delay={delay} {...props} />
 );
 
 export const Tooltip = ({

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -69,6 +69,10 @@ const arrow = tv({
  * Timing follows Spectrum's tooltip guideline: tooltips wait for a global
  * warm-up, after which neighbouring tooltips open immediately. Pick the
  * delay from `tooltipDelay`.
+ *
+ * A tooltip stays open while the pointer is over it (react-aria keeps it
+ * hoverable, WCAG 1.4.13). In a vertical stack of triggers a tooltip on top
+ * would cover the neighbour above, so place those to the side.
  */
 export const TooltipTrigger = ({
   delay = tooltipDelay.short,

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -81,7 +81,7 @@ export const Tooltip = ({
   children,
   className,
   wide,
-  offset = 8,
+  offset = 10,
   ...props
 }: Omit<RacTooltipProps, "className" | "children"> & {
   children?: ReactNode;
@@ -97,8 +97,9 @@ export const Tooltip = ({
       {...props}
     >
       <OverlayArrow className={arrow()}>
-        <svg width={8} height={8} viewBox="0 0 8 8" aria-hidden="true">
-          <path d="M0 0 L4 4 L8 0" />
+        {/* square canvas so the rotation for left/right keeps it in place; the triangle fills the top half */}
+        <svg width={16} height={16} viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M0 0 L8 8 L16 0" />
         </svg>
       </OverlayArrow>
       {children}

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -1,0 +1,113 @@
+import type { ElementType, HTMLAttributes, ReactNode, Ref } from "react";
+import { mergeProps, useFocusable, useObjectRef } from "react-aria";
+import {
+  OverlayArrow,
+  Tooltip as RacTooltip,
+  type TooltipProps as RacTooltipProps,
+  TooltipTrigger as RacTooltipTrigger,
+  type TooltipTriggerComponentProps,
+} from "react-aria-components";
+import { tv } from "tailwind-variants";
+
+const tooltip = tv({
+  base: [
+    "z-[9999]",
+    "max-w-[400px]",
+    "rounded",
+    "bg-white",
+    "shadow-[0_0_8px_rgba(0,0,0,0.18)]",
+    "px-[14px] py-2",
+    "text-left",
+    "text-base",
+    "font-normal",
+    "text-gray-800",
+    "data-entering:animate-fade-in",
+    "data-exiting:animate-fade-out",
+    // rich content
+    "[&_p]:text-sm [&_h3]:text-sm [&_li]:text-sm",
+    "[&_p]:leading-[1.3] [&_h3]:leading-[1.3] [&_h4]:leading-[1.3]",
+    "[&_p]:mt-2 [&_h3]:mt-2 [&_h4]:mt-2",
+    "[&_ul]:my-[6px] [&_ul]:pl-4",
+    "[&_li]:leading-[1.3] [&_li]:mb-[5px]",
+  ],
+  variants: {
+    wide: { true: "max-w-[700px]" },
+  },
+});
+
+const arrow = tv({
+  base: [
+    "*:block",
+    "*:fill-white",
+    "data-[placement=bottom]:*:rotate-180",
+    "data-[placement=left]:*:-rotate-90",
+    "data-[placement=right]:*:rotate-90",
+  ],
+});
+
+/**
+ * Wraps a trigger element and its Tooltip:
+ *
+ *   <TooltipTrigger>
+ *     <IconButton … />
+ *     <Tooltip>{text}</Tooltip>
+ *   </TooltipTrigger>
+ *
+ * Buttons based on BasicButton attach themselves to the trigger.
+ * Other elements need a TooltipTarget (or react-aria's Focusable for native buttons).
+ */
+export const TooltipTrigger = ({
+  delay = 500,
+  ...props
+}: TooltipTriggerComponentProps) => (
+  <RacTooltipTrigger delay={delay} {...props} />
+);
+
+export const Tooltip = ({
+  children,
+  className,
+  wide,
+  offset = 8,
+  ...props
+}: Omit<RacTooltipProps, "className" | "children"> & {
+  children?: ReactNode;
+  className?: string;
+  wide?: boolean;
+}) => {
+  if (!children) return null;
+
+  return (
+    <RacTooltip
+      offset={offset}
+      className={tooltip({ wide, className })}
+      {...props}
+    >
+      <OverlayArrow className={arrow()}>
+        <svg width={8} height={8} viewBox="0 0 8 8" aria-hidden="true">
+          <path d="M0 0 L4 4 L8 0" />
+        </svg>
+      </OverlayArrow>
+      {children}
+    </RacTooltip>
+  );
+};
+
+/**
+ * Makes a non-button element the element a TooltipTrigger attaches to.
+ * Static content stays out of the tab order with `excludeFromTabOrder`.
+ */
+export const TooltipTarget = ({
+  as: Tag = "span",
+  ref,
+  excludeFromTabOrder,
+  ...props
+}: HTMLAttributes<HTMLElement> & {
+  as?: ElementType;
+  ref?: Ref<HTMLElement>;
+  excludeFromTabOrder?: boolean;
+}) => {
+  const domRef = useObjectRef(ref);
+  const { focusableProps } = useFocusable({ excludeFromTabOrder }, domRef);
+
+  return <Tag ref={domRef} {...mergeProps(focusableProps, props)} />;
+};

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -35,6 +35,16 @@ const tooltip = tv({
   },
 });
 
+/** Warm-up in ms before a tooltip opens, by what the tooltip is for. */
+export const tooltipDelay = {
+  /** the tooltip is the only affordance: help icons, validation icons */
+  help: 0,
+  /** names a control, mostly icon-only buttons */
+  control: 300,
+  /** further information on larger surfaces: tabs, dropzones, settings */
+  info: 1500,
+} as const;
+
 const arrow = tv({
   base: [
     "*:block",
@@ -57,12 +67,11 @@ const arrow = tv({
  * Other elements need a TooltipTarget (or react-aria's Focusable for native buttons).
  *
  * Timing follows Spectrum's tooltip guideline: tooltips wait for a global
- * warm-up, after which neighbouring tooltips open immediately. The warm-up
- * is short because most triggers are icon-only buttons. Help icons, where
- * the tooltip is the sole affordance, open right away with `delay={0}`.
+ * warm-up, after which neighbouring tooltips open immediately. Pick the
+ * delay from `tooltipDelay`.
  */
 export const TooltipTrigger = ({
-  delay = 300,
+  delay = tooltipDelay.control,
   ...props
 }: TooltipTriggerComponentProps) => (
   <RacTooltipTrigger delay={delay} {...props} />

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -35,14 +35,14 @@ const tooltip = tv({
   },
 });
 
-/** Warm-up in ms before a tooltip opens, by what the tooltip is for. */
+/** Warm-up in ms before a tooltip opens. */
 export const tooltipDelay = {
   /** the tooltip is the only affordance: help icons, validation icons */
-  help: 0,
-  /** names a control, mostly icon-only buttons */
-  control: 300,
+  immediate: 0,
+  /** default: names a control, mostly icon-only buttons */
+  short: 300,
   /** further information on larger surfaces: tabs, dropzones, settings */
-  info: 1500,
+  long: 1500,
 } as const;
 
 const arrow = tv({
@@ -71,7 +71,7 @@ const arrow = tv({
  * delay from `tooltipDelay`.
  */
 export const TooltipTrigger = ({
-  delay = tooltipDelay.control,
+  delay = tooltipDelay.short,
   ...props
 }: TooltipTriggerComponentProps) => (
   <RacTooltipTrigger delay={delay} {...props} />


### PR DESCRIPTION
**Design-system prep, step 2: hover tooltips on react-aria-components**

Stacked on #3999. `WithTooltip` (tippy) becomes `ui-components/Tooltip`, in react-aria's composition shape so call sites won't change again as more components move to react-aria:

```tsx
<TooltipTrigger>
  <IconButton … />
  <Tooltip>{t("common.delete")}</Tooltip>
</TooltipTrigger>
```

- `react-aria-components` and `react-aria` added, pinned to the same release: a second copy of `react-aria` would carry its own React contexts and silently break the trigger wiring
- buttons are triggers on their own; `TooltipTarget` marks static content and keeps it out of the tab order
- timing per Spectrum's guideline via `tooltipDelay`: `immediate` for help icons, `short` (300 ms) by default, `long` (1500 ms) for hints on larger surfaces; after the warm-up, neighboring tooltips open instantly; a tooltip closes 300 ms after the pointer leaves (a hover-revealed trigger stays `invisible` rather than `hidden`, so the closing tooltip keeps its anchor)
- look unchanged; storybook loads `index.css` now; `Tooltip` stories
- tippy stays for the three click popovers until the menus step

