### PR TITLE
refactor(frontend): accessible names for the icon-only buttons

### DIFF
--- a/frontend/src/js/concept-trees/ConceptTree.tsx
+++ b/frontend/src/js/concept-trees/ConceptTree.tsx
@@ -61,6 +61,7 @@ const ConceptTree = ({
           intent="tertiary"
           size="sm"
           danger
+          aria-label={t("common.retry")}
           onPress={() => onLoadTree(conceptId)}
         >
           <Icon icon={faRedo} />

--- a/frontend/src/js/external-forms/form-components/DropzoneList.tsx
+++ b/frontend/src/js/external-forms/form-components/DropzoneList.tsx
@@ -1,6 +1,7 @@
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import type { ReactNode, Ref } from "react";
 import type { DropTargetMonitor } from "react-dnd";
+import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import { Button } from "../../ui-components/Button";
 import type {
@@ -71,6 +72,7 @@ const DropzoneList = <DroppableObject extends PossibleDroppableObject>({
   dropBetween,
   ref,
 }: PropsT<DroppableObject> & { ref?: Ref<HTMLDivElement> }) => {
+  const { t } = useTranslation();
   // allow at least one column
   const showDropzone =
     (items && items.length === 0) || !disallowMultipleColumns;
@@ -97,6 +99,7 @@ const DropzoneList = <DroppableObject extends PossibleDroppableObject>({
                   <Button
                     size="sm"
                     intent="tertiary"
+                    aria-label={t("common.delete")}
                     onPress={() => onDelete(i)}
                   >
                     <Icon icon={faTimes} />

--- a/frontend/src/js/external-forms/form-components/DynamicInputGroup.tsx
+++ b/frontend/src/js/external-forms/form-components/DynamicInputGroup.tsx
@@ -1,5 +1,6 @@
 import { faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import { Button } from "../../ui-components/Button";
 import { Icon } from "../../ui-components/Icon";
@@ -33,6 +34,7 @@ const DynamicInputGroup = ({
   onRemoveClick,
   onAddClick,
 }: PropsT) => {
+  const { t } = useTranslation();
   // 0 means "infinite"
   const limitNotReached = limit === 0 || items.length < limit;
 
@@ -55,6 +57,7 @@ const DynamicInputGroup = ({
               <Button
                 intent="tertiary"
                 size="sm"
+                aria-label={t("common.delete")}
                 onPress={() => onRemoveClick(idx)}
               >
                 <Icon icon={faTimes} />
@@ -64,7 +67,12 @@ const DynamicInputGroup = ({
         </div>
       ))}
       {limitNotReached && (
-        <Button intent="tertiary" size="sm" onPress={onAddClick}>
+        <Button
+          intent="tertiary"
+          size="sm"
+          aria-label={t("common.add")}
+          onPress={onAddClick}
+        >
           <Icon icon={faPlus} />
         </Button>
       )}

--- a/frontend/src/js/external-forms/form-query-dropzone/FormQueryResult.tsx
+++ b/frontend/src/js/external-forms/form-query-dropzone/FormQueryResult.tsx
@@ -1,4 +1,5 @@
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import { exists } from "../../common/helpers/exists";
 import type { DragItemQuery } from "../../standard-query-editor/types";
@@ -36,6 +37,7 @@ const FormQueryResult = ({
   error,
   onDelete,
 }: PropsT) => {
+  const { t } = useTranslation();
   return (
     <div className={root({ error: exists(error), className })}>
       {error ? (
@@ -44,7 +46,12 @@ const FormQueryResult = ({
         queryResult.label || queryResult.id
       ) : null}
       {onDelete && (
-        <Button intent="tertiary" size="sm" onPress={onDelete}>
+        <Button
+          intent="tertiary"
+          size="sm"
+          aria-label={t("common.delete")}
+          onPress={onDelete}
+        >
           <Icon icon={faTimes} />
         </Button>
       )}

--- a/frontend/src/js/external-forms/form/fields/DisclosureListField.tsx
+++ b/frontend/src/js/external-forms/form/fields/DisclosureListField.tsx
@@ -6,6 +6,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { type ComponentProps, useEffect, useState } from "react";
 import { useFieldArray } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import { exists } from "../../../common/helpers/exists";
 import { usePrevious } from "../../../common/helpers/usePrevious";
@@ -50,6 +51,7 @@ const DisclosureField = ({
   canRemove?: boolean;
   commonProps: Omit<ComponentProps<typeof Field>, "field">;
 }) => {
+  const { t } = useTranslation();
   if (field.fields.length === 0) return null;
 
   const { formType, locale } = commonProps;
@@ -82,7 +84,12 @@ const DisclosureField = ({
         </div>
         {field.creatable && canRemove && (
           <div className="absolute right-0 top-1/2 -translate-y-1/2">
-            <Button size="sm" intent="tertiary" onPress={() => remove(index)}>
+            <Button
+              size="sm"
+              intent="tertiary"
+              aria-label={t("common.delete")}
+              onPress={() => remove(index)}
+            >
               <Icon icon={faTimes} />
             </Button>
           </div>

--- a/frontend/src/js/header/HelpMenu.tsx
+++ b/frontend/src/js/header/HelpMenu.tsx
@@ -22,7 +22,11 @@ export const HelpMenu = ({ contactEmail, manualUrl }: Props) => {
 
   return (
     <MenuTrigger>
-      <Button intent="secondary" data-test-id="help-menu">
+      <Button
+        intent="secondary"
+        aria-label={t("common.help")}
+        data-test-id="help-menu"
+      >
         <Icon icon={faQuestion} />
       </Button>
       <Menu

--- a/frontend/src/js/preview/Charts.tsx
+++ b/frontend/src/js/preview/Charts.tsx
@@ -77,6 +77,7 @@ export default function Charts({
       <div className={directionSelector()}>
         <Button
           intent="tertiary"
+          aria-label={t("preview.previousPage")}
           onPress={() => updatePage(-1)}
           isDisabled={page === 0}
         >
@@ -88,6 +89,7 @@ export default function Charts({
         </span>
         <Button
           intent="tertiary"
+          aria-label={t("preview.nextPage")}
           onPress={() => updatePage(1)}
           isDisabled={page === maxPage - 1}
         >

--- a/frontend/src/js/previous-queries/list/ProjectItem.tsx
+++ b/frontend/src/js/previous-queries/list/ProjectItem.tsx
@@ -268,6 +268,7 @@ const ProjectItem = ({
               <Button
                 intent="tertiary"
                 size="sm"
+                aria-label={t("previousQuery.editFolders")}
                 onPress={onIndicateEditFolders}
                 isDisabled={!mayEdit}
               >

--- a/frontend/src/js/query-node-editor/ConceptEntry.tsx
+++ b/frontend/src/js/query-node-editor/ConceptEntry.tsx
@@ -61,6 +61,7 @@ const ConceptEntry = ({
         <Button
           intent="tertiary"
           size="sm"
+          aria-label={t("common.delete")}
           onPress={() => onRemoveConcept(conceptId)}
         >
           <Icon icon={faTrashCan} />

--- a/frontend/src/js/ui-components/ConfirmMenu.tsx
+++ b/frontend/src/js/ui-components/ConfirmMenu.tsx
@@ -10,7 +10,7 @@ import { Menu, MenuItem } from "./Menu";
 
 /**
  * Asks for confirmation before calling onConfirm: a menu with a single item.
- * The child is the trigger, a button built on BasicButton.
+ * The child is the trigger: a Button or ToggleButton.
  */
 export const ConfirmMenu = ({
   children,

--- a/frontend/src/js/ui-components/InputDate/CustomHeader.tsx
+++ b/frontend/src/js/ui-components/InputDate/CustomHeader.tsx
@@ -4,6 +4,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { useState } from "react";
 import type { ReactDatePickerCustomHeaderProps } from "react-datepicker";
+import { useTranslation } from "react-i18next";
 import { tv } from "tailwind-variants";
 import type { SelectOptionT } from "../../api/types";
 import { useMonthName, useMonthNames } from "../../common/helpers/dateHelper";
@@ -145,10 +146,12 @@ export const CustomHeader = ({
   prevMonthButtonDisabled,
   nextMonthButtonDisabled,
 }: ReactDatePickerCustomHeaderProps) => {
+  const { t } = useTranslation();
   return (
     <div className={root()}>
       <Button
         intent="tertiary"
+        aria-label={t("inputDate.previousMonth")}
         onPress={decreaseMonth}
         isDisabled={prevMonthButtonDisabled}
       >
@@ -161,6 +164,7 @@ export const CustomHeader = ({
       />
       <Button
         intent="tertiary"
+        aria-label={t("inputDate.nextMonth")}
         onPress={increaseMonth}
         isDisabled={nextMonthButtonDisabled}
       >

--- a/frontend/src/js/ui-components/Menu.tsx
+++ b/frontend/src/js/ui-components/Menu.tsx
@@ -54,8 +54,8 @@ const menuItem = tv({
  *     </Menu>
  *   </MenuTrigger>
  *
- * MenuTrigger comes from react-aria-components; buttons built on BasicButton
- * are its trigger without further wiring. Items focus on hover, arrow keys
+ * MenuTrigger comes from react-aria-components; a Button or ToggleButton
+ * is its trigger without further wiring. Items focus on hover, arrow keys
  * move between them, the menu closes after an action. `placement` positions
  * the menu relative to the trigger (default below, start-aligned).
  */

--- a/frontend/src/js/ui-components/Tooltip.tsx
+++ b/frontend/src/js/ui-components/Tooltip.tsx
@@ -63,8 +63,8 @@ const arrow = tv({
  *     <Tooltip>{text}</Tooltip>
  *   </TooltipTrigger>
  *
- * Buttons based on BasicButton attach themselves to the trigger.
- * Other elements need a TooltipTarget (or react-aria's Focusable for native buttons).
+ * Button and ToggleButton are triggers on their own. Other elements need
+ * a TooltipTarget (or react-aria's Focusable for native buttons).
  *
  * Timing follows Spectrum's tooltip guideline: tooltips wait for a global
  * warm-up, after which neighboring tooltips open immediately. Pick the

--- a/frontend/src/localization/de.json
+++ b/frontend/src/localization/de.json
@@ -133,6 +133,8 @@
     "unshare": "Freigabe aufheben"
   },
   "common": {
+    "add": "Hinzufügen",
+    "retry": "Erneut versuchen",
     "version": "Version",
     "help": "Hilfe",
     "manual": "Handbuch",
@@ -395,8 +397,14 @@
     "placeholder": "Suchen ...",
     "resultLabel": "{{totalResults}} Ergebnisse ({{duration}} s)"
   },
+  "inputDate": {
+    "previousMonth": "Vormonat",
+    "nextMonth": "Nächster Monat"
+  },
   "preview": {
     "preview": "Vorschau",
+    "previousPage": "Vorherige Seite",
+    "nextPage": "Nächste Seite",
     "page": "Seite",
     "headline": "Ergebnisvorschau",
     "previewHeadline": "Ergebnis-CSV",

--- a/frontend/src/localization/en.json
+++ b/frontend/src/localization/en.json
@@ -133,6 +133,8 @@
     "unshare": "Revoke sharing"
   },
   "common": {
+    "add": "Add",
+    "retry": "Try again",
     "version": "Version",
     "help": "Help",
     "manual": "Manual",
@@ -395,8 +397,14 @@
     "placeholder": "Search ...",
     "resultLabel": "{{totalResults}} results ({{duration}} s)"
   },
+  "inputDate": {
+    "previousMonth": "Previous month",
+    "nextMonth": "Next month"
+  },
   "preview": {
     "preview": "Preview",
+    "previousPage": "Previous page",
+    "nextPage": "Next page",
     "page": "Page",
     "headline": "Results preview",
     "previewHeadline": "Result CSV",


### PR DESCRIPTION
**Design-system prep, step 10: accessible names for the icon-only buttons**

Stacked on #4009. Step 7 gave the icon-only buttons inside a tooltip their tooltip text as `aria-label`; the ones without a tooltip get theirs here, so every button in the app has a name for screen readers and tests.

- 13 buttons named: retry a concept tree, page through the preview charts, previous and next month in the datepicker, the help menu, edit folders, remove a concept from a node, the remove and add buttons in the forms
- new keys `common.add`, `common.retry`, `preview.previousPage` / `nextPage`, `inputDate.previousMonth` / `nextMonth`, in both languages
- the trigger docs on `Tooltip`, `Menu` and `ConfirmMenu` name `Button` and `ToggleButton`
