### PR TITLE
refactor(frontend): Disclosure on react-aria-components

### DIFF
--- a/frontend/src/js/external-forms/form/fields/DisclosureListField.tsx
+++ b/frontend/src/js/external-forms/form/fields/DisclosureListField.tsx
@@ -1,18 +1,18 @@
-import {
-  faAdd,
-  faChevronDown,
-  faChevronRight,
-  faTimes,
-} from "@fortawesome/free-solid-svg-icons";
-import { type ComponentProps, useEffect, useState } from "react";
+import { faAdd, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { type ComponentProps, useCallback, useEffect, useState } from "react";
+import type { Key } from "react-aria-components";
 import { useFieldArray } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { tv } from "tailwind-variants";
 import { exists } from "../../../common/helpers/exists";
 import { usePrevious } from "../../../common/helpers/usePrevious";
 import { Button } from "../../../ui-components/Button";
+import {
+  Disclosure,
+  DisclosureGroup,
+  DisclosurePanel,
+  DisclosureTitle,
+} from "../../../ui-components/Disclosure";
 import { Icon } from "../../../ui-components/Icon";
-import InfoTooltip from "../../../ui-components/InfoTooltip";
 import type { DisclosureListField as DisclosureListFieldT } from "../../config-types";
 import {
   getFieldKey,
@@ -21,69 +21,34 @@ import {
 } from "../../helper";
 import Field from "../Field";
 
-const summary = tv({
-  base: [
-    "relative",
-    "flex items-center justify-between",
-    "gap-3",
-    "cursor-pointer",
-    "bg-white",
-    "py-3 pr-10 pl-3",
-    "text-sm",
-    "font-normal",
-  ],
-});
-
 const DisclosureField = ({
+  id,
   field,
   index,
-  isOpen,
-  toggleOpen,
   remove,
   canRemove,
   commonProps,
 }: {
+  id: string;
   field: DisclosureListFieldT;
   index: number;
-  isOpen: boolean;
-  toggleOpen: () => void;
   remove: (index: number) => void;
   canRemove?: boolean;
   commonProps: Omit<ComponentProps<typeof Field>, "field">;
 }) => {
   const { t } = useTranslation();
+
   if (field.fields.length === 0) return null;
 
   const { formType, locale } = commonProps;
 
   return (
-    <details
-      className="overflow-hidden rounded-sm border border-gray-400"
-      open={isOpen}
-      onToggle={(e) => {
-        if (
-          (isOpen && e.currentTarget.open) ||
-          (!isOpen && !e.currentTarget.open)
-        ) {
-          // Without this, we're getting open/close flickering
-          return;
-        }
-
-        toggleOpen();
-      }}
-    >
-      <summary className={summary()}>
-        <div className="flex items-center gap-3">
-          <span className="w-5">
-            <Icon icon={isOpen ? faChevronDown : faChevronRight} />
-          </span>
-          {field.label[locale]}
-          {exists(field.tooltip) && (
-            <InfoTooltip text={field.tooltip[locale]} />
-          )}
-        </div>
-        {field.creatable && canRemove && (
-          <div className="absolute right-0 top-1/2 -translate-y-1/2">
+    <Disclosure id={id}>
+      <DisclosureTitle
+        info={exists(field.tooltip) ? field.tooltip[locale] : undefined}
+        actions={
+          field.creatable &&
+          canRemove && (
             <Button
               size="sm"
               intent="tertiary"
@@ -92,42 +57,49 @@ const DisclosureField = ({
             >
               <Icon icon={faTimes} />
             </Button>
-          </div>
-        )}
-      </summary>
-      <div className="flex flex-col gap-2 bg-bg-50 border-t border-gray-300 p-3">
-        {field.fields.map((f, i) => {
-          const key = getFieldKey(formType, f, i);
-          const childField = isFormFieldWithValue(f)
-            ? { ...f, name: `${field.name}[${index}].${f.name}` }
-            : f;
+          )
+        }
+      >
+        {field.label[locale]}
+      </DisclosureTitle>
+      <DisclosurePanel>
+        <div className="flex flex-col gap-2">
+          {field.fields.map((f, i) => {
+            const key = getFieldKey(formType, f, i);
+            const childField = isFormFieldWithValue(f)
+              ? { ...f, name: `${field.name}[${index}].${f.name}` }
+              : f;
 
-          return <Field key={key} field={childField} {...commonProps} />;
-        })}
-      </div>
-    </details>
+            return <Field key={key} field={childField} {...commonProps} />;
+          })}
+        </div>
+      </DisclosurePanel>
+    </Disclosure>
   );
 };
 
-const useOpenState = ({
+// which sections are open; the group keeps a single one when only one may be
+const useExpandedKeys = ({
   defaultOpen,
   onlyOneOpenAtATime = false,
 }: {
   defaultOpen?: string;
   onlyOneOpenAtATime?: boolean;
 }) => {
-  const [isOpen, setIsOpen] = useState<Record<string, boolean>>(
-    defaultOpen ? { [defaultOpen]: true } : {},
+  const [expandedKeys, setExpandedKeys] = useState<Set<Key>>(
+    () => new Set(defaultOpen ? [defaultOpen] : []),
   );
 
-  const toggleOpen = (id: string) => {
-    setIsOpen((prev) => ({
-      ...(onlyOneOpenAtATime ? {} : prev),
-      [id]: !prev[id],
-    }));
-  };
+  const open = useCallback(
+    (id: string) => {
+      setExpandedKeys((prev) =>
+        onlyOneOpenAtATime ? new Set([id]) : new Set(prev).add(id),
+      );
+    },
+    [onlyOneOpenAtATime],
+  );
 
-  return { isOpen, toggleOpen };
+  return { expandedKeys, setExpandedKeys, open };
 };
 
 export const DisclosureListField = ({
@@ -166,7 +138,7 @@ export const DisclosureListField = ({
 
   const prevFieldsLength = usePrevious(fields.length);
 
-  const { isOpen, toggleOpen } = useOpenState({
+  const { expandedKeys, setExpandedKeys, open } = useExpandedKeys({
     onlyOneOpenAtATime: field.onlyOneOpenAtATime,
     defaultOpen: field.defaultOpen ? fields[0]?.id : undefined,
   });
@@ -175,12 +147,10 @@ export const DisclosureListField = ({
     function openFirstFieldIfNecessary() {
       if (prevFieldsLength === 0 && fields.length > 0 && field.defaultOpen) {
         const id = fields[0]?.id;
-        if (id && !isOpen[id]) {
-          toggleOpen(id);
-        }
+        if (id) open(id);
       }
     },
-    [prevFieldsLength, fields, toggleOpen, isOpen, field.defaultOpen],
+    [prevFieldsLength, fields, open, field.defaultOpen],
   );
 
   useEffect(
@@ -194,19 +164,10 @@ export const DisclosureListField = ({
         commonProps.trigger();
 
         const id = fields[fields.length - 1]?.id;
-        if (id && !isOpen[id]) {
-          toggleOpen(id);
-        }
+        if (id) open(id);
       }
     },
-    [
-      prevFieldsLength,
-      fields,
-      isOpen,
-      toggleOpen,
-      field.defaultOpen,
-      commonProps,
-    ],
+    [prevFieldsLength, fields, open, field.defaultOpen, commonProps],
   );
 
   if (field.fields.length === 0) return null;
@@ -214,19 +175,24 @@ export const DisclosureListField = ({
   const { locale } = commonProps;
 
   return (
-    <div className="space-y-2">
-      {fields.map((fd, index) => (
-        <DisclosureField
-          key={fd.id}
-          field={field}
-          index={index}
-          remove={remove}
-          isOpen={isOpen[fd.id]}
-          toggleOpen={() => toggleOpen(fd.id)}
-          canRemove={fields.length > 1}
-          commonProps={commonProps}
-        />
-      ))}
+    <div className="flex flex-col gap-2">
+      <DisclosureGroup
+        allowsMultipleExpanded={!field.onlyOneOpenAtATime}
+        expandedKeys={expandedKeys}
+        onExpandedChange={setExpandedKeys}
+      >
+        {fields.map((fd, index) => (
+          <DisclosureField
+            key={fd.id}
+            id={fd.id}
+            field={field}
+            index={index}
+            remove={remove}
+            canRemove={fields.length > 1}
+            commonProps={commonProps}
+          />
+        ))}
+      </DisclosureGroup>
       {field.creatable && (
         <div className="grid">
           <Button

--- a/frontend/src/js/ui-components/Disclosure.stories.tsx
+++ b/frontend/src/js/ui-components/Disclosure.stories.tsx
@@ -1,0 +1,91 @@
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "./Button";
+import {
+  Disclosure,
+  DisclosureGroup,
+  DisclosurePanel,
+  DisclosureTitle,
+} from "./Disclosure";
+import { Icon } from "./Icon";
+
+export default {
+  title: "UiComponents/Disclosure",
+  component: Disclosure,
+  parameters: { layout: "centered" },
+} as Meta<typeof Disclosure>;
+
+type Story = StoryObj<typeof Disclosure>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[400px]">
+      <Disclosure defaultExpanded>
+        <DisclosureTitle>Time range</DisclosureTitle>
+        <DisclosurePanel>
+          <p className="text-sm">From 2020 to 2024, whole years.</p>
+        </DisclosurePanel>
+      </Disclosure>
+    </div>
+  ),
+};
+
+export const WithInfoAndActions: Story = {
+  render: () => (
+    <div className="w-[400px]">
+      <Disclosure>
+        <DisclosureTitle
+          info="Regions the report covers."
+          actions={
+            <Button size="sm" intent="tertiary" aria-label="Remove">
+              <Icon icon={faTimes} />
+            </Button>
+          }
+        >
+          Regions
+        </DisclosureTitle>
+        <DisclosurePanel>
+          <p className="text-sm">North, South.</p>
+        </DisclosurePanel>
+      </Disclosure>
+    </div>
+  ),
+};
+
+const sections = ["Regions", "Years", "Products"];
+
+export const Group: Story = {
+  render: () => (
+    <div className="w-[400px]">
+      <DisclosureGroup defaultExpandedKeys={["Regions"]}>
+        {sections.map((section) => (
+          <Disclosure key={section} id={section}>
+            <DisclosureTitle>{section}</DisclosureTitle>
+            <DisclosurePanel>
+              <p className="text-sm">Fields for {section.toLowerCase()}.</p>
+            </DisclosurePanel>
+          </Disclosure>
+        ))}
+      </DisclosureGroup>
+    </div>
+  ),
+};
+
+/** Several sections open at once. */
+export const GroupMultiple: Story = {
+  render: () => (
+    <div className="w-[400px]">
+      <DisclosureGroup allowsMultipleExpanded defaultExpandedKeys={sections}>
+        {sections.map((section) => (
+          <Disclosure key={section} id={section}>
+            <DisclosureTitle>{section}</DisclosureTitle>
+            <DisclosurePanel>
+              <p className="text-sm">Fields for {section.toLowerCase()}.</p>
+            </DisclosurePanel>
+          </Disclosure>
+        ))}
+      </DisclosureGroup>
+    </div>
+  ),
+};

--- a/frontend/src/js/ui-components/Disclosure.tsx
+++ b/frontend/src/js/ui-components/Disclosure.tsx
@@ -20,7 +20,8 @@ const root = tv({
 
 const title = tv({ base: ["flex items-center", "bg-white", "pr-2"] });
 
-const heading = tv({ base: ["grow", "min-w-0", "text-sm font-normal"] });
+// the base heading style gives h3 a bottom margin; the trigger sets the height
+const heading = tv({ base: ["grow", "min-w-0", "m-0", "text-sm font-normal"] });
 
 const trigger = tv({
   base: [

--- a/frontend/src/js/ui-components/Disclosure.tsx
+++ b/frontend/src/js/ui-components/Disclosure.tsx
@@ -1,0 +1,113 @@
+import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import type { ReactNode } from "react";
+import {
+  Heading,
+  Button as RacButton,
+  Disclosure as RacDisclosure,
+  DisclosureGroup as RacDisclosureGroup,
+  type DisclosureGroupProps as RacDisclosureGroupProps,
+  DisclosurePanel as RacDisclosurePanel,
+  type DisclosureProps as RacDisclosureProps,
+} from "react-aria-components";
+import { tv } from "tailwind-variants";
+
+import { Icon } from "./Icon";
+import InfoTooltip from "./InfoTooltip";
+
+const root = tv({
+  base: ["group", "overflow-hidden", "rounded-sm", "border border-gray-400"],
+});
+
+const title = tv({ base: ["flex items-center", "bg-white", "pr-2"] });
+
+const heading = tv({ base: ["grow", "min-w-0", "text-sm font-normal"] });
+
+const trigger = tv({
+  base: [
+    "flex items-center",
+    "gap-3",
+    "w-full",
+    "py-3 pl-3",
+    "text-left",
+    "cursor-pointer",
+    "outline-none",
+    "data-focus-visible:outline-2 data-focus-visible:-outline-offset-2 data-focus-visible:outline-primary-500",
+  ],
+});
+
+const chevron = tv({
+  base: ["transition-transform duration-100", "group-data-expanded:rotate-90"],
+});
+
+const panel = tv({ base: ["border-t border-gray-300", "bg-bg-50", "p-3"] });
+
+const group = tv({ base: ["flex flex-col", "gap-2"] });
+
+export interface DisclosureProps
+  extends Omit<RacDisclosureProps, "className" | "style" | "children"> {
+  children: ReactNode;
+}
+
+/**
+ * A collapsible section on react-aria-components: `isExpanded` /
+ * `onExpandedChange` or `defaultExpanded`; inside a DisclosureGroup it is
+ * keyed by `id` and the group holds the state.
+ *
+ *   <Disclosure defaultExpanded>
+ *     <DisclosureTitle info="…" actions={<Button …/>}>Section</DisclosureTitle>
+ *     <DisclosurePanel>…</DisclosurePanel>
+ *   </Disclosure>
+ */
+export const Disclosure = ({ children, ...props }: DisclosureProps) => (
+  <RacDisclosure className={root()} {...props}>
+    {children}
+  </RacDisclosure>
+);
+
+/**
+ * The heading with the trigger button. `info` puts a help icon after it,
+ * `actions` further buttons; both sit outside the trigger, which may not
+ * contain interactive elements.
+ */
+export const DisclosureTitle = ({
+  children,
+  info,
+  actions,
+}: {
+  children: ReactNode;
+  info?: string;
+  actions?: ReactNode;
+}) => (
+  <div className={title()}>
+    <Heading className={heading()}>
+      <RacButton slot="trigger" className={trigger()}>
+        <Icon icon={faChevronRight} className={chevron()} />
+        {children}
+      </RacButton>
+    </Heading>
+    {info && <InfoTooltip text={info} />}
+    {actions}
+  </div>
+);
+
+export const DisclosurePanel = ({ children }: { children: ReactNode }) => (
+  <RacDisclosurePanel className={panel()}>{children}</RacDisclosurePanel>
+);
+
+export interface DisclosureGroupProps
+  extends Omit<RacDisclosureGroupProps, "className" | "style" | "children"> {
+  children: ReactNode;
+}
+
+/**
+ * Stacks Disclosures and owns their state: `expandedKeys` /
+ * `onExpandedChange`, `allowsMultipleExpanded` for more than one open at a time.
+ */
+export const DisclosureGroup = ({
+  children,
+  ...props
+}: DisclosureGroupProps) => (
+  <RacDisclosureGroup className={group()} {...props}>
+    {children}
+  </RacDisclosureGroup>
+);

--- a/frontend/src/js/ui-components/Disclosure.tsx
+++ b/frontend/src/js/ui-components/Disclosure.tsx
@@ -20,8 +20,15 @@ const root = tv({
 
 const title = tv({ base: ["flex items-center", "bg-white", "pr-2"] });
 
-// the base heading style gives h3 a bottom margin; the trigger sets the height
-const heading = tv({ base: ["grow", "min-w-0", "m-0", "text-sm font-normal"] });
+// resets the base h3 style: no margin, body color and line height, the trigger sets the height
+const heading = tv({
+  base: [
+    "grow",
+    "min-w-0",
+    "m-0",
+    "text-sm leading-normal font-normal text-gray-800",
+  ],
+});
 
 const trigger = tv({
   base: [

--- a/frontend/src/js/ui-components/Disclosure.tsx
+++ b/frontend/src/js/ui-components/Disclosure.tsx
@@ -98,8 +98,12 @@ export const DisclosureTitle = ({
   </div>
 );
 
+// while collapsed the panel is hidden "until found", which keeps the element's
+// own box; so the padding and border sit on an inner element
 export const DisclosurePanel = ({ children }: { children: ReactNode }) => (
-  <RacDisclosurePanel className={panel()}>{children}</RacDisclosurePanel>
+  <RacDisclosurePanel>
+    <div className={panel()}>{children}</div>
+  </RacDisclosurePanel>
 );
 
 export interface DisclosureGroupProps


### PR DESCRIPTION
**Disclosure on react-aria's Disclosure**

The form's disclosure list, a `details` element with an open-state workaround, moves to `ui-components/Disclosure` with `DisclosureTitle`, `DisclosurePanel` and `DisclosureGroup` on react-aria-components. Based on develop.

```tsx
<DisclosureGroup expandedKeys={keys} onExpandedChange={setKeys}>
  <Disclosure id="regions">
    <DisclosureTitle info="…" actions={<Button …/>}>Regions</DisclosureTitle>
    <DisclosurePanel>…</DisclosurePanel>
  </Disclosure>
</DisclosureGroup>
```

- the trigger is a real button with `aria-expanded` and a focus ring; the chevron rotates while expanded; the help icon and the remove button sit next to the trigger, since a button may not contain interactive elements
- `DisclosureGroup` owns which sections are open: `allowsMultipleExpanded` off gives the form's "only one open at a time", so the field keeps a set of keys instead of the toggle bookkeeping and the `onToggle` flicker guard
- `Disclosure` stories: default, with info and actions, a group with one open, a group with several open

<img width="469" height="297" alt="Screenshot 2026-09-09 at 18 40 42" src="https://github.com/user-attachments/assets/0f93bb1e-2d41-4972-8c4f-8e0ba997790c" />


