### PR TITLE
ci: merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: "CI"
+
+# Single entry point for the test workflows. The `ci` job at the end is the only
+# required status check on develop: it fails if any job failed, and skipped jobs
+# (backend-only or frontend-only changes) do not block it.
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - release
+  pull_request:
+  merge_group:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # only pull requests are narrowed down; pushes and merge queue entries run everything
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh pr diff "$PR" --name-only)
+          echo "$files"
+          changed() { if echo "$files" | grep -Eq "$1"; then echo true; else echo false; fi; }
+          echo "frontend=$(changed '^(frontend/|\.github/workflows/(ci|test_frontend)\.yml$)')" >> "$GITHUB_OUTPUT"
+          echo "backend=$(changed '^(backend/|pom\.xml$|\.github/workflows/(ci|test_backend)\.yml$)')" >> "$GITHUB_OUTPUT"
+
+  frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    uses: ./.github/workflows/test_frontend.yml
+
+  backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    uses: ./.github/workflows/test_backend.yml
+
+  e2e:
+    uses: ./.github/workflows/test_cypress.yml
+
+  ci:
+    if: always()
+    needs: [changes, frontend, backend, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail if any job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/test_backend.yml"
+  # merge queue: paths filters do not apply here, the job runs on every queue entry
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -1,18 +1,8 @@
 name: "Test Backend"
 
+# Called from ci.yml, which decides based on the changed paths whether this runs.
 on:
-  push:
-    branches:
-      # Always run on protected branches
-      - master
-      - develop
-      - release
-  pull_request:
-    paths:
-      - "backend/**"
-      - ".github/workflows/test_backend.yml"
-  # merge queue: paths filters do not apply here, the job runs on every queue entry
-  merge_group:
+  workflow_call:
 
 jobs:
   build:
@@ -38,6 +28,7 @@ jobs:
       run: mvn -T 1C install -pl backend -DskipTests -am
 
   test:
+    name: test (${{ matrix.test-group.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build

--- a/.github/workflows/test_cypress.yml
+++ b/.github/workflows/test_cypress.yml
@@ -8,6 +8,7 @@ on:
       - develop
       - release
   pull_request:
+  merge_group:
 
 jobs:
   test:

--- a/.github/workflows/test_cypress.yml
+++ b/.github/workflows/test_cypress.yml
@@ -1,14 +1,8 @@
 name: "End-To-End Tests"
 
+# Called from ci.yml on every run.
 on:
-  push:
-    branches:
-      # Always run on protected branches
-      - master
-      - develop
-      - release
-  pull_request:
-  merge_group:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/test_frontend.yml
+++ b/.github/workflows/test_frontend.yml
@@ -1,17 +1,8 @@
 name: "Test Frontend"
 
+# Called from ci.yml, which decides based on the changed paths whether this runs.
 on:
-  push:
-    branches:
-      # Always run on protected branches
-      - master
-      - develop
-      - release
-  pull_request:
-    paths:
-      - "frontend/**"
-  # merge queue: paths filters do not apply here, the job runs on every queue entry
-  merge_group:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/test_frontend.yml
+++ b/.github/workflows/test_frontend.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     paths:
       - "frontend/**"
+  # merge queue: paths filters do not apply here, the job runs on every queue entry
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
**Why:** every merge into `develop` invalidates the checks of all other open PRs. Each one needs a manual "Update branch" and a full CI rerun before it can merge. A **merge queue** does that for us, but our workflows were not ready for it. Also, the required check `test` was produced by the E2E job alone, so backend tests were never actually required.

**What:** one `CI` workflow (`ci.yml`) that runs on push, PR and merge queue. It calls the three test workflows (now `workflow_call`), skips frontend or backend jobs when their paths are untouched, and ends in a gate job `ci`. That gate is the only check to require: it fails if any job failed, skipped jobs pass through.

## Admin steps (one sitting)

On https://github.com/ingef/conquery/settings/branches, rule `develop`:

1. Required status checks: remove `test`, add `ci`.
2. Tick **Require merge queue** (merge method *Merge commit*, defaults otherwise).
3. Save, merge this PR via "Merge when ready".

Other open PRs need one "Update branch" afterwards. (Rollback: untick **Require merge queue**.)
